### PR TITLE
Add real read-only GitHub module

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ import chatRouter from "./src/routes/chat.js";
 import healthRouter from "./src/routes/health.js";
 import memoryRouter from "./src/routes/memoryRouter.js";
 import cloudRouter from "./src/routes/cloudRouter.js";
+import githubRouter from "./src/routes/githubRouter.js";
 
 dotenv.config();
 
@@ -38,6 +39,7 @@ app.use("/chat", chatRouter);
 app.use("/health", healthRouter);
 app.use("/memory", memoryRouter);
 app.use("/cloud", cloudRouter);
+app.use("/github", githubRouter);
 
 app.get("/opensearch-status", async (req, res) => {
   const client = getOpenSearchClient();

--- a/src/routes/githubRouter.js
+++ b/src/routes/githubRouter.js
@@ -1,0 +1,61 @@
+import express from "express";
+import {
+  getConfiguredRepository,
+  getFileContent,
+  getRepositorySummary,
+  GitHubServiceError,
+  listRecentCommits,
+} from "../services/githubService.js";
+
+const router = express.Router();
+
+function sendError(res, error) {
+  if (error instanceof GitHubServiceError) {
+    return res.status(error.status).json({
+      error: error.message,
+      code: error.code,
+    });
+  }
+  console.error("[GitHub] Unexpected failure:", error);
+  return res.status(500).json({
+    error: "Неочаквана грешка в GitHub модула.",
+    code: "INTERNAL_ERROR",
+  });
+}
+
+router.get("/status", async (_req, res) => {
+  try {
+    const repository = getConfiguredRepository();
+    const summary = await getRepositorySummary(repository);
+    res.json({ status: "connected", mode: "read-only", ...summary });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+router.get("/commits", async (req, res) => {
+  try {
+    const commits = await listRecentCommits(
+      getConfiguredRepository(),
+      req.query.limit,
+    );
+    res.json({ mode: "read-only", commits });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+router.get("/file", async (req, res) => {
+  try {
+    const file = await getFileContent(
+      req.query.path,
+      getConfiguredRepository(),
+      req.query.ref,
+    );
+    res.json({ mode: "read-only", ...file });
+  } catch (error) {
+    sendError(res, error);
+  }
+});
+
+export default router;

--- a/src/services/githubService.js
+++ b/src/services/githubService.js
@@ -1,0 +1,165 @@
+const DEFAULT_REPOSITORY =
+  "radostinvgeorgiev-commits/sunchron-backend";
+const DEFAULT_API_URL = "https://api.github.com";
+const DEFAULT_TIMEOUT_MS = 10000;
+
+export class GitHubServiceError extends Error {
+  constructor(message, status = 500, code = "GITHUB_ERROR") {
+    super(message);
+    this.name = "GitHubServiceError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function configuredRepository() {
+  return (process.env.GITHUB_REPOSITORY || DEFAULT_REPOSITORY).trim();
+}
+
+function assertAllowedRepository(repository) {
+  const allowed = configuredRepository();
+  if (repository !== allowed) {
+    throw new GitHubServiceError(
+      "Това GitHub хранилище не е разрешено.",
+      403,
+      "REPOSITORY_NOT_ALLOWED",
+    );
+  }
+}
+
+function githubHeaders() {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "Synchron-X",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  return headers;
+}
+
+async function githubRequest(path, options = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  const apiUrl = (process.env.GITHUB_API_URL || DEFAULT_API_URL).replace(
+    /\/+$/u,
+    "",
+  );
+
+  try {
+    const response = await fetch(`${apiUrl}${path}`, {
+      headers: githubHeaders(),
+      signal: controller.signal,
+      ...options,
+    });
+    if (!response.ok) {
+      const details = await response.text();
+      console.error(`[GitHub] ${response.status}:`, details || "<empty>");
+      throw new GitHubServiceError(
+        response.status === 404
+          ? "GitHub ресурсът не е намерен."
+          : `GitHub върна грешка ${response.status}.`,
+        response.status,
+        "GITHUB_API_ERROR",
+      );
+    }
+    return response.json();
+  } catch (error) {
+    if (error instanceof GitHubServiceError) throw error;
+    if (error?.name === "AbortError") {
+      throw new GitHubServiceError(
+        "GitHub не отговори навреме.",
+        504,
+        "GITHUB_TIMEOUT",
+      );
+    }
+    throw new GitHubServiceError(
+      "Връзката с GitHub не е достъпна.",
+      503,
+      "GITHUB_UNAVAILABLE",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function encodePath(path) {
+  return path
+    .split("/")
+    .filter(Boolean)
+    .map(encodeURIComponent)
+    .join("/");
+}
+
+export function getConfiguredRepository() {
+  return configuredRepository();
+}
+
+export async function getRepositorySummary(
+  repository = configuredRepository(),
+) {
+  assertAllowedRepository(repository);
+  const data = await githubRequest(`/repos/${repository}`);
+  return {
+    repository: data.full_name,
+    defaultBranch: data.default_branch,
+    private: data.private,
+    description: data.description,
+    updatedAt: data.updated_at,
+    url: data.html_url,
+  };
+}
+
+export async function listRecentCommits(
+  repository = configuredRepository(),
+  limit = 5,
+) {
+  assertAllowedRepository(repository);
+  const safeLimit = Math.min(Math.max(Number(limit) || 5, 1), 20);
+  const commits = await githubRequest(
+    `/repos/${repository}/commits?per_page=${safeLimit}`,
+  );
+  return commits.map((item) => ({
+    sha: item.sha,
+    shortSha: item.sha.slice(0, 7),
+    message: item.commit?.message || "",
+    author: item.commit?.author?.name || null,
+    date: item.commit?.author?.date || null,
+    url: item.html_url,
+  }));
+}
+
+export async function getFileContent(
+  path,
+  repository = configuredRepository(),
+  ref,
+) {
+  assertAllowedRepository(repository);
+  const cleanPath = typeof path === "string" ? path.trim() : "";
+  if (!cleanPath || cleanPath.includes("..")) {
+    throw new GitHubServiceError(
+      "Невалиден път към GitHub файл.",
+      400,
+      "INVALID_PATH",
+    );
+  }
+  const query = ref ? `?ref=${encodeURIComponent(ref)}` : "";
+  const data = await githubRequest(
+    `/repos/${repository}/contents/${encodePath(cleanPath)}${query}`,
+  );
+  if (data.type !== "file" || typeof data.content !== "string") {
+    throw new GitHubServiceError(
+      "Посоченият GitHub ресурс не е текстов файл.",
+      422,
+      "NOT_A_FILE",
+    );
+  }
+  return {
+    path: data.path,
+    sha: data.sha,
+    size: data.size,
+    content: Buffer.from(data.content, "base64").toString("utf8"),
+    url: data.html_url,
+  };
+}

--- a/tests/githubService.test.js
+++ b/tests/githubService.test.js
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  getFileContent,
+  getRepositorySummary,
+  GitHubServiceError,
+  listRecentCommits,
+} from "../src/services/githubService.js";
+
+const originalFetch = global.fetch;
+const originalRepository = process.env.GITHUB_REPOSITORY;
+const originalApiUrl = process.env.GITHUB_API_URL;
+const originalToken = process.env.GITHUB_TOKEN;
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test.beforeEach(() => {
+  process.env.GITHUB_REPOSITORY =
+    "radostinvgeorgiev-commits/sunchron-backend";
+  process.env.GITHUB_API_URL = "https://github.test";
+  delete process.env.GITHUB_TOKEN;
+});
+
+test.afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+test.after(() => {
+  if (originalRepository === undefined) delete process.env.GITHUB_REPOSITORY;
+  else process.env.GITHUB_REPOSITORY = originalRepository;
+  if (originalApiUrl === undefined) delete process.env.GITHUB_API_URL;
+  else process.env.GITHUB_API_URL = originalApiUrl;
+  if (originalToken === undefined) delete process.env.GITHUB_TOKEN;
+  else process.env.GITHUB_TOKEN = originalToken;
+});
+
+test("returns a repository summary in read-only mode", async () => {
+  global.fetch = async (url, options) => {
+    assert.equal(
+      url,
+      "https://github.test/repos/radostinvgeorgiev-commits/sunchron-backend",
+    );
+    assert.equal(options.headers.Authorization, undefined);
+    return jsonResponse({
+      full_name: "radostinvgeorgiev-commits/sunchron-backend",
+      default_branch: "main",
+      private: false,
+      description: "Synchron-X",
+      updated_at: "2026-07-25T00:00:00Z",
+      html_url:
+        "https://github.com/radostinvgeorgiev-commits/sunchron-backend",
+    });
+  };
+
+  const summary = await getRepositorySummary();
+  assert.equal(summary.repository, process.env.GITHUB_REPOSITORY);
+  assert.equal(summary.defaultBranch, "main");
+});
+
+test("limits and normalizes recent commits", async () => {
+  global.fetch = async (url) => {
+    assert.match(url, /commits\?per_page=20$/u);
+    return jsonResponse([
+      {
+        sha: "a07541e61e4e56af0ca41d3d6596b53cbc244081",
+        commit: {
+          message: "Fix memory",
+          author: { name: "Codex", date: "2026-07-25T00:00:00Z" },
+        },
+        html_url: "https://github.test/commit/a07541e",
+      },
+    ]);
+  };
+
+  const commits = await listRecentCommits(undefined, 100);
+  assert.equal(commits[0].shortSha, "a07541e");
+  assert.equal(commits[0].message, "Fix memory");
+});
+
+test("reads and decodes an allowed text file", async () => {
+  global.fetch = async (url) => {
+    assert.match(url, /contents\/src\/routes\/chat.js\?ref=main$/u);
+    return jsonResponse({
+      type: "file",
+      path: "src/routes/chat.js",
+      sha: "abc123",
+      size: 5,
+      content: Buffer.from("hello").toString("base64"),
+      html_url: "https://github.test/file",
+    });
+  };
+
+  const file = await getFileContent("src/routes/chat.js", undefined, "main");
+  assert.equal(file.content, "hello");
+});
+
+test("rejects traversal and repositories outside the allowlist", async () => {
+  await assert.rejects(
+    () => getFileContent("../secret"),
+    (error) =>
+      error instanceof GitHubServiceError && error.code === "INVALID_PATH",
+  );
+  await assert.rejects(
+    () => getRepositorySummary("someone/else"),
+    (error) =>
+      error instanceof GitHubServiceError &&
+      error.code === "REPOSITORY_NOT_ALLOWED",
+  );
+});
+
+test("does not hide GitHub API failures", async () => {
+  global.fetch = async () => jsonResponse({ message: "Not Found" }, 404);
+  await assert.rejects(
+    () => getRepositorySummary(),
+    (error) =>
+      error instanceof GitHubServiceError &&
+      error.status === 404 &&
+      error.code === "GITHUB_API_ERROR",
+  );
+});


### PR DESCRIPTION
## Какво е добавено

- реална връзка към GitHub API в режим само за четене
- проверка на състоянието на разрешеното хранилище
- списък с последните commit-и
- четене на конкретен текстов файл
- ограничение до `radostinvgeorgiev-commits/sunchron-backend`
- ясни грешки при липсващ ресурс, забранено хранилище или проблем с връзката

## Защо

Synchron-X досега можеше само да описва GitHub действия. Този модул добавя първата реална външна способност, без право за промяна на данни.

## Проверки

- `node --check` за новите файлове и сървъра
- 5 нови теста за GitHub модула
- целият пакет: 18 теста, 18 успешни

Промяната е в отделен клон и не засяга `main` преди преглед.