### PR TITLE
Add read-only Google Calendar integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node --check server.js && node --check src/routes/chat.js && node --check src/routes/githubRouter.js && node --check src/routes/memoryRouter.js && node --check src/routes/permissionsRouter.js && node --check src/routes/confirmedActionsRouter.js && node --check src/services/githubService.js && node --check src/services/memoryService.js && node --check src/services/permissionService.js && node --check src/services/confirmationService.js && node --check src/services/githubWriteService.js && node --check public/app.js && node --test tests/*.test.js"
+    "test": "node --check server.js && node --check src/routes/chat.js && node --check src/routes/githubRouter.js && node --check src/routes/calendarRouter.js && node --check src/routes/memoryRouter.js && node --check src/routes/permissionsRouter.js && node --check src/routes/confirmedActionsRouter.js && node --check src/services/githubService.js && node --check src/services/calendarService.js && node --check src/services/memoryService.js && node --check src/services/permissionService.js && node --check src/services/confirmationService.js && node --check src/services/githubWriteService.js && node --check public/app.js && node --test tests/*.test.js"
   },
   "dependencies": {
     "@opensearch-project/opensearch": "^3.5.1",

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ import healthRouter from "./src/routes/health.js";
 import memoryRouter from "./src/routes/memoryRouter.js";
 import cloudRouter from "./src/routes/cloudRouter.js";
 import githubRouter from "./src/routes/githubRouter.js";
+import calendarRouter from "./src/routes/calendarRouter.js";
 import permissionsRouter from "./src/routes/permissionsRouter.js";
 import confirmedActionsRouter from "./src/routes/confirmedActionsRouter.js";
 
@@ -42,6 +43,7 @@ app.use("/health", healthRouter);
 app.use("/memory", memoryRouter);
 app.use("/cloud", cloudRouter);
 app.use("/github", githubRouter);
+app.use("/calendar", calendarRouter);
 app.use("/permissions", permissionsRouter);
 app.use("/confirmed-actions", confirmedActionsRouter);
 

--- a/src/routes/calendarRouter.js
+++ b/src/routes/calendarRouter.js
@@ -1,0 +1,75 @@
+import express from "express";
+import {
+  CalendarServiceError,
+  listUpcomingEvents,
+} from "../services/calendarService.js";
+import {
+  evaluatePermission,
+  recordAuditEvent,
+} from "../services/permissionService.js";
+
+const router = express.Router();
+
+router.get("/status", async (req, res) => {
+  const permission = evaluatePermission("calendar.read");
+  if (permission.decision !== "allow") {
+    return res.status(403).json({ error: permission.reason });
+  }
+  try {
+    const events = await listUpcomingEvents({ days: 1, limit: 1 });
+    await recordAuditEvent({
+      action: "calendar.read",
+      decision: permission.decision,
+      outcome: "succeeded",
+      resource: "GET /calendar/status",
+    });
+    res.json({ status: "connected", mode: "read-only", reachable: true, events: events.length });
+  } catch (error) {
+    await recordAuditEvent({
+      action: "calendar.read",
+      decision: permission.decision,
+      outcome: "failed",
+      resource: "GET /calendar/status",
+      details: error?.code,
+    });
+    const status = error instanceof CalendarServiceError ? error.status : 500;
+    res.status(status).json({
+      error: error instanceof CalendarServiceError
+        ? error.message
+        : "Неочаквана грешка в календарния модул.",
+      code: error?.code || "INTERNAL_ERROR",
+    });
+  }
+});
+
+router.get("/events", async (req, res) => {
+  const permission = evaluatePermission("calendar.read");
+  if (permission.decision !== "allow") {
+    return res.status(403).json({ error: permission.reason });
+  }
+  try {
+    const events = await listUpcomingEvents({
+      days: req.query.days,
+      limit: req.query.limit,
+      timeMin: req.query.timeMin,
+    });
+    await recordAuditEvent({
+      action: "calendar.read",
+      decision: permission.decision,
+      outcome: "succeeded",
+      resource: "GET /calendar/events",
+      details: `events:${events.length}`,
+    });
+    res.json({ mode: "read-only", timezone: "Europe/Sofia", events });
+  } catch (error) {
+    const status = error instanceof CalendarServiceError ? error.status : 500;
+    res.status(status).json({
+      error: error instanceof CalendarServiceError
+        ? error.message
+        : "Неочаквана грешка в календарния модул.",
+      code: error?.code || "INTERNAL_ERROR",
+    });
+  }
+});
+
+export default router;

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -19,6 +19,11 @@ import {
   isGitHubReadRequest,
 } from "../services/githubService.js";
 import {
+  answerCalendarReadRequest,
+  CalendarServiceError,
+  isCalendarReadRequest,
+} from "../services/calendarService.js";
+import {
   evaluatePermission,
   recordAuditEvent,
 } from "../services/permissionService.js";
@@ -317,6 +322,35 @@ router.post("/chat", async (req, res) => {
   }
 
   try {
+    const wantsCalendarRead = isCalendarReadRequest(cleanMessage);
+    const calendarPermission = wantsCalendarRead
+      ? evaluatePermission("calendar.read")
+      : null;
+    if (calendarPermission && calendarPermission.decision !== "allow") {
+      throw new CalendarServiceError(
+        calendarPermission.reason,
+        403,
+        "PERMISSION_DENIED",
+      );
+    }
+    const calendarReply = wantsCalendarRead
+      ? await answerCalendarReadRequest(cleanMessage)
+      : null;
+    if (calendarReply) {
+      await saveConversationTurn(cleanSessionId, cleanMessage, calendarReply);
+      await auditAction({
+        action: "calendar.read",
+        decision: calendarPermission.decision,
+        outcome: "succeeded",
+        resource: "chat-tool",
+        sessionId: cleanSessionId,
+      });
+      sendEvent("token", { token: calendarReply });
+      sendEvent("done", { ok: true, tool: "calendar", mode: "read-only" });
+      res.end();
+      return;
+    }
+
     const wantsGitHubRead = isGitHubReadRequest(cleanMessage);
     const githubPermission = wantsGitHubRead
       ? evaluatePermission("github.read")

--- a/src/services/calendarService.js
+++ b/src/services/calendarService.js
@@ -1,0 +1,164 @@
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_CALENDAR_API = "https://www.googleapis.com/calendar/v3";
+const DEFAULT_TIMEOUT_MS = 10000;
+
+export class CalendarServiceError extends Error {
+  constructor(message, status = 500, code = "CALENDAR_ERROR") {
+    super(message);
+    this.name = "CalendarServiceError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function requiredConfig() {
+  const config = {
+    clientId: process.env.GOOGLE_CALENDAR_CLIENT_ID,
+    clientSecret: process.env.GOOGLE_CALENDAR_CLIENT_SECRET,
+    refreshToken: process.env.GOOGLE_CALENDAR_REFRESH_TOKEN,
+    calendarId: process.env.GOOGLE_CALENDAR_ID || "primary",
+  };
+  if (!config.clientId || !config.clientSecret || !config.refreshToken) {
+    throw new CalendarServiceError(
+      "Google Calendar още не е свързан със Synchron-X.",
+      503,
+      "CALENDAR_NOT_CONFIGURED",
+    );
+  }
+  return config;
+}
+
+async function fetchWithTimeout(url, options = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } catch (error) {
+    if (error?.name === "AbortError") {
+      throw new CalendarServiceError(
+        "Google Calendar не отговори навреме.",
+        504,
+        "CALENDAR_TIMEOUT",
+      );
+    }
+    throw new CalendarServiceError(
+      "Връзката с Google Calendar не е достъпна.",
+      503,
+      "CALENDAR_UNAVAILABLE",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function accessToken() {
+  const config = requiredConfig();
+  const response = await fetchWithTimeout(
+    process.env.GOOGLE_TOKEN_URL || GOOGLE_TOKEN_URL,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: config.clientId,
+        client_secret: config.clientSecret,
+        refresh_token: config.refreshToken,
+        grant_type: "refresh_token",
+      }),
+    },
+  );
+  if (!response.ok) {
+    throw new CalendarServiceError(
+      "Google Calendar отказа достъпа. Нужно е ново свързване.",
+      502,
+      "CALENDAR_AUTH_FAILED",
+    );
+  }
+  const data = await response.json();
+  if (!data.access_token) {
+    throw new CalendarServiceError(
+      "Google Calendar не върна валиден достъп.",
+      502,
+      "CALENDAR_AUTH_FAILED",
+    );
+  }
+  return { token: data.access_token, config };
+}
+
+export async function listUpcomingEvents(options = {}) {
+  const { token, config } = await accessToken();
+  const now = options.timeMin ? new Date(options.timeMin) : new Date();
+  const days = Math.min(Math.max(Number(options.days) || 7, 1), 30);
+  const limit = Math.min(Math.max(Number(options.limit) || 10, 1), 25);
+  if (Number.isNaN(now.getTime())) {
+    throw new CalendarServiceError(
+      "Невалидна начална дата.",
+      400,
+      "INVALID_DATE",
+    );
+  }
+  const end = new Date(now.getTime() + days * 86400000);
+  const query = new URLSearchParams({
+    timeMin: now.toISOString(),
+    timeMax: end.toISOString(),
+    singleEvents: "true",
+    orderBy: "startTime",
+    maxResults: String(limit),
+    timeZone: "Europe/Sofia",
+  });
+  const apiBase = (process.env.GOOGLE_CALENDAR_API || GOOGLE_CALENDAR_API).replace(
+    /\/+$/u,
+    "",
+  );
+  const calendarId = encodeURIComponent(config.calendarId);
+  const response = await fetchWithTimeout(
+    `${apiBase}/calendars/${calendarId}/events?${query}`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!response.ok) {
+    throw new CalendarServiceError(
+      `Google Calendar върна грешка ${response.status}.`,
+      response.status,
+      "CALENDAR_API_ERROR",
+    );
+  }
+  const data = await response.json();
+  return (data.items || []).map((event) => ({
+    id: event.id,
+    title: event.summary || "Събитие без заглавие",
+    start: event.start?.dateTime || event.start?.date || null,
+    end: event.end?.dateTime || event.end?.date || null,
+    location: event.location || null,
+    url: event.htmlLink || null,
+    allDay: Boolean(event.start?.date && !event.start?.dateTime),
+  }));
+}
+
+export function isCalendarReadRequest(message) {
+  const text = typeof message === "string" ? message.toLowerCase() : "";
+  return /(?:календар|събития|ангажимент|срещи|програмата ми)/u.test(text);
+}
+
+export async function answerCalendarReadRequest(message) {
+  if (!isCalendarReadRequest(message)) return null;
+  const events = await listUpcomingEvents({ days: 7, limit: 10 });
+  if (!events.length) {
+    return "Нямаш записани събития в календара за следващите 7 дни.";
+  }
+  const formatter = new Intl.DateTimeFormat("bg-BG", {
+    timeZone: "Europe/Sofia",
+    weekday: "short",
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return [
+    "Предстоящите ти събития са:",
+    ...events.map((event) => {
+      const when = event.allDay
+        ? `${event.start} (цял ден)`
+        : formatter.format(new Date(event.start));
+      return `• ${when} — ${event.title}${event.location ? `, ${event.location}` : ""}`;
+    }),
+  ].join("\n");
+}

--- a/src/services/permissionService.js
+++ b/src/services/permissionService.js
@@ -16,6 +16,16 @@ const POLICY = Object.freeze({
     risk: "medium",
     reason: "Промените в GitHub изискват отделно разрешение.",
   }),
+  "calendar.read": Object.freeze({
+    decision: "allow",
+    risk: "low",
+    reason: "Четенето на собствения календар е разрешено.",
+  }),
+  "calendar.write": Object.freeze({
+    decision: "confirm",
+    risk: "medium",
+    reason: "Промените в календара изискват отделно потвърждение.",
+  }),
   "memory.read": Object.freeze({
     decision: "allow",
     risk: "low",

--- a/tests/calendarService.test.js
+++ b/tests/calendarService.test.js
@@ -1,0 +1,84 @@
+import test, { afterEach, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  answerCalendarReadRequest,
+  isCalendarReadRequest,
+  listUpcomingEvents,
+} from "../src/services/calendarService.js";
+
+const originalFetch = global.fetch;
+const envKeys = [
+  "GOOGLE_CALENDAR_CLIENT_ID",
+  "GOOGLE_CALENDAR_CLIENT_SECRET",
+  "GOOGLE_CALENDAR_REFRESH_TOKEN",
+  "GOOGLE_CALENDAR_API",
+  "GOOGLE_TOKEN_URL",
+];
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+
+beforeEach(() => {
+  process.env.GOOGLE_CALENDAR_CLIENT_ID = "client";
+  process.env.GOOGLE_CALENDAR_CLIENT_SECRET = "secret";
+  process.env.GOOGLE_CALENDAR_REFRESH_TOKEN = "refresh";
+  process.env.GOOGLE_TOKEN_URL = "https://google.test/token";
+  process.env.GOOGLE_CALENDAR_API = "https://google.test/calendar/v3";
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  for (const key of envKeys) {
+    if (originalEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = originalEnv[key];
+  }
+});
+
+test("recognizes calendar questions", () => {
+  assert.equal(isCalendarReadRequest("Какво имам в календара?"), true);
+  assert.equal(isCalendarReadRequest("Как работи GitHub?"), false);
+});
+
+test("reads and normalizes upcoming calendar events", async () => {
+  const calls = [];
+  global.fetch = async (url, options = {}) => {
+    calls.push({ url: String(url), options });
+    if (String(url).endsWith("/token")) {
+      return new Response(JSON.stringify({ access_token: "access" }), { status: 200 });
+    }
+    return new Response(JSON.stringify({
+      items: [{
+        id: "event-1",
+        summary: "Среща",
+        start: { dateTime: "2026-07-27T10:00:00+03:00" },
+        end: { dateTime: "2026-07-27T11:00:00+03:00" },
+        location: "Варна",
+      }],
+    }), { status: 200 });
+  };
+
+  const events = await listUpcomingEvents({
+    timeMin: "2026-07-26T10:00:00+03:00",
+    days: 7,
+  });
+  assert.equal(events.length, 1);
+  assert.equal(events[0].title, "Среща");
+  assert.match(calls[1].url, /calendars\/primary\/events/u);
+  assert.equal(calls[1].options.headers.Authorization, "Bearer access");
+});
+
+test("answers a calendar question naturally", async () => {
+  global.fetch = async (url) => {
+    if (String(url).endsWith("/token")) {
+      return new Response(JSON.stringify({ access_token: "access" }), { status: 200 });
+    }
+    return new Response(JSON.stringify({
+      items: [{
+        id: "event-1",
+        summary: "Преглед",
+        start: { dateTime: "2026-07-27T10:00:00+03:00" },
+        end: { dateTime: "2026-07-27T10:30:00+03:00" },
+      }],
+    }), { status: 200 });
+  };
+  const answer = await answerCalendarReadRequest("Какво имам в календара?");
+  assert.match(answer, /Преглед/u);
+});


### PR DESCRIPTION
## Какво се променя
- добавя защитен read-only Google Calendar модул
- календарни въпроси работят директно в чата
- добавя разрешения и audit запис
- добавя API маршрути и автоматични тестове

## Проверка
- локалният пакет от 56 теста мина успешно
- записване в календара остава блокирано без отделно потвърждение