### PR TITLE
Protect full memory deletion with explicit confirmation

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -6,6 +6,7 @@ import {
   extractForgetMemoryCommand,
   extractImplicitMemoryCandidates,
   extractPersistentMemoryCommands,
+  isConfirmedForgetAllCommand,
   isForgetAllCommand,
   listConversationMessages,
   listProfileMemories,
@@ -151,9 +152,11 @@ router.post("/chat", async (req, res) => {
               scope: items[0].scope,
             }
           : { type: "batch", items };
-    } else if (isForgetAllCommand(cleanMessage)) {
+    } else if (isConfirmedForgetAllCommand(cleanMessage)) {
       const deleted = await clearProfileMemories();
       memoryAction = { type: "cleared", deleted };
+    } else if (isForgetAllCommand(cleanMessage)) {
+      memoryAction = { type: "clear-confirmation-required" };
     } else {
       const forgetCommand = extractForgetMemoryCommand(cleanMessage);
       if (forgetCommand) {
@@ -219,7 +222,10 @@ router.post("/chat", async (req, res) => {
 
     if (memoryAction) {
     let fullReply;
-    if (memoryAction.type === "cleared") {
+    if (memoryAction.type === "clear-confirmation-required") {
+      fullReply =
+        "Това ще изтрие цялата постоянна памет. За да потвърдиш, напиши точно: „Потвърждавам изтриването на цялата постоянна памет“.";
+    } else if (memoryAction.type === "cleared") {
       fullReply = "Изчистих постоянната памет.";
     } else if (memoryAction.type === "forgot") {
       fullReply = memoryAction.deleted
@@ -243,16 +249,22 @@ router.post("/chat", async (req, res) => {
     }
 
     await saveConversationTurn(cleanSessionId, cleanMessage, fullReply);
+    const isDeleteAction =
+      memoryAction.type === "cleared" ||
+      memoryAction.type === "forgot" ||
+      memoryAction.type === "clear-confirmation-required";
     await auditAction({
-      action:
-        memoryAction.type === "cleared" || memoryAction.type === "forgot"
-          ? "memory.delete"
-          : "memory.write",
+      action: isDeleteAction ? "memory.delete" : "memory.write",
       decision:
-        memoryAction.type === "cleared" || memoryAction.type === "forgot"
-          ? "confirmed"
-          : "allow",
-      outcome: "succeeded",
+        memoryAction.type === "clear-confirmation-required"
+          ? "confirm"
+          : isDeleteAction
+            ? "confirmed"
+            : "allow",
+      outcome:
+        memoryAction.type === "clear-confirmation-required"
+          ? "requested"
+          : "succeeded",
       resource: "profile-memory",
       details: memoryAction.type,
       sessionId: cleanSessionId,

--- a/src/services/memoryService.js
+++ b/src/services/memoryService.js
@@ -342,6 +342,12 @@ export function isForgetAllCommand(message) {
   );
 }
 
+export function isConfirmedForgetAllCommand(message) {
+  return /^потвърждавам\s+изтриването\s+на\s+цялата\s+постоянна\s+(?:ми\s+)?памет[.!]?$/iu.test(
+    message.trim(),
+  );
+}
+
 async function fetchProfileHits() {
   const response = await getClientOrThrow().search({
     index: PROFILE_INDEX,

--- a/src/services/memoryService.js
+++ b/src/services/memoryService.js
@@ -337,7 +337,7 @@ export function extractForgetMemoryCommand(message) {
 }
 
 export function isForgetAllCommand(message) {
-  return /^(?:забрави|изтрий)\s+(?:цялата|всичко\s+от)\s+постоянната\s+(?:ми\s+)?памет[.!]?$/iu.test(
+  return /^(?:забрави|изтрий)\s+(?:цялата|всичко\s+от)\s+постоянна(?:та)?\s+(?:ми\s+)?памет[.!]?$/iu.test(
     message.trim(),
   );
 }

--- a/tests/memoryService.test.js
+++ b/tests/memoryService.test.js
@@ -7,6 +7,8 @@ import {
   deriveMemoryMetadata,
   extractForgetMemoryCommand,
   extractImplicitMemoryCandidates,
+  isConfirmedForgetAllCommand,
+  isForgetAllCommand,
   extractPersistentMemoryCommand,
 } from "../src/services/memoryService.js";
 
@@ -199,4 +201,21 @@ test("splits and deduplicates legacy profile lists without deleting history", ()
     ["живея във Варна", "имам бизнес с бунгала в Камчия", "Казвам се Радко"],
   );
   assert.equal(items.some((item) => item.fact.startsWith("-")), false);
+});
+
+test("full memory deletion requires a separate explicit confirmation phrase", () => {
+  assert.equal(
+    isForgetAllCommand("Изтрий цялата постоянна памет."),
+    true,
+  );
+  assert.equal(
+    isConfirmedForgetAllCommand(
+      "Потвърждавам изтриването на цялата постоянна памет.",
+    ),
+    true,
+  );
+  assert.equal(
+    isConfirmedForgetAllCommand("Да, изтрий я."),
+    false,
+  );
 });


### PR DESCRIPTION
Добавя двустъпкова защита при изтриване на цялата постоянна памет. Първата команда само показва предупреждение; реалното изтриване изисква точна отделна фраза за потвърждение. Добавен е автоматичен тест.