### PR TITLE
Restore DigitalOcean message role property

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -69,7 +69,7 @@ const ASSISTANT_CONTEXT = [
 export function buildAvatarMessages(memories, history, cleanMessage) {
   return [
     {
-      // DigitalOcean GenAI Agent accepts user/assistant messages.\n      // A system role makes the upstream endpoint return HTTP 400.\n      role: "user",
+      role: "user",
       content: [ASSISTANT_CONTEXT, buildMemoryContext(memories)].join("\n\n"),
     },
     ...history.map(({ role, content }) => ({ role, content })),


### PR DESCRIPTION
Restores `role: "user"` as a real object property. The previous explanatory comment contained literal escaped newline characters and accidentally commented out the role field, producing HTTP 422.