### PR TITLE
Показвай файловете, променени в конкретен GitHub commit

### DIFF
--- a/src/routes/githubRouter.js
+++ b/src/routes/githubRouter.js
@@ -1,6 +1,7 @@
 import express from "express";
 import {
   getConfiguredRepository,
+  getCommitDetails,
   getFileContent,
   getRepositorySummary,
   GitHubServiceError,
@@ -75,6 +76,19 @@ router.get("/commits", async (req, res) => {
     );
     await audit(req, "succeeded", `commits:${commits.length}`);
     res.json({ mode: "read-only", commits });
+  } catch (error) {
+    await sendError(req, res, error);
+  }
+});
+
+router.get("/commit/:ref", async (req, res) => {
+  try {
+    const commit = await getCommitDetails(
+      req.params.ref,
+      getConfiguredRepository(),
+    );
+    await audit(req, "succeeded", `commit:${commit.shortSha}`);
+    res.json({ mode: "read-only", commit });
   } catch (error) {
     await sendError(req, res, error);
   }

--- a/src/services/githubService.js
+++ b/src/services/githubService.js
@@ -130,6 +130,47 @@ export async function listRecentCommits(
   }));
 }
 
+export async function getCommitDetails(
+  ref,
+  repository = configuredRepository(),
+) {
+  assertAllowedRepository(repository);
+  const cleanRef = typeof ref === "string" ? ref.trim() : "";
+  if (!/^[a-f0-9]{7,40}$/iu.test(cleanRef)) {
+    throw new GitHubServiceError(
+      "Невалиден GitHub commit.",
+      400,
+      "INVALID_COMMIT",
+    );
+  }
+
+  const data = await githubRequest(
+    `/repos/${repository}/commits/${encodeURIComponent(cleanRef)}`,
+  );
+  return {
+    sha: data.sha,
+    shortSha: data.sha?.slice(0, 7),
+    message: data.commit?.message || "",
+    date: data.commit?.author?.date || null,
+    url: data.html_url,
+    stats: {
+      additions: data.stats?.additions || 0,
+      deletions: data.stats?.deletions || 0,
+      total: data.stats?.total || 0,
+    },
+    files: Array.isArray(data.files)
+      ? data.files.map((file) => ({
+          path: file.filename,
+          status: file.status,
+          additions: file.additions || 0,
+          deletions: file.deletions || 0,
+          changes: file.changes || 0,
+          previousPath: file.previous_filename || null,
+        }))
+      : [],
+  };
+}
+
 export async function getFileContent(
   path,
   repository = configuredRepository(),
@@ -176,6 +217,45 @@ export function isGitHubReadRequest(message) {
 export async function answerGitHubReadRequest(message) {
   if (!isGitHubReadRequest(message)) return null;
 
+  const text = message.toLowerCase();
+  const explicitRef = message.match(/\b[a-f0-9]{7,40}\b/iu)?.[0];
+  const asksForDetails =
+    /(?:кои|изброй|файлов|файли|diff|разлик|подробност|какво точно|във всеки файл)/u.test(
+      text,
+    );
+
+  if (asksForDetails) {
+    const ref =
+      explicitRef ||
+      (await listRecentCommits(getConfiguredRepository(), 1))[0]?.sha;
+    if (!ref) {
+      return "В GitHub не намерих commit за подробна проверка.";
+    }
+
+    const commit = await getCommitDetails(ref, getConfiguredRepository());
+    if (!commit.files.length) {
+      return `Commit ${commit.shortSha} няма отчетени променени файлове.`;
+    }
+
+    const statusLabels = {
+      added: "добавен",
+      modified: "променен",
+      removed: "изтрит",
+      renamed: "преименуван",
+    };
+    return [
+      `В commit ${commit.shortSha} са променени ${commit.files.length} файла:`,
+      ...commit.files.map((file) => {
+        const status = statusLabels[file.status] || file.status || "променен";
+        const rename = file.previousPath
+          ? ` от ${file.previousPath}`
+          : "";
+        return `• ${file.path} — ${status}${rename}; +${file.additions}/-${file.deletions} реда.`;
+      }),
+      `Общо: +${commit.stats.additions}/-${commit.stats.deletions} реда.`,
+    ].join("\n");
+  }
+
   const commits = await listRecentCommits(getConfiguredRepository(), 5);
   if (!commits.length) {
     return "В GitHub не намерих commit-и за разрешеното хранилище.";
@@ -183,7 +263,7 @@ export async function answerGitHubReadRequest(message) {
 
   const asksForSeveral =
     /последните|промените|комитите|commit-и|история/u.test(
-      message.toLowerCase(),
+      text,
     );
   const selected = asksForSeveral ? commits : commits.slice(0, 1);
   const heading =

--- a/tests/githubService.test.js
+++ b/tests/githubService.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   answerGitHubReadRequest,
+  getCommitDetails,
   getFileContent,
   getRepositorySummary,
   GitHubServiceError,
@@ -84,6 +85,41 @@ test("limits and normalizes recent commits", async () => {
   assert.equal(commits[0].message, "Fix memory");
 });
 
+test("returns changed files for a specific commit", async () => {
+  global.fetch = async (url) => {
+    assert.match(url, /commits\/3d6474b$/u);
+    return jsonResponse({
+      sha: "3d6474b18a070ccca57573dd5c7eff95207aba1e",
+      commit: {
+        message: "Merge pull request #9",
+        author: { date: "2026-07-25T14:18:42Z" },
+      },
+      stats: { additions: 20, deletions: 3, total: 23 },
+      files: [
+        {
+          filename: "src/services/githubService.js",
+          status: "modified",
+          additions: 20,
+          deletions: 3,
+          changes: 23,
+        },
+      ],
+    });
+  };
+
+  const commit = await getCommitDetails("3d6474b");
+  assert.equal(commit.files[0].path, "src/services/githubService.js");
+  assert.equal(commit.stats.additions, 20);
+});
+
+test("rejects an invalid commit reference", async () => {
+  await assert.rejects(
+    () => getCommitDetails("../main"),
+    (error) =>
+      error instanceof GitHubServiceError && error.code === "INVALID_COMMIT",
+  );
+});
+
 test("reads and decodes an allowed text file", async () => {
   global.fetch = async (url) => {
     assert.match(url, /contents\/src\/routes\/chat.js\?ref=main$/u);
@@ -153,4 +189,30 @@ test("answers a GitHub question with verified commit data", async () => {
   );
   assert.match(reply, /95f7207/u);
   assert.match(reply, /Add real read-only GitHub module/u);
+});
+
+test("answers a commit details question with changed files", async () => {
+  global.fetch = async (url) => {
+    assert.match(url, /commits\/3d6474b$/u);
+    return jsonResponse({
+      sha: "3d6474b18a070ccca57573dd5c7eff95207aba1e",
+      commit: { message: "Merge pull request #9" },
+      stats: { additions: 10, deletions: 2, total: 12 },
+      files: [
+        {
+          filename: "src/services/githubService.js",
+          status: "modified",
+          additions: 10,
+          deletions: 2,
+          changes: 12,
+        },
+      ],
+    });
+  };
+
+  const reply = await answerGitHubReadRequest(
+    "Изброй файловете, променени в commit 3d6474b, и обясни какво е променено.",
+  );
+  assert.match(reply, /src\/services\/githubService\.js/u);
+  assert.match(reply, /\+10\/-2/u);
 });


### PR DESCRIPTION
## Какво се поправя
Synchron-X вече чете подробностите на конкретен commit от GitHub API, вместо да повтаря само заглавието му.

## Промени
- добавено четене на променените файлове, статуса и броя добавени/изтрити редове;
- добавен read-only endpoint `/github/commit/:ref`;
- заявките „какво точно е променено“ и „изброй файловете“ връщат реалните файлове;
- добавени тестове за подробности и невалиден commit.

## Проверка
Локално: 46/46 теста успешни.

## Риск
Нисък. Промяната е само за четене и не засяга паметта или GitHub записването.