### PR TITLE
Restore required DigitalOcean agent role field

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -437,7 +437,6 @@ router.post("/chat", async (req, res) => {
       sendEvent("error", {
         status: agentRes.status,
         message: `AI агентът върна грешка ${agentRes.status}. Опитай отново.`,
-        diagnostic: body.slice(0, 1000),
       });
       return;
     }


### PR DESCRIPTION
Fixes the generated context object so `role: "user"` is a real property, not part of a comment. Removes the temporary upstream diagnostic from the public response. The upstream 422 detail confirmed the missing `messages[0].role` field.