### PR TITLE
Use DigitalOcean agent for image analysis

### DIFF
--- a/src/services/imageService.js
+++ b/src/services/imageService.js
@@ -67,12 +67,12 @@ export async function analyzeImage({
   prompt,
   context,
   fetchImpl = fetch,
-  apiKey = process.env.OPENAI_API_KEY,
-  model = process.env.OPENAI_VISION_MODEL || "gpt-4o-mini",
+  agentUrl = process.env.AGENT_URL,
+  agentKey = process.env.AGENT_KEY,
   signal,
 }) {
   const validated = validateImageInput(image);
-  if (!apiKey) {
+  if (!agentUrl || !agentKey) {
     throw new ImageServiceError(
       "Разпознаването на снимки не е конфигурирано.",
       503,
@@ -80,33 +80,38 @@ export async function analyzeImage({
     );
   }
 
-  const response = await fetchImpl("https://api.openai.com/v1/responses", {
+  const response = await fetchImpl(
+    `${agentUrl.replace(/\/+$/u, "")}/api/v1/chat/completions`,
+    {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: `Bearer ${agentKey}`,
     },
     body: JSON.stringify({
-      model,
-      input: [
+      messages: [
         {
           role: "user",
           content: [
             {
-              type: "input_text",
+              type: "text",
               text: [context, prompt].filter(Boolean).join("\n\n"),
             },
             {
-              type: "input_image",
-              image_url: validated.dataUrl,
-              detail: "auto",
+              type: "image_url",
+              image_url: {
+                url: validated.dataUrl,
+                detail: "auto",
+              },
             },
           ],
         },
       ],
+      stream: false,
     }),
     signal,
-  });
+    },
+  );
 
   if (!response.ok) {
     const body = await response.text();
@@ -119,15 +124,16 @@ export async function analyzeImage({
   }
 
   const result = await response.json();
-  const text =
-    typeof result.output_text === "string"
-      ? result.output_text.trim()
-      : result.output
-          ?.flatMap((item) => item.content || [])
-          .filter((item) => item.type === "output_text")
-          .map((item) => item.text)
-          .join("")
-          .trim();
+  const content = result.choices?.[0]?.message?.content;
+  const text = Array.isArray(content)
+    ? content
+        .filter((item) => item?.type === "text")
+        .map((item) => item.text || "")
+        .join("")
+        .trim()
+    : typeof content === "string"
+      ? content.trim()
+      : "";
 
   if (!text) {
     throw new ImageServiceError(

--- a/tests/imageService.test.js
+++ b/tests/imageService.test.js
@@ -32,30 +32,38 @@ test("image input rejects unsupported formats", () => {
   );
 });
 
-test("vision uses the Responses API with text, context, and image", async () => {
+test("vision uses the existing DigitalOcean agent with text, context, and image", async () => {
   let request;
   const answer = await analyzeImage({
     image: tinyPng,
     prompt: "Какво виждаш?",
     context: "Отговаряй на български.",
-    apiKey: "test-key",
+    agentUrl: "https://example.agents.do-ai.run/",
+    agentKey: "test-key",
     fetchImpl: async (url, options) => {
       request = { url, options };
       return new Response(
-        JSON.stringify({ output_text: "Виждам тестова снимка." }),
+        JSON.stringify({
+          choices: [
+            { message: { content: "Виждам тестова снимка." } },
+          ],
+        }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
     },
   });
 
   assert.equal(answer, "Виждам тестова снимка.");
-  assert.equal(request.url, "https://api.openai.com/v1/responses");
+  assert.equal(
+    request.url,
+    "https://example.agents.do-ai.run/api/v1/chat/completions",
+  );
   assert.equal(request.options.headers.Authorization, "Bearer test-key");
 
   const body = JSON.parse(request.options.body);
-  assert.equal(body.model, "gpt-4o-mini");
-  assert.equal(body.input[0].content[0].type, "input_text");
-  assert.match(body.input[0].content[0].text, /Отговаряй на български/u);
-  assert.equal(body.input[0].content[1].type, "input_image");
-  assert.equal(body.input[0].content[1].image_url, tinyPng.dataUrl);
+  assert.equal(body.stream, false);
+  assert.equal(body.messages[0].content[0].type, "text");
+  assert.match(body.messages[0].content[0].text, /Отговаряй на български/u);
+  assert.equal(body.messages[0].content[1].type, "image_url");
+  assert.equal(body.messages[0].content[1].image_url.url, tinyPng.dataUrl);
 });


### PR DESCRIPTION
Премахва нуждата от отделен `OPENAI_API_KEY` за снимки.

Снимките вече се изпращат към съществуващия DigitalOcean AI Agent чрез наличните `AGENT_URL` и `AGENT_KEY`. Добавен е тест за точния мултимодален формат.

Проверка: 64 теста минават локално.