### PR TITLE
Connect verified GitHub reads to chat

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -12,6 +12,10 @@ import {
   saveConversationTurn,
   saveProfileMemory,
 } from "../services/memoryService.js";
+import {
+  answerGitHubReadRequest,
+  GitHubServiceError,
+} from "../services/githubService.js";
 
 const router = express.Router();
 const HEARTBEAT_INTERVAL_MS = 15000;
@@ -254,6 +258,25 @@ router.post("/chat", async (req, res) => {
     await saveConversationTurn(cleanSessionId, cleanMessage, fullReply);
     sendEvent("token", { token: fullReply });
     sendEvent("done", { ok: true, memoryCount: scopedMemories.length });
+    res.end();
+    return;
+  }
+
+  try {
+    const githubReply = await answerGitHubReadRequest(cleanMessage);
+    if (githubReply) {
+      await saveConversationTurn(cleanSessionId, cleanMessage, githubReply);
+      sendEvent("token", { token: githubReply });
+      sendEvent("done", { ok: true, tool: "github", mode: "read-only" });
+      res.end();
+      return;
+    }
+  } catch (error) {
+    const message =
+      error instanceof GitHubServiceError
+        ? error.message
+        : "GitHub модулът временно не е достъпен.";
+    sendEvent("error", { message, tool: "github" });
     res.end();
     return;
   }

--- a/src/services/githubService.js
+++ b/src/services/githubService.js
@@ -163,3 +163,39 @@ export async function getFileContent(
     url: data.html_url,
   };
 }
+
+export function isGitHubReadRequest(message) {
+  const text = typeof message === "string" ? message.trim().toLowerCase() : "";
+  return (
+    /\bgithub\b/u.test(text) ||
+    /\b(commit|комит|хранилищ|репозитор)/u.test(text) ||
+    /последн(?:ата|ите)\s+промян/u.test(text)
+  );
+}
+
+export async function answerGitHubReadRequest(message) {
+  if (!isGitHubReadRequest(message)) return null;
+
+  const commits = await listRecentCommits(getConfiguredRepository(), 5);
+  if (!commits.length) {
+    return "В GitHub не намерих commit-и за разрешеното хранилище.";
+  }
+
+  const asksForSeveral =
+    /последните|промените|комитите|commit-и|история/u.test(
+      message.toLowerCase(),
+    );
+  const selected = asksForSeveral ? commits : commits.slice(0, 1);
+  const heading =
+    selected.length === 1
+      ? "Последната реална промяна в GitHub е:"
+      : "Последните реални промени в GitHub са:";
+
+  return [
+    heading,
+    ...selected.map(
+      (commit) =>
+        `• ${commit.shortSha} — ${commit.message}${commit.date ? ` (${commit.date})` : ""}`,
+    ),
+  ].join("\n");
+}

--- a/tests/githubService.test.js
+++ b/tests/githubService.test.js
@@ -1,10 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  answerGitHubReadRequest,
   getFileContent,
   getRepositorySummary,
   GitHubServiceError,
   listRecentCommits,
+  isGitHubReadRequest,
 } from "../src/services/githubService.js";
 
 const originalFetch = global.fetch;
@@ -122,4 +124,33 @@ test("does not hide GitHub API failures", async () => {
       error.status === 404 &&
       error.code === "GITHUB_API_ERROR",
   );
+});
+
+test("recognizes GitHub questions but ignores unrelated chat", () => {
+  assert.equal(
+    isGitHubReadRequest("Каква е последната промяна в проекта?"),
+    true,
+  );
+  assert.equal(isGitHubReadRequest("Провери последните commit-и в GitHub"), true);
+  assert.equal(isGitHubReadRequest("Какво е времето във Варна?"), false);
+});
+
+test("answers a GitHub question with verified commit data", async () => {
+  global.fetch = async () =>
+    jsonResponse([
+      {
+        sha: "95f7207f884fe67ed31b9e4ba078c903aa41b6d3",
+        commit: {
+          message: "Add real read-only GitHub module",
+          author: { name: "Codex", date: "2026-07-25T00:30:00Z" },
+        },
+        html_url: "https://github.test/commit/95f7207",
+      },
+    ]);
+
+  const reply = await answerGitHubReadRequest(
+    "Каква е последната промяна в проекта?",
+  );
+  assert.match(reply, /95f7207/u);
+  assert.match(reply, /Add real read-only GitHub module/u);
 });


### PR DESCRIPTION
## Какво се променя

Synchron-X вече разпознава въпроси за GitHub и последните промени, извиква реалния GitHub модул и връща проверени commit данни. Отговорът се записва и в историята на разговора.

## Защити

- модулът остава само за четене
- работи само с разрешеното хранилище
- при грешка не твърди, че действието е изпълнено

## Проверки

- 7 теста за GitHub модула
- целият пакет: 20 теста, 20 успешни