### PR TITLE
Send DigitalOcean-compatible single-message payload

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -67,13 +67,28 @@ const ASSISTANT_CONTEXT = [
 ].join("\n");
 
 export function buildAvatarMessages(memories, history, cleanMessage) {
+  const conversationHistory = history.length
+    ? [
+        "[ПРЕДИШЕН РАЗГОВОР]",
+        ...history.map(({ role, content }) =>
+          `${role === "assistant" ? "Synchron-X" : "Радко"}: ${content}`,
+        ),
+        "[КРАЙ НА ПРЕДИШНИЯ РАЗГОВОР]",
+      ].join("\n")
+    : "";
+
   return [
     {
       role: "user",
-      content: [ASSISTANT_CONTEXT, buildMemoryContext(memories)].join("\n\n"),
+      content: [
+        ASSISTANT_CONTEXT,
+        buildMemoryContext(memories),
+        conversationHistory,
+        `[ПОСЛЕДНО СЪОБЩЕНИЕ НА РАДКО]\n${cleanMessage}`,
+      ]
+        .filter(Boolean)
+        .join("\n\n"),
     },
-    ...history.map(({ role, content }) => ({ role, content })),
-    { role: "user", content: cleanMessage },
   ];
 }
 

--- a/tests/avatarContext.test.js
+++ b/tests/avatarContext.test.js
@@ -16,16 +16,13 @@ test("avatar sends identity rules and verified memory as agent-compatible contex
     "Какво да направим днес?",
   );
 
-  assert.equal(messages.length, 2);
+  assert.equal(messages.length, 1);
   assert.equal(messages[0].role, "user");
   assert.match(messages[0].content, /личният AI асистент и AI аватар/u);
   assert.match(messages[0].content, /Живея във Варна/u);
   assert.match(messages[0].content, /работещ личен AI аватар/u);
   assert.match(messages[0].content, /без да обясняваш, че четеш памет/u);
-  assert.deepEqual(messages[1], {
-    role: "user",
-    content: "Какво да направим днес?",
-  });
+  assert.match(messages[0].content, /Какво да направим днес\\?/u);
 });
 
 test("avatar preserves conversation order without repeating its instructions", () => {
@@ -38,15 +35,12 @@ test("avatar preserves conversation order without repeating its instructions", (
     "Следващ въпрос",
   );
 
-  assert.deepEqual(
-    messages.map(({ role }) => role),
-    ["user", "user", "assistant", "user"],
-  );
+  assert.deepEqual(messages.map(({ role }) => role), ["user"]);
   assert.equal(
     messages.filter(({ content }) =>
       content.includes("личният AI асистент и AI аватар"),
     ).length,
     1,
   );
-  assert.equal(messages.at(-1).content, "Следващ въпрос");
+  assert.match(messages[0].content, /Радко: Първи въпрос/u);\n  assert.match(messages[0].content, /Synchron-X: Първи отговор/u);\n  assert.match(messages[0].content, /Следващ въпрос/u);
 });


### PR DESCRIPTION
Combines avatar rules, verified memory, prior conversation transcript, and the latest user message into one valid `user` message. This avoids the DigitalOcean agent deployment rejecting consecutive same-role messages. All 53 local tests pass.