### PR TITLE
Add memory and permission controls

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -5,9 +5,9 @@ const state = {
     lastActions: [],
     chatBusy: false,
     speakingButton: null,
-    pendingImage: null
-    ,
-    conversations: []
+    pendingImage: null,
+    conversations: [],
+    memoryItems: []
 };
 
 const elements = {
@@ -35,7 +35,14 @@ const elements = {
     conversationSearch: document.getElementById('conversationSearch'),
     searchChatsBtn: document.getElementById('searchChatsBtn'),
     mobileMenuBtn: document.getElementById('mobileMenuBtn'),
-    sidebar: document.getElementById('sidebar')
+    sidebar: document.getElementById('sidebar'),
+    memoryBtn: document.getElementById('memoryBtn'),
+    permissionsBtn: document.getElementById('permissionsBtn'),
+    dataDrawer: document.getElementById('dataDrawer'),
+    dataDrawerTitle: document.getElementById('dataDrawerTitle'),
+    dataDrawerBody: document.getElementById('dataDrawerBody'),
+    drawerBackdrop: document.getElementById('drawerBackdrop'),
+    closeDataDrawerBtn: document.getElementById('closeDataDrawerBtn')
 };
 
 function createSessionId() {
@@ -76,6 +83,11 @@ async function init() {
     elements.mobileMenuBtn.addEventListener('click', () => {
         elements.sidebar.classList.toggle('mobile-visible');
     });
+    elements.memoryBtn.addEventListener('click', openMemoryDrawer);
+    elements.permissionsBtn.addEventListener('click', openPermissionsDrawer);
+    elements.closeDataDrawerBtn.addEventListener('click', closeDataDrawer);
+    elements.drawerBackdrop.addEventListener('click', closeDataDrawer);
+    elements.dataDrawerBody.addEventListener('click', handleDataDrawerAction);
 
     checkHealth();
     checkOpenSearch();
@@ -280,6 +292,139 @@ function openStatus() {
 
 function closeStatus() {
     elements.statusPanel.classList.remove('mobile-visible');
+}
+
+function openDataDrawer(title) {
+    elements.dataDrawerTitle.textContent = title;
+    elements.dataDrawer.hidden = false;
+    elements.drawerBackdrop.hidden = false;
+    elements.sidebar.classList.remove('mobile-visible');
+}
+
+function closeDataDrawer() {
+    elements.dataDrawer.hidden = true;
+    elements.drawerBackdrop.hidden = true;
+}
+
+function renderDrawerLoading() {
+    elements.dataDrawerBody.innerHTML =
+        '<div class="drawer-state"><i class="fa-solid fa-circle-notch fa-spin"></i> Зареждане…</div>';
+}
+
+function renderDrawerError(message) {
+    elements.dataDrawerBody.innerHTML =
+        `<div class="drawer-state drawer-error">${escapeHtml(message)}</div>`;
+}
+
+function escapeHtml(value) {
+    const div = document.createElement('div');
+    div.textContent = String(value ?? '');
+    return div.innerHTML;
+}
+
+async function openMemoryDrawer() {
+    openDataDrawer('Памет');
+    renderDrawerLoading();
+    try {
+        const response = await fetch('/memory/profile', { cache: 'no-store' });
+        if (!response.ok) throw new Error('Паметта временно не е достъпна.');
+        const data = await response.json();
+        state.memoryItems = Array.isArray(data.items) ? data.items : [];
+        renderMemoryItems();
+    } catch (error) {
+        renderDrawerError(error.message);
+    }
+}
+
+function renderMemoryItems() {
+    const personal = state.memoryItems.filter(
+        (item) => (item.scope || 'personal') === 'personal'
+    );
+    const project = state.memoryItems.filter((item) => item.scope === 'project');
+    const section = (title, items) => `
+        <section class="drawer-section">
+            <h3>${title} <span>${items.length}</span></h3>
+            ${items.length
+                ? items.map((item) => `
+                    <article class="memory-card">
+                        <p>${escapeHtml(item.fact)}</p>
+                        <button type="button" data-memory-delete="${escapeHtml(item.id)}"
+                            aria-label="Изтрий този спомен" title="Изтрий">
+                            <i class="fa-regular fa-trash-can"></i>
+                        </button>
+                    </article>`).join('')
+                : '<div class="drawer-empty">Няма записани спомени.</div>'}
+        </section>`;
+    elements.dataDrawerBody.innerHTML =
+        section('За теб', personal) + section('За проекта', project);
+}
+
+async function openPermissionsDrawer() {
+    openDataDrawer('Разрешения');
+    renderDrawerLoading();
+    try {
+        const response = await fetch('/permissions', { cache: 'no-store' });
+        if (!response.ok) throw new Error('Разрешенията временно не са достъпни.');
+        const data = await response.json();
+        const labels = { allow: 'Разрешено', confirm: 'Иска потвърждение', deny: 'Забранено' };
+        elements.dataDrawerBody.innerHTML = `
+            <div class="permission-default">
+                Непознатите действия са <strong>забранени по подразбиране</strong>.
+            </div>
+            <section class="drawer-section permission-list">
+                ${(data.permissions || []).map((item) => `
+                    <article class="permission-card">
+                        <div>
+                            <strong>${escapeHtml(item.action)}</strong>
+                            <p>${escapeHtml(item.reason)}</p>
+                        </div>
+                        <span class="permission-badge ${escapeHtml(item.decision)}">
+                            ${labels[item.decision] || escapeHtml(item.decision)}
+                        </span>
+                    </article>`).join('')}
+            </section>`;
+    } catch (error) {
+        renderDrawerError(error.message);
+    }
+}
+
+async function handleDataDrawerAction(event) {
+    const button = event.target.closest('button[data-memory-delete]');
+    if (!button) return;
+    const item = state.memoryItems.find(
+        (candidate) => candidate.id === button.dataset.memoryDelete
+    );
+    if (!item) return;
+
+    const confirmed = window.confirm(
+        `Да изтрия ли този спомен?\n\n${item.fact}`
+    );
+    if (!confirmed) return;
+
+    button.disabled = true;
+    try {
+        const response = await fetch(
+            '/memory/profile/' + encodeURIComponent(item.id),
+            {
+                method: 'DELETE',
+                headers: {
+                    'x-confirm-memory-delete':
+                        'Потвърждавам изтриването на постоянната памет'
+                }
+            }
+        );
+        if (!response.ok) {
+            const data = await response.json().catch(() => null);
+            throw new Error(data?.error || 'Споменът не можа да бъде изтрит.');
+        }
+        state.memoryItems = state.memoryItems.filter(
+            (candidate) => candidate.id !== item.id
+        );
+        renderMemoryItems();
+        logAction('Изтрит е потвърден спомен');
+    } catch (error) {
+        renderDrawerError(error.message);
+    }
 }
 
 function showTypingIndicator() {

--- a/public/appshell.css
+++ b/public/appshell.css
@@ -29,9 +29,25 @@
 .composer-note{padding-top:7px;color:#777;font-size:11px;text-align:center}
 .statusPanel{width:340px;max-width:calc(100vw - 24px);position:fixed;top:12px;right:12px;bottom:12px;z-index:50;display:none;overflow:hidden;border:1px solid #ddd;border-radius:16px;background:#fff;box-shadow:0 20px 60px rgba(0,0,0,.18)}
 .statusPanel.mobile-visible{display:flex}
+.drawer-backdrop{position:fixed;inset:0;z-index:70;background:rgba(0,0,0,.28);backdrop-filter:blur(2px)}
+.data-drawer{width:min(480px,100vw);position:fixed;inset:0 0 0 auto;z-index:71;display:flex;flex-direction:column;background:#fff;box-shadow:-16px 0 50px rgba(0,0,0,.16)}
+.data-drawer[hidden],.drawer-backdrop[hidden]{display:none}
+.data-drawer-header{min-height:78px;padding:18px 20px;display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid #ececec}
+.data-drawer-header h2{margin:2px 0 0;font-size:22px}.data-drawer-kicker{color:#777;font-size:12px}
+.data-drawer-header button,.memory-card button{border:0;background:transparent;cursor:pointer}
+.data-drawer-header button{width:40px;height:40px;border-radius:50%;font-size:18px}.data-drawer-header button:hover{background:#f0f0f0}
+.data-drawer-body{min-height:0;flex:1;padding:18px;overflow-y:auto}.drawer-state{padding:42px 12px;color:#666;text-align:center}.drawer-error{color:#b42318}
+.drawer-section{margin-bottom:24px}.drawer-section h3{margin:0 0 10px;font-size:14px}.drawer-section h3 span{margin-left:5px;color:#777;font-weight:500}
+.memory-card,.permission-card{margin-bottom:8px;padding:13px 14px;display:flex;align-items:flex-start;justify-content:space-between;gap:12px;border:1px solid #e6e6e6;border-radius:12px}
+.memory-card p,.permission-card p{margin:0;color:#333;line-height:1.45}.memory-card button{width:32px;height:32px;flex:0 0 32px;color:#777;border-radius:8px}.memory-card button:hover{color:#c0362c;background:#fff0ef}
+.drawer-empty{padding:18px;color:#777;border:1px dashed #ddd;border-radius:12px;text-align:center}
+.permission-default{margin-bottom:18px;padding:13px 14px;border-radius:12px;background:#f3f6f8;line-height:1.45}.permission-list{display:grid;gap:2px}
+.permission-card{align-items:center}.permission-card strong{font-size:13px}.permission-card p{margin-top:4px;color:#666;font-size:12px}.permission-badge{padding:5px 8px;flex:0 0 auto;border-radius:999px;font-size:11px;font-weight:700}
+.permission-badge.allow{color:#137333;background:#e6f4ea}.permission-badge.confirm{color:#8a4b00;background:#fff4df}.permission-badge.deny{color:#b42318;background:#feeceb}
 @media(max-width:760px){
   .app-shell{display:block}.sidebar{display:none}.sidebar.mobile-visible{width:min(86vw,320px);position:fixed;inset:0 auto 0 0;z-index:60;display:flex;box-shadow:16px 0 50px rgba(0,0,0,.18)}.chatPanel{height:100dvh}.mobile-menu{display:block}
   .chat-toolbar{min-height:56px;padding:7px 12px}.status-indicator{padding:6px}#agentStatusText{display:none}
   #chatMessages{padding:18px 14px 8px}.user-turn{max-width:88%}
   .composer-wrap{padding:8px 10px max(8px,env(safe-area-inset-bottom))}
+  .data-drawer{width:100vw}
 }

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,8 @@
             <nav class="sidebar-nav" aria-label="Основно меню">
                 <button id="searchChatsBtn" type="button"><i class="fa-solid fa-magnifying-glass"></i><span>Търси</span></button>
                 <button type="button"><i class="fa-regular fa-images"></i><span>Снимки и файлове</span></button>
-                <button type="button"><i class="fa-solid fa-brain"></i><span>Памет</span></button>
+                <button id="memoryBtn" type="button"><i class="fa-solid fa-brain"></i><span>Памет</span></button>
+                <button id="permissionsBtn" type="button"><i class="fa-solid fa-shield-halved"></i><span>Разрешения</span></button>
                 <button type="button"><i class="fa-solid fa-puzzle-piece"></i><span>Модули</span></button>
             </nav>
             <div class="sidebar-section">
@@ -102,8 +103,22 @@
                 </ul>
             </div>
         </aside>
+
+        <div class="drawer-backdrop" id="drawerBackdrop" hidden></div>
+        <aside class="data-drawer" id="dataDrawer" aria-label="Памет и разрешения" hidden>
+            <header class="data-drawer-header">
+                <div>
+                    <span class="data-drawer-kicker">Твоите данни</span>
+                    <h2 id="dataDrawerTitle">Памет</h2>
+                </div>
+                <button id="closeDataDrawerBtn" type="button" aria-label="Затвори">
+                    <i class="fa-solid fa-xmark"></i>
+                </button>
+            </header>
+            <div class="data-drawer-body" id="dataDrawerBody"></div>
+        </aside>
     </main>
 
-    <script src="/app.js?v=20260726-appshell"></script>
+    <script src="/app.js?v=20260726-memory-control"></script>
 </body>
 </html>

--- a/tests/dataControlsUi.test.js
+++ b/tests/dataControlsUi.test.js
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("application exposes working memory and permission controls", async () => {
+  const [html, script] = await Promise.all([
+    readFile(new URL("../public/index.html", import.meta.url), "utf8"),
+    readFile(new URL("../public/app.js", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(html, /id="memoryBtn"/u);
+  assert.match(html, /id="permissionsBtn"/u);
+  assert.match(html, /id="dataDrawer"/u);
+  assert.match(script, /fetch\('\/memory\/profile'/u);
+  assert.match(script, /fetch\('\/permissions'/u);
+  assert.match(script, /x-confirm-memory-delete/u);
+});


### PR DESCRIPTION
## Какво се променя
- добавя екран за преглед и контрол на личната и проектната памет
- позволява безопасно единично изтриване с точно потвърждение
- показва разрешенията и забраната по подразбиране
- добавя мобилен панел и автоматичен UI тест

## Проверка
- `npm test` — 60 теста минават успешно