### PR TITLE
Fix DigitalOcean agent HTTP 400

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -69,7 +69,7 @@ const ASSISTANT_CONTEXT = [
 export function buildAvatarMessages(memories, history, cleanMessage) {
   return [
     {
-      role: "system",
+      // DigitalOcean GenAI Agent accepts user/assistant messages.\n      // A system role makes the upstream endpoint return HTTP 400.\n      role: "user",
       content: [ASSISTANT_CONTEXT, buildMemoryContext(memories)].join("\n\n"),
     },
     ...history.map(({ role, content }) => ({ role, content })),

--- a/tests/avatarContext.test.js
+++ b/tests/avatarContext.test.js
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { buildAvatarMessages } from "../src/routes/chat.js";
 
-test("avatar sends identity rules and verified memory as system context", () => {
+test("avatar sends identity rules and verified memory as agent-compatible context", () => {
   const messages = buildAvatarMessages(
     [
       { fact: "Живея във Варна", scope: "personal" },
@@ -17,7 +17,7 @@ test("avatar sends identity rules and verified memory as system context", () => 
   );
 
   assert.equal(messages.length, 2);
-  assert.equal(messages[0].role, "system");
+  assert.equal(messages[0].role, "user");
   assert.match(messages[0].content, /личният AI асистент и AI аватар/u);
   assert.match(messages[0].content, /Живея във Варна/u);
   assert.match(messages[0].content, /работещ личен AI аватар/u);
@@ -40,7 +40,7 @@ test("avatar preserves conversation order without repeating its instructions", (
 
   assert.deepEqual(
     messages.map(({ role }) => role),
-    ["system", "user", "assistant", "user"],
+    ["user", "user", "assistant", "user"],
   );
   assert.equal(
     messages.filter(({ content }) =>


### PR DESCRIPTION
## Какво е поправено

Връща контекстното съобщение към поддържаната от DigitalOcean GenAI Agent роля `user`.

## Причина

Последната промяна използваше роля `system`. Публичният DigitalOcean agent endpoint я отхвърляше с HTTP 400 за всеки нормален AI въпрос.

## Проверка

Локално минаха всички 53 автоматични теста, включително обновените тестове за аватарния контекст.