### PR TITLE
Use DigitalOcean inference for image analysis

### DIFF
--- a/src/services/imageService.js
+++ b/src/services/imageService.js
@@ -67,12 +67,15 @@ export async function analyzeImage({
   prompt,
   context,
   fetchImpl = fetch,
-  agentUrl = process.env.AGENT_URL,
-  agentKey = process.env.AGENT_KEY,
+  inferenceUrl =
+    process.env.DIGITALOCEAN_INFERENCE_URL ||
+    "https://inference.do-ai.run/v1/chat/completions",
+  modelAccessKey = process.env.MODEL_ACCESS_KEY,
+  model = process.env.DIGITALOCEAN_VISION_MODEL || "openai-gpt-4o-mini",
   signal,
 }) {
   const validated = validateImageInput(image);
-  if (!agentUrl || !agentKey) {
+  if (!modelAccessKey) {
     throw new ImageServiceError(
       "Разпознаването на снимки не е конфигурирано.",
       503,
@@ -80,15 +83,14 @@ export async function analyzeImage({
     );
   }
 
-  const response = await fetchImpl(
-    `${agentUrl.replace(/\/+$/u, "")}/api/v1/chat/completions`,
-    {
+  const response = await fetchImpl(inferenceUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${agentKey}`,
+      Authorization: `Bearer ${modelAccessKey}`,
     },
     body: JSON.stringify({
+      model,
       messages: [
         {
           role: "user",
@@ -110,8 +112,7 @@ export async function analyzeImage({
       stream: false,
     }),
     signal,
-    },
-  );
+  });
 
   if (!response.ok) {
     const body = await response.text();

--- a/tests/imageService.test.js
+++ b/tests/imageService.test.js
@@ -32,14 +32,13 @@ test("image input rejects unsupported formats", () => {
   );
 });
 
-test("vision uses the existing DigitalOcean agent with text, context, and image", async () => {
+test("vision uses DigitalOcean inference with text, context, and image", async () => {
   let request;
   const answer = await analyzeImage({
     image: tinyPng,
     prompt: "Какво виждаш?",
     context: "Отговаряй на български.",
-    agentUrl: "https://example.agents.do-ai.run/",
-    agentKey: "test-key",
+    modelAccessKey: "test-key",
     fetchImpl: async (url, options) => {
       request = { url, options };
       return new Response(
@@ -56,11 +55,12 @@ test("vision uses the existing DigitalOcean agent with text, context, and image"
   assert.equal(answer, "Виждам тестова снимка.");
   assert.equal(
     request.url,
-    "https://example.agents.do-ai.run/api/v1/chat/completions",
+    "https://inference.do-ai.run/v1/chat/completions",
   );
   assert.equal(request.options.headers.Authorization, "Bearer test-key");
 
   const body = JSON.parse(request.options.body);
+  assert.equal(body.model, "openai-gpt-4o-mini");
   assert.equal(body.stream, false);
   assert.equal(body.messages[0].content[0].type, "text");
   assert.match(body.messages[0].content[0].text, /Отговаряй на български/u);


### PR DESCRIPTION
DigitalOcean Agent endpoint приема само текст и върна 422 при реалния тест със снимка. Тази промяна насочва снимките към официалния DigitalOcean Inference endpoint и използва `MODEL_ACCESS_KEY`, без OpenAI ключ.

Проверка: 64 теста минават локално.