### PR TITLE
Добавяне на снимки в мобилния чат

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4,13 +4,20 @@ const state = {
     opensearchStatus: 'unknown',
     lastActions: [],
     chatBusy: false,
-    speakingButton: null
+    speakingButton: null,
+    pendingImage: null
 };
 
 const elements = {
     chatMessages: document.getElementById('chatMessages'),
     chatInput: document.getElementById('chatInput'),
     sendBtn: document.getElementById('sendBtn'),
+    attachBtn: document.getElementById('attachBtn'),
+    imageInput: document.getElementById('imageInput'),
+    attachmentPreview: document.getElementById('attachmentPreview'),
+    attachmentImage: document.getElementById('attachmentImage'),
+    attachmentName: document.getElementById('attachmentName'),
+    removeAttachmentBtn: document.getElementById('removeAttachmentBtn'),
     newChatBtn: document.getElementById('newChatBtn'),
     toggleStatusBtn: document.getElementById('toggleStatusBtn'),
     closeContextBtn: document.getElementById('closeContextBtn'),
@@ -31,6 +38,9 @@ function init() {
     updateSessionDisplay();
 
     elements.sendBtn.addEventListener('click', sendMessage);
+    elements.attachBtn.addEventListener('click', () => elements.imageInput.click());
+    elements.imageInput.addEventListener('change', handleImageSelection);
+    elements.removeAttachmentBtn.addEventListener('click', clearPendingImage);
     elements.chatInput.addEventListener('keydown', (event) => {
         if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault();
@@ -63,6 +73,7 @@ function showWelcomeMessage() {
 
 function startNewChat() {
     if (state.chatBusy) return;
+    clearPendingImage();
     state.sessionId = createSessionId();
     state.lastActions = [];
     elements.chatMessages.replaceChildren();
@@ -71,6 +82,50 @@ function startNewChat() {
     showWelcomeMessage();
     logAction('Започнат е нов разговор');
     elements.chatInput.focus();
+}
+
+function handleImageSelection(event) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+    if (!allowedTypes.includes(file.type)) {
+        appendMessage('agent', '❌ Поддържат се само JPEG, PNG и WebP снимки.');
+        clearPendingImage();
+        return;
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+        appendMessage('agent', '❌ Снимката трябва да бъде до 5 MB.');
+        clearPendingImage();
+        return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+        state.pendingImage = {
+            dataUrl: reader.result,
+            mimeType: file.type,
+            name: file.name
+        };
+        elements.attachmentImage.src = reader.result;
+        elements.attachmentName.textContent = file.name;
+        elements.attachmentPreview.hidden = false;
+        elements.chatInput.focus();
+    };
+    reader.onerror = () => {
+        appendMessage('agent', '❌ Снимката не можа да бъде прочетена.');
+        clearPendingImage();
+    };
+    reader.readAsDataURL(file);
+}
+
+function clearPendingImage() {
+    state.pendingImage = null;
+    elements.imageInput.value = '';
+    elements.attachmentImage.removeAttribute('src');
+    elements.attachmentName.textContent = '';
+    elements.attachmentPreview.hidden = true;
 }
 
 function openStatus() {
@@ -107,6 +162,7 @@ function setChatBusy(isBusy) {
     elements.sendBtn.disabled = isBusy;
     elements.chatInput.disabled = isBusy;
     elements.newChatBtn.disabled = isBusy;
+    elements.attachBtn.disabled = isBusy;
 }
 
 function renderAgentText(element, text) {
@@ -260,10 +316,13 @@ function parseSseEvent(rawEvent) {
 
 async function sendMessage() {
     const text = elements.chatInput.value.trim();
-    if (!text || state.chatBusy) return;
+    const image = state.pendingImage;
+    if ((!text && !image) || state.chatBusy) return;
 
-    appendMessage('user', text);
+    const messageText = text || 'Какво виждаш на тази снимка?';
+    appendMessage('user', messageText, image);
     elements.chatInput.value = '';
+    clearPendingImage();
     logAction('Изпратено съобщение');
     showTypingIndicator();
     setChatBusy(true);
@@ -277,7 +336,8 @@ async function sendMessage() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 sessionId: state.sessionId,
-                message: text
+                message: messageText,
+                image
             })
         });
 
@@ -375,7 +435,7 @@ async function sendMessage() {
     }
 }
 
-function appendMessage(role, text) {
+function appendMessage(role, text, image = null) {
     if (role === 'agent') {
         const assistantTurn = createAssistantTurn(text, true);
         scrollChatToBottom();
@@ -384,7 +444,17 @@ function appendMessage(role, text) {
 
     const div = document.createElement('div');
     div.className = `message ${role}`;
-    div.textContent = text;
+    if (image?.dataUrl) {
+        const preview = document.createElement('img');
+        preview.className = 'message-image';
+        preview.src = image.dataUrl;
+        preview.alt = image.name || 'Изпратена снимка';
+        div.appendChild(preview);
+    }
+
+    const textNode = document.createElement('div');
+    textNode.textContent = text;
+    div.appendChild(textNode);
 
     elements.chatMessages.appendChild(div);
     scrollChatToBottom();

--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#087cf0">
     <title>Synchron-X</title>
-    <link rel="stylesheet" href="/styles.css?v=20260724-thinking1">
+    <link rel="stylesheet" href="/styles.css?v=20260724-images1">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
@@ -54,7 +54,22 @@
 
             <div id="chatMessages" aria-live="polite"></div>
 
+            <div id="attachmentPreview" class="attachment-preview" hidden>
+                <img id="attachmentImage" alt="Избрана снимка">
+                <div>
+                    <strong id="attachmentName"></strong>
+                    <span>Снимката ще бъде изпратена с въпроса</span>
+                </div>
+                <button id="removeAttachmentBtn" type="button" aria-label="Премахни снимката">
+                    <i class="fa-solid fa-xmark"></i>
+                </button>
+            </div>
+
             <div class="chat-input-area">
+                <button id="attachBtn" class="attach-btn" type="button" aria-label="Добави снимка" title="Добави снимка">
+                    <i class="fa-solid fa-plus"></i>
+                </button>
+                <input id="imageInput" type="file" accept="image/jpeg,image/png,image/webp" hidden>
                 <input
                     type="text"
                     id="chatInput"
@@ -98,6 +113,6 @@
         </aside>
     </main>
 
-    <script src="/app.js?v=20260724-thinking1"></script>
+    <script src="/app.js?v=20260724-images1"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -614,3 +614,84 @@ input {
     0%, 80%, 100% { transform: translateY(0); opacity: 0.35; }
     40% { transform: translateY(-3px); opacity: 1; }
 }
+
+
+.attach-btn {
+    width: 48px;
+    height: 48px;
+    flex: 0 0 48px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    border-radius: 50%;
+    color: #30363b;
+    background: #f1f2f3;
+    cursor: pointer;
+    font-size: 18px;
+}
+
+.attach-btn:disabled {
+    opacity: 0.45;
+    cursor: default;
+}
+
+.attachment-preview {
+    margin: 8px 12px 0;
+    padding: 8px;
+    display: grid;
+    grid-template-columns: 54px minmax(0, 1fr) 36px;
+    align-items: center;
+    gap: 10px;
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    background: #f8fafb;
+}
+
+.attachment-preview[hidden] {
+    display: none;
+}
+
+.attachment-preview img {
+    width: 54px;
+    height: 54px;
+    object-fit: cover;
+    border-radius: 10px;
+}
+
+.attachment-preview strong,
+.attachment-preview span {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.attachment-preview strong {
+    font-size: 13px;
+}
+
+.attachment-preview span {
+    margin-top: 3px;
+    color: var(--muted);
+    font-size: 11px;
+}
+
+#removeAttachmentBtn {
+    width: 36px;
+    height: 36px;
+    border: 0;
+    border-radius: 50%;
+    color: #4e5c69;
+    background: #edf2f6;
+    cursor: pointer;
+}
+
+.message-image {
+    display: block;
+    width: min(280px, 100%);
+    max-height: 320px;
+    margin-bottom: 8px;
+    object-fit: contain;
+    border-radius: 12px;
+}

--- a/server.js
+++ b/server.js
@@ -22,7 +22,7 @@ if (!process.env.AGENT_KEY) {
 const app = express();
 
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: "8mb" }));
 app.use(
   express.static("public", {
     maxAge: 0,

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -54,18 +54,47 @@ router.post("/chat", async (req, res) => {
     DEFAULT_AGENT_TIMEOUT_MS,
   );
 
-  const { sessionId, message } = req.body || {};
-  if (
-    !sessionId ||
-    typeof sessionId !== "string" ||
-    !sessionId.trim() ||
-    !message ||
-    typeof message !== "string" ||
-    !message.trim()
-  ) {
+  const { sessionId, message, image } = req.body || {};
+  const hasMessage = typeof message === "string" && Boolean(message.trim());
+  const hasImage = image && typeof image === "object" && image.dataUrl;
+
+  if (!sessionId || typeof sessionId !== "string" || !sessionId.trim()) {
     return res.status(400).json({
-      error: "sessionId and message are required and must be non-empty strings.",
+      error: "sessionId is required and must be a non-empty string.",
     });
+  }
+
+  if (!hasMessage && !hasImage) {
+    return res.status(400).json({
+      error: "Изпратете съобщение или снимка.",
+    });
+  }
+
+  let validatedImage = null;
+  if (hasImage) {
+    const allowedTypes = new Set(["image/jpeg", "image/png", "image/webp"]);
+    const mimeType = typeof image.mimeType === "string" ? image.mimeType : "";
+    const dataUrl = typeof image.dataUrl === "string" ? image.dataUrl : "";
+    const expectedPrefix = `data:${mimeType};base64,`;
+
+    if (
+      !allowedTypes.has(mimeType) ||
+      !dataUrl.startsWith(expectedPrefix) ||
+      dataUrl.length > 7_100_000
+    ) {
+      return res.status(400).json({
+        error: "Снимката е невалидна или е по-голяма от 5 MB.",
+      });
+    }
+
+    validatedImage = {
+      dataUrl,
+      mimeType,
+      name:
+        typeof image.name === "string"
+          ? image.name.slice(0, 160)
+          : "Изпратена снимка",
+    };
   }
 
   if (!agentKey) {
@@ -74,7 +103,9 @@ router.post("/chat", async (req, res) => {
       .json({ error: "AGENT_KEY environment variable is required." });
   }
 
-  const cleanMessage = message.trim();
+  const cleanMessage = hasMessage
+    ? message.trim()
+    : "Какво виждаш на тази снимка?";
   console.log(`[POST /chat] sessionId: ${sessionId}`);
 
   let memories;
@@ -98,13 +129,35 @@ router.post("/chat", async (req, res) => {
 
   const memoryContext = buildMemoryContext(memories);
   const previousHistory = sessionHistory.get(sessionId) || [];
-  let history = [...previousHistory, { role: "user", content: cleanMessage }];
+  const userHistoryMessage = {
+    role: "user",
+    content: validatedImage
+      ? `${cleanMessage}\n[Потребителят изпрати снимка: ${validatedImage.name}]`
+      : cleanMessage,
+  };
+  let history = [...previousHistory, userHistoryMessage];
   if (history.length > MAX_HISTORY_LENGTH * 2) {
     history = history.slice(-(MAX_HISTORY_LENGTH * 2));
   }
-  const agentMessages = memoryContext
-    ? [{ role: "user", content: memoryContext }, ...history]
-    : history;
+
+  const currentAgentMessage = validatedImage
+    ? {
+        role: "user",
+        content: [
+          { type: "text", text: cleanMessage },
+          {
+            type: "image_url",
+            image_url: { url: validatedImage.dataUrl },
+          },
+        ],
+      }
+    : userHistoryMessage;
+  const earlierHistory = history.slice(0, -1);
+  const agentMessages = [
+    ...(memoryContext ? [{ role: "user", content: memoryContext }] : []),
+    ...earlierHistory,
+    currentAgentMessage,
+  ];
 
   res.status(200);
   res.setHeader("Content-Type", "text/event-stream; charset=utf-8");


### PR DESCRIPTION
## Какво е добавено
- бутон „+“ за избор на снимка
- преглед и премахване преди изпращане
- JPEG, PNG и WebP до 5 MB
- валидиране и ограничение и в сървъра
- изпращане на снимката към мултимодалния AI модел
- снимките не се пазят в RAM историята след заявката

## Проверки
- сравнението с main съдържа само 5 очаквани файла
- JavaScript синтаксисът на клиента, чат маршрута и сървъра е проверен

## Причина
OpenAI GPT-4o mini вече е активен и позволява реално визуално разбиране, вместо демонстрационен бутон.