### PR TITLE
Add image analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node --check server.js && node --check src/routes/chat.js && node --check src/routes/githubRouter.js && node --check src/routes/calendarRouter.js && node --check src/routes/memoryRouter.js && node --check src/routes/permissionsRouter.js && node --check src/routes/confirmedActionsRouter.js && node --check src/services/githubService.js && node --check src/services/calendarService.js && node --check src/services/memoryService.js && node --check src/services/permissionService.js && node --check src/services/confirmationService.js && node --check src/services/githubWriteService.js && node --check public/app.js && node --test tests/*.test.js"
+    "test": "node --check server.js && node --check src/routes/chat.js && node --check src/routes/githubRouter.js && node --check src/routes/calendarRouter.js && node --check src/routes/memoryRouter.js && node --check src/routes/permissionsRouter.js && node --check src/routes/confirmedActionsRouter.js && node --check src/services/githubService.js && node --check src/services/calendarService.js && node --check src/services/imageService.js && node --check src/services/memoryService.js && node --check src/services/permissionService.js && node --check src/services/confirmationService.js && node --check src/services/githubWriteService.js && node --check public/app.js && node --test tests/*.test.js"
   },
   "dependencies": {
     "@opensearch-project/opensearch": "^3.5.1",

--- a/public/index.html
+++ b/public/index.html
@@ -119,6 +119,6 @@
         </aside>
     </main>
 
-    <script src="/app.js?v=20260726-voice-input"></script>
+    <script src="/app.js?v=20260726-image-analysis"></script>
 </body>
 </html>

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -27,6 +27,11 @@ import {
   evaluatePermission,
   recordAuditEvent,
 } from "../services/permissionService.js";
+import {
+  analyzeImage,
+  ImageServiceError,
+  validateImageInput,
+} from "../services/imageService.js";
 
 const router = express.Router();
 const HEARTBEAT_INTERVAL_MS = 15000;
@@ -145,12 +150,6 @@ router.post("/chat", async (req, res) => {
   if (!cleanSessionId) {
     return res.status(400).json({ error: "Липсва валидна сесия." });
   }
-  if (image) {
-    return res.status(422).json({
-      error:
-        "Разпознаването на снимки ще бъде добавено по-късно. Текстовият чат работи.",
-    });
-  }
   if (!cleanMessage) {
     return res.status(400).json({ error: "Напиши съобщение." });
   }
@@ -233,6 +232,15 @@ router.post("/chat", async (req, res) => {
 
   const messages = buildAvatarMessages(memories, history, cleanMessage);
 
+  if (image) {
+    try {
+      validateImageInput(image);
+    } catch (error) {
+      const status = error instanceof ImageServiceError ? error.status : 400;
+      return res.status(status).json({ error: error.message });
+    }
+  }
+
   res.status(200);
   res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
   res.setHeader("Cache-Control", "no-cache, no-transform");
@@ -250,6 +258,37 @@ router.post("/chat", async (req, res) => {
       res.write(`: heartbeat ${Date.now()}\n\n`);
     }
   };
+
+  if (image) {
+    try {
+      const fullReply = await analyzeImage({
+        image,
+        prompt: cleanMessage,
+        context: messages[0].content,
+      });
+      await saveConversationTurn(cleanSessionId, cleanMessage, fullReply);
+      await auditAction({
+        action: "image.read",
+        decision: "allow",
+        outcome: "succeeded",
+        resource: image.name || "chat-image",
+        sessionId: cleanSessionId,
+      });
+      sendEvent("token", { token: fullReply });
+      sendEvent("done", { ok: true, tool: "vision" });
+    } catch (error) {
+      console.error(`[Vision] Failure for ${cleanSessionId}:`, error);
+      sendEvent("error", {
+        status: error instanceof ImageServiceError ? error.status : 502,
+        message:
+          error instanceof ImageServiceError
+            ? error.message
+            : "Снимката не можа да бъде разпозната. Опитай отново.",
+      });
+    }
+    res.end();
+    return;
+  }
 
   if (memoryAction) {
     let fullReply;

--- a/src/services/imageService.js
+++ b/src/services/imageService.js
@@ -1,0 +1,141 @@
+const ALLOWED_IMAGE_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+export class ImageServiceError extends Error {
+  constructor(message, status = 502, code = "IMAGE_SERVICE_ERROR") {
+    super(message);
+    this.name = "ImageServiceError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export function validateImageInput(image) {
+  if (!image || typeof image !== "object") {
+    throw new ImageServiceError("Липсва валидна снимка.", 400, "INVALID_IMAGE");
+  }
+
+  const { dataUrl, mimeType } = image;
+  if (
+    typeof dataUrl !== "string" ||
+    typeof mimeType !== "string" ||
+    !ALLOWED_IMAGE_TYPES.has(mimeType)
+  ) {
+    throw new ImageServiceError(
+      "Поддържат се само JPEG, PNG и WebP снимки.",
+      415,
+      "UNSUPPORTED_IMAGE",
+    );
+  }
+
+  const prefix = `data:${mimeType};base64,`;
+  if (!dataUrl.startsWith(prefix)) {
+    throw new ImageServiceError(
+      "Снимката е в невалиден формат.",
+      400,
+      "INVALID_IMAGE",
+    );
+  }
+
+  const base64 = dataUrl.slice(prefix.length);
+  if (!/^[A-Za-z0-9+/]+={0,2}$/u.test(base64)) {
+    throw new ImageServiceError(
+      "Снимката е в невалиден формат.",
+      400,
+      "INVALID_IMAGE",
+    );
+  }
+
+  const byteLength = Buffer.from(base64, "base64").byteLength;
+  if (!byteLength || byteLength > MAX_IMAGE_BYTES) {
+    throw new ImageServiceError(
+      "Снимката трябва да бъде до 5 MB.",
+      413,
+      "IMAGE_TOO_LARGE",
+    );
+  }
+
+  return { dataUrl, mimeType, byteLength };
+}
+
+export async function analyzeImage({
+  image,
+  prompt,
+  context,
+  fetchImpl = fetch,
+  apiKey = process.env.OPENAI_API_KEY,
+  model = process.env.OPENAI_VISION_MODEL || "gpt-4o-mini",
+  signal,
+}) {
+  const validated = validateImageInput(image);
+  if (!apiKey) {
+    throw new ImageServiceError(
+      "Разпознаването на снимки не е конфигурирано.",
+      503,
+      "VISION_NOT_CONFIGURED",
+    );
+  }
+
+  const response = await fetchImpl("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      input: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "input_text",
+              text: [context, prompt].filter(Boolean).join("\n\n"),
+            },
+            {
+              type: "input_image",
+              image_url: validated.dataUrl,
+              detail: "auto",
+            },
+          ],
+        },
+      ],
+    }),
+    signal,
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    console.error(`[Vision] ${response.status}:`, body || "<empty>");
+    throw new ImageServiceError(
+      `Разпознаването на снимката върна грешка ${response.status}.`,
+      502,
+      "VISION_UPSTREAM_ERROR",
+    );
+  }
+
+  const result = await response.json();
+  const text =
+    typeof result.output_text === "string"
+      ? result.output_text.trim()
+      : result.output
+          ?.flatMap((item) => item.content || [])
+          .filter((item) => item.type === "output_text")
+          .map((item) => item.text)
+          .join("")
+          .trim();
+
+  if (!text) {
+    throw new ImageServiceError(
+      "Не получих описание на снимката.",
+      502,
+      "EMPTY_VISION_RESPONSE",
+    );
+  }
+
+  return text;
+}

--- a/tests/imageService.test.js
+++ b/tests/imageService.test.js
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  analyzeImage,
+  ImageServiceError,
+  validateImageInput,
+} from "../src/services/imageService.js";
+
+const tinyPng = {
+  dataUrl: "data:image/png;base64,iVBORw0KGgo=",
+  mimeType: "image/png",
+  name: "test.png",
+};
+
+test("image input validates supported base64 data URLs", () => {
+  const result = validateImageInput(tinyPng);
+  assert.equal(result.mimeType, "image/png");
+  assert.ok(result.byteLength > 0);
+});
+
+test("image input rejects unsupported formats", () => {
+  assert.throws(
+    () =>
+      validateImageInput({
+        dataUrl: "data:image/gif;base64,R0lGODlh",
+        mimeType: "image/gif",
+      }),
+    (error) =>
+      error instanceof ImageServiceError &&
+      error.code === "UNSUPPORTED_IMAGE",
+  );
+});
+
+test("vision uses the Responses API with text, context, and image", async () => {
+  let request;
+  const answer = await analyzeImage({
+    image: tinyPng,
+    prompt: "Какво виждаш?",
+    context: "Отговаряй на български.",
+    apiKey: "test-key",
+    fetchImpl: async (url, options) => {
+      request = { url, options };
+      return new Response(
+        JSON.stringify({ output_text: "Виждам тестова снимка." }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    },
+  });
+
+  assert.equal(answer, "Виждам тестова снимка.");
+  assert.equal(request.url, "https://api.openai.com/v1/responses");
+  assert.equal(request.options.headers.Authorization, "Bearer test-key");
+
+  const body = JSON.parse(request.options.body);
+  assert.equal(body.model, "gpt-4o-mini");
+  assert.equal(body.input[0].content[0].type, "input_text");
+  assert.match(body.input[0].content[0].text, /Отговаряй на български/u);
+  assert.equal(body.input[0].content[1].type, "input_image");
+  assert.equal(body.input[0].content[1].image_url, tinyPng.dataUrl);
+});


### PR DESCRIPTION
## Какво се променя
- Synchron-X приема JPEG, PNG и WebP снимки до 5 MB
- анализира снимката през OpenAI Responses API
- използва личния контекст и отговаря на български
- валидира файла преди изпращане и записва действието в дневника

## Проверка
- `npm test` — 64 теста минават успешно