### PR TITLE
Remove duplicate DigitalOcean deploy job

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,19 +29,3 @@ jobs:
 
       - name: Run checks
         run: npm test
-
-  deploy:
-    needs: test
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Deploy to DigitalOcean App Platform
-        uses: digitalocean/app_action/deploy@v2
-        with:
-          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-          app_name: sunchron-backend


### PR DESCRIPTION
## Какво се променя

Премахва се само дублираната задача `deploy` от `.github/workflows/nodejs.yml`.

## Защо

DigitalOcean App Platform вече следи `main` и публикува директно от GitHub. Допълнителният GitHub Actions deploy дублира този процес и се проваля заради липсващ вход `token`.

## Какво остава

Автоматичният тест `test` остава непроменен. Работещият сайт, паметта и приложението не се засягат.

## Проверка

Workflow файлът е проверен след промяната: съдържа само тестовата задача.