### PR TITLE
Add permissions and action audit log

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node --check server.js && node --check src/routes/chat.js && node --check src/routes/memoryRouter.js && node --check src/services/memoryService.js && node --check public/app.js && node --test tests/*.test.js"
+    "test": "node --check server.js && node --check src/routes/chat.js && node --check src/routes/githubRouter.js && node --check src/routes/memoryRouter.js && node --check src/routes/permissionsRouter.js && node --check src/services/githubService.js && node --check src/services/memoryService.js && node --check src/services/permissionService.js && node --check public/app.js && node --test tests/*.test.js"
   },
   "dependencies": {
     "@opensearch-project/opensearch": "^3.5.1",

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ import healthRouter from "./src/routes/health.js";
 import memoryRouter from "./src/routes/memoryRouter.js";
 import cloudRouter from "./src/routes/cloudRouter.js";
 import githubRouter from "./src/routes/githubRouter.js";
+import permissionsRouter from "./src/routes/permissionsRouter.js";
 
 dotenv.config();
 
@@ -40,6 +41,7 @@ app.use("/health", healthRouter);
 app.use("/memory", memoryRouter);
 app.use("/cloud", cloudRouter);
 app.use("/github", githubRouter);
+app.use("/permissions", permissionsRouter);
 
 app.get("/opensearch-status", async (req, res) => {
   const client = getOpenSearchClient();

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -15,11 +15,24 @@ import {
 import {
   answerGitHubReadRequest,
   GitHubServiceError,
+  isGitHubReadRequest,
 } from "../services/githubService.js";
+import {
+  evaluatePermission,
+  recordAuditEvent,
+} from "../services/permissionService.js";
 
 const router = express.Router();
 const HEARTBEAT_INTERVAL_MS = 15000;
 const DEFAULT_AGENT_TIMEOUT_MS = 120000;
+
+async function auditAction(event) {
+  try {
+    await recordAuditEvent(event);
+  } catch (error) {
+    console.error("[Audit] Write failure:", error);
+  }
+}
 
 const ASSISTANT_CONTEXT = [
   "[КОНТЕКСТ И ПРАВИЛА ЗА ТОЗИ РАЗГОВОР]",
@@ -195,7 +208,7 @@ router.post("/chat", async (req, res) => {
     }
   };
 
-  if (memoryAction) {
+    if (memoryAction) {
     let fullReply;
     if (memoryAction.type === "cleared") {
       fullReply = "Изчистих постоянната памет.";
@@ -221,6 +234,20 @@ router.post("/chat", async (req, res) => {
     }
 
     await saveConversationTurn(cleanSessionId, cleanMessage, fullReply);
+    await auditAction({
+      action:
+        memoryAction.type === "cleared" || memoryAction.type === "forgot"
+          ? "memory.delete"
+          : "memory.write",
+      decision:
+        memoryAction.type === "cleared" || memoryAction.type === "forgot"
+          ? "confirmed"
+          : "allow",
+      outcome: "succeeded",
+      resource: "profile-memory",
+      details: memoryAction.type,
+      sessionId: cleanSessionId,
+    });
     sendEvent("token", { token: fullReply });
     sendEvent("done", { ok: true, memoryUpdated: true });
     res.end();
@@ -263,9 +290,37 @@ router.post("/chat", async (req, res) => {
   }
 
   try {
-    const githubReply = await answerGitHubReadRequest(cleanMessage);
+    const wantsGitHubRead = isGitHubReadRequest(cleanMessage);
+    const githubPermission = wantsGitHubRead
+      ? evaluatePermission("github.read")
+      : null;
+    if (githubPermission && githubPermission.decision !== "allow") {
+      await auditAction({
+        action: "github.read",
+        decision: githubPermission.decision,
+        outcome: "blocked",
+        resource: "chat-tool",
+        sessionId: cleanSessionId,
+      });
+      throw new GitHubServiceError(
+        githubPermission.reason,
+        403,
+        "PERMISSION_DENIED",
+      );
+    }
+
+    const githubReply = wantsGitHubRead
+      ? await answerGitHubReadRequest(cleanMessage)
+      : null;
     if (githubReply) {
       await saveConversationTurn(cleanSessionId, cleanMessage, githubReply);
+      await auditAction({
+        action: "github.read",
+        decision: githubPermission.decision,
+        outcome: "succeeded",
+        resource: "chat-tool",
+        sessionId: cleanSessionId,
+      });
       sendEvent("token", { token: githubReply });
       sendEvent("done", { ok: true, tool: "github", mode: "read-only" });
       res.end();

--- a/src/routes/githubRouter.js
+++ b/src/routes/githubRouter.js
@@ -6,10 +6,41 @@ import {
   GitHubServiceError,
   listRecentCommits,
 } from "../services/githubService.js";
+import {
+  evaluatePermission,
+  recordAuditEvent,
+} from "../services/permissionService.js";
 
 const router = express.Router();
 
-function sendError(res, error) {
+function requireGitHubRead(req, res, next) {
+  const permission = evaluatePermission("github.read");
+  if (permission.decision !== "allow") {
+    return res.status(403).json({
+      error: permission.reason,
+      code: "PERMISSION_DENIED",
+    });
+  }
+  req.permission = permission;
+  next();
+}
+
+async function audit(req, outcome, details = null) {
+  try {
+    await recordAuditEvent({
+      action: "github.read",
+      decision: req.permission?.decision,
+      outcome,
+      resource: `${req.method} ${req.baseUrl}${req.path}`,
+      details,
+    });
+  } catch (error) {
+    console.error("[Audit] Write failure:", error);
+  }
+}
+
+async function sendError(req, res, error) {
+  await audit(req, "failed", error?.code || error?.message);
   if (error instanceof GitHubServiceError) {
     return res.status(error.status).json({
       error: error.message,
@@ -23,13 +54,16 @@ function sendError(res, error) {
   });
 }
 
-router.get("/status", async (_req, res) => {
+router.use(requireGitHubRead);
+
+router.get("/status", async (req, res) => {
   try {
     const repository = getConfiguredRepository();
     const summary = await getRepositorySummary(repository);
+    await audit(req, "succeeded", repository);
     res.json({ status: "connected", mode: "read-only", ...summary });
   } catch (error) {
-    sendError(res, error);
+    await sendError(req, res, error);
   }
 });
 
@@ -39,9 +73,10 @@ router.get("/commits", async (req, res) => {
       getConfiguredRepository(),
       req.query.limit,
     );
+    await audit(req, "succeeded", `commits:${commits.length}`);
     res.json({ mode: "read-only", commits });
   } catch (error) {
-    sendError(res, error);
+    await sendError(req, res, error);
   }
 });
 
@@ -52,9 +87,10 @@ router.get("/file", async (req, res) => {
       getConfiguredRepository(),
       req.query.ref,
     );
+    await audit(req, "succeeded", file.path);
     res.json({ mode: "read-only", ...file });
   } catch (error) {
-    sendError(res, error);
+    await sendError(req, res, error);
   }
 });
 

--- a/src/routes/permissionsRouter.js
+++ b/src/routes/permissionsRouter.js
@@ -1,0 +1,34 @@
+import express from "express";
+import {
+  evaluatePermission,
+  listAuditEvents,
+  listPermissions,
+} from "../services/permissionService.js";
+
+const router = express.Router();
+
+router.get("/", (_req, res) => {
+  res.json({
+    defaultDecision: "deny",
+    permissions: listPermissions(),
+  });
+});
+
+router.get("/check", (req, res) => {
+  res.json(evaluatePermission(req.query.action));
+});
+
+router.get("/audit", async (req, res) => {
+  try {
+    const events = await listAuditEvents(req.query.limit);
+    res.json({ events });
+  } catch (error) {
+    console.error("[Audit] Read failure:", error);
+    res.status(503).json({
+      error: "Дневникът на действията временно не е достъпен.",
+      code: "AUDIT_UNAVAILABLE",
+    });
+  }
+});
+
+export default router;

--- a/src/services/permissionService.js
+++ b/src/services/permissionService.js
@@ -1,0 +1,116 @@
+import { randomUUID } from "node:crypto";
+import { getOpenSearchClient } from "../config/opensearch.js";
+
+const AUDIT_INDEX = process.env.AUDIT_INDEX || "synchron-action-audit";
+const MAX_FALLBACK_EVENTS = 500;
+const fallbackEvents = [];
+
+const POLICY = Object.freeze({
+  "github.read": Object.freeze({
+    decision: "allow",
+    risk: "low",
+    reason: "GitHub достъпът е ограничен само до четене.",
+  }),
+  "github.write": Object.freeze({
+    decision: "confirm",
+    risk: "medium",
+    reason: "Промените в GitHub изискват отделно разрешение.",
+  }),
+  "memory.read": Object.freeze({
+    decision: "allow",
+    risk: "low",
+    reason: "Четенето на собствената памет е разрешено.",
+  }),
+  "memory.write": Object.freeze({
+    decision: "allow",
+    risk: "medium",
+    reason: "Записът е разрешен, когато е поискан в разговора.",
+  }),
+  "memory.delete": Object.freeze({
+    decision: "confirm",
+    risk: "high",
+    reason: "Изтриването на постоянна памет изисква потвърждение.",
+  }),
+  "external.send": Object.freeze({
+    decision: "confirm",
+    risk: "high",
+    reason: "Изпращането или публикуването от името на Радко изисква потвърждение.",
+  }),
+  payment: Object.freeze({
+    decision: "confirm",
+    risk: "critical",
+    reason: "Плащане, покупка или резервация изисква потвърждение.",
+  }),
+});
+
+function cleanText(value, fallback = null) {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+export function evaluatePermission(action) {
+  const cleanAction = cleanText(action);
+  const policy = cleanAction ? POLICY[cleanAction] : null;
+  if (policy) return { action: cleanAction, ...policy };
+  return {
+    action: cleanAction || "unknown",
+    decision: "deny",
+    risk: "unknown",
+    reason: "Действието не е описано в разрешенията и е блокирано по подразбиране.",
+  };
+}
+
+export function listPermissions() {
+  return Object.entries(POLICY).map(([action, policy]) => ({
+    action,
+    ...policy,
+  }));
+}
+
+export async function recordAuditEvent(event) {
+  const permission = evaluatePermission(event.action);
+  const entry = {
+    id: randomUUID(),
+    timestamp: new Date().toISOString(),
+    actor: cleanText(event.actor, "synchron-x"),
+    action: permission.action,
+    decision: cleanText(event.decision, permission.decision),
+    outcome: cleanText(event.outcome, "attempted"),
+    resource: cleanText(event.resource),
+    details: cleanText(event.details),
+    sessionId: cleanText(event.sessionId),
+  };
+
+  const client = getOpenSearchClient();
+  if (client) {
+    await client.index({
+      index: AUDIT_INDEX,
+      id: entry.id,
+      body: entry,
+      refresh: true,
+    });
+  } else {
+    fallbackEvents.unshift(entry);
+    if (fallbackEvents.length > MAX_FALLBACK_EVENTS) fallbackEvents.pop();
+  }
+  return entry;
+}
+
+export async function listAuditEvents(limit = 50) {
+  const safeLimit = Math.min(Math.max(Number(limit) || 50, 1), 100);
+  const client = getOpenSearchClient();
+  if (!client) return fallbackEvents.slice(0, safeLimit);
+
+  const response = await client.search({
+    index: AUDIT_INDEX,
+    body: {
+      size: safeLimit,
+      sort: [{ timestamp: { order: "desc" } }],
+      query: { match_all: {} },
+    },
+  });
+  return (response.body?.hits?.hits || []).map((hit) => hit._source);
+}
+
+export function resetAuditFallbackForTests() {
+  fallbackEvents.length = 0;
+}

--- a/tests/permissionService.test.js
+++ b/tests/permissionService.test.js
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  evaluatePermission,
+  listAuditEvents,
+  listPermissions,
+  recordAuditEvent,
+  resetAuditFallbackForTests,
+} from "../src/services/permissionService.js";
+
+test.beforeEach(() => {
+  delete process.env.OPENSEARCH_USERNAME;
+  delete process.env.OPENSEARCH_PASSWORD;
+  delete process.env.OPENSEARCH_HOST;
+  delete process.env.OPENSEARCH_PORT;
+  resetAuditFallbackForTests();
+});
+
+test("allows approved reads and requires confirmation for risky actions", () => {
+  assert.equal(evaluatePermission("github.read").decision, "allow");
+  assert.equal(evaluatePermission("github.write").decision, "confirm");
+  assert.equal(evaluatePermission("payment").decision, "confirm");
+});
+
+test("denies unknown actions by default", () => {
+  const result = evaluatePermission("unregistered.action");
+  assert.equal(result.decision, "deny");
+  assert.equal(result.risk, "unknown");
+});
+
+test("exposes the permission registry without mutable policy objects", () => {
+  const permissions = listPermissions();
+  assert.ok(permissions.some((item) => item.action === "memory.delete"));
+  assert.ok(permissions.every((item) => item.decision));
+});
+
+test("records append-only audit events when OpenSearch is unavailable", async () => {
+  const saved = await recordAuditEvent({
+    action: "github.read",
+    outcome: "succeeded",
+    resource: "GET /github/commits",
+  });
+  const events = await listAuditEvents();
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].id, saved.id);
+  assert.equal(events[0].decision, "allow");
+  assert.equal(events[0].outcome, "succeeded");
+});


### PR DESCRIPTION
## Какво се променя

- добавя централен регистър за разрешения с решения allow, confirm и deny;
- блокира непознати действия по подразбиране;
- добавя дневник на GitHub прочитите и промените в паметта;
- пази дневника в OpenSearch, с ограничен временен режим при липса на връзка;
- добавя API за проверка на разрешение и преглед на дневника.

## Защо

Synchron-X трябва да проверява разрешенията преди реално действие и да оставя проверима следа след него.

## Проверка

- `npm test`: 27/27 успешни
- `git diff --check`: успешно
- `main` не е променян