### PR TITLE
Require confirmation for single memory deletion

### DIFF
--- a/src/routes/memoryRouter.js
+++ b/src/routes/memoryRouter.js
@@ -78,6 +78,20 @@ router.post("/profile", async (req, res) => {
 
 router.delete("/profile/:id", async (req, res) => {
   try {
+    if (!hasClearMemoryConfirmation(req)) {
+      await auditMemoryAction({
+        action: "memory.delete",
+        decision: "confirm",
+        outcome: "requested",
+        resource: "profile-memory",
+        details: `api:item:${req.params.id}`,
+      });
+      return res.status(409).json({
+        error: "Изтриването изисква отделно точно потвърждение.",
+        confirmationHeader: "x-confirm-memory-delete",
+        confirmationValue: CLEAR_MEMORY_CONFIRMATION,
+      });
+    }
     const deleted = await deleteProfileMemory(req.params.id);
     await auditMemoryAction({
       action: "memory.delete",

--- a/tests/memoryRouter.test.js
+++ b/tests/memoryRouter.test.js
@@ -15,7 +15,7 @@ function requestWithConfirmation(value) {
   };
 }
 
-test("bulk memory API deletion requires exact explicit confirmation", () => {
+test("memory API deletion requires exact explicit confirmation", () => {
   assert.equal(hasClearMemoryConfirmation(requestWithConfirmation()), false);
   assert.equal(
     hasClearMemoryConfirmation(requestWithConfirmation("да, изтрий")),


### PR DESCRIPTION
## Промяна
- единичното изтриване на памет вече изисква същото точно потвърждение като масовото
- отказаният опит се записва в одитния дневник
- съществуващите записи не се променят

## Проверка
GitHub Actions изпълнява пълния тестов пакет.