### PR TITLE
Protect bulk memory API deletion

### DIFF
--- a/src/routes/memoryRouter.js
+++ b/src/routes/memoryRouter.js
@@ -9,6 +9,13 @@ import {
 
 const router = express.Router();
 
+export const CLEAR_MEMORY_CONFIRMATION =
+  "Потвърждавам изтриването на постоянната памет";
+
+export function hasClearMemoryConfirmation(req) {
+  return req.get("x-confirm-memory-delete") === CLEAR_MEMORY_CONFIRMATION;
+}
+
 function sendMemoryError(res, error) {
   const status = error?.code === "INVALID_MEMORY" ? 400 : 503;
   console.error("[Memory]", error?.message || error);
@@ -67,6 +74,13 @@ router.delete("/profile/:id", async (req, res) => {
 
 router.delete("/profile", async (req, res) => {
   try {
+    if (!hasClearMemoryConfirmation(req)) {
+      return res.status(409).json({
+        error: "Изтриването изисква отделно точно потвърждение.",
+        confirmationHeader: "x-confirm-memory-delete",
+        confirmationValue: CLEAR_MEMORY_CONFIRMATION,
+      });
+    }
     const scope =
       typeof req.query.scope === "string" ? req.query.scope : undefined;
     const deleted = await clearProfileMemories(scope);

--- a/tests/memoryRouter.test.js
+++ b/tests/memoryRouter.test.js
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CLEAR_MEMORY_CONFIRMATION,
+  hasClearMemoryConfirmation,
+} from "../src/routes/memoryRouter.js";
+
+function requestWithConfirmation(value) {
+  return {
+    get(name) {
+      assert.equal(name, "x-confirm-memory-delete");
+      return value;
+    },
+  };
+}
+
+test("bulk memory API deletion requires exact explicit confirmation", () => {
+  assert.equal(hasClearMemoryConfirmation(requestWithConfirmation()), false);
+  assert.equal(
+    hasClearMemoryConfirmation(requestWithConfirmation("да, изтрий")),
+    false,
+  );
+  assert.equal(
+    hasClearMemoryConfirmation(
+      requestWithConfirmation(CLEAR_MEMORY_CONFIRMATION),
+    ),
+    true,
+  );
+});


### PR DESCRIPTION
## Какво е променено

- добавя задължително точно потвърждение за `DELETE /memory/profile`
- защитава и пълно, и ограничено по scope масово изтриване
- добавя автоматичен тест за липсващо, грешно и правилно потвърждение

## Защо

Чат командата вече е защитена, но директният API маршрут все още можеше да изтрие много записи без отделно потвърждение.

## Проверка

GitHub Actions изпълнява пълния тестов пакет преди сливане.