### PR TITLE
Fix Bulgarian memory overview questions

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -60,6 +60,15 @@ function parsePositiveInteger(value, fallback) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+export function isOverviewQuestion(message, subject) {
+  const normalizedQuestion = message.replace(/[„“"'’]/gu, "").trim();
+  const questionEnd = String.raw`(?=\s|[?!.,:;]|$)`;
+  return new RegExp(
+    String.raw`^какво\s+знаеш\s+за\s+${subject}${questionEnd}`,
+    "iu",
+  ).test(normalizedQuestion);
+}
+
 function extractTokenFromAgentEvent(rawEvent) {
   const dataLines = rawEvent
     .split(/\r?\n/)
@@ -254,16 +263,11 @@ router.post("/chat", async (req, res) => {
     return;
   }
 
-  const normalizedQuestion = cleanMessage
-    .replace(/[„“"'’]/gu, "")
-    .trim();
-  const isProfileOverviewQuestion = /^какво\s+знаеш\s+за\s+мен\b/iu.test(
-    normalizedQuestion,
+  const isProfileOverviewQuestion = isOverviewQuestion(cleanMessage, "мен");
+  const isProjectOverviewQuestion = isOverviewQuestion(
+    cleanMessage,
+    "(?:проекта|synchron-x)",
   );
-  const isProjectOverviewQuestion =
-    /^какво\s+знаеш\s+за\s+(?:проекта|synchron-x)\b/iu.test(
-      normalizedQuestion,
-    );
   if (isProfileOverviewQuestion || isProjectOverviewQuestion) {
     const requestedScope = isProjectOverviewQuestion ? "project" : "personal";
     const scopedMemories = memories.filter(

--- a/tests/chatOverviewQuestions.test.js
+++ b/tests/chatOverviewQuestions.test.js
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isOverviewQuestion } from "../src/routes/chat.js";
+
+test("recognizes Bulgarian personal overview questions with punctuation", () => {
+  assert.equal(isOverviewQuestion("Какво знаеш за мен?", "мен"), true);
+  assert.equal(isOverviewQuestion("Какво знаеш за мен", "мен"), true);
+});
+
+test("recognizes Bulgarian project overview questions with punctuation", () => {
+  assert.equal(
+    isOverviewQuestion("Какво знаеш за проекта?", "(?:проекта|synchron-x)"),
+    true,
+  );
+  assert.equal(
+    isOverviewQuestion(
+      "Какво знаеш за Synchron-X?",
+      "(?:проекта|synchron-x)",
+    ),
+    true,
+  );
+});
+
+test("does not match longer unrelated words", () => {
+  assert.equal(isOverviewQuestion("Какво знаеш за ментора?", "мен"), false);
+});


### PR DESCRIPTION
Поправя разпознаването на „Какво знаеш за мен?“ и „Какво знаеш за проекта?“ при кирилица и пунктуация.

Причина: JavaScript `\b` не разпознава правилно граница след кирилица, затова заявката минаваше към AI модела вместо да върне проверената постоянна памет.

Проверка: 49 автоматични теста минават успешно, включително нови тестове за двата въпроса.