### PR TITLE
Използване на OpenAI ключа за снимки

### DIFF
--- a/src/services/imageService.js
+++ b/src/services/imageService.js
@@ -68,10 +68,9 @@ export async function analyzeImage({
   context,
   fetchImpl = fetch,
   inferenceUrl =
-    process.env.DIGITALOCEAN_INFERENCE_URL ||
-    "https://inference.do-ai.run/v1/chat/completions",
-  modelAccessKey = process.env.MODEL_ACCESS_KEY,
-  model = process.env.DIGITALOCEAN_VISION_MODEL || "openai-gpt-4o-mini",
+    process.env.OPENAI_API_URL || "https://api.openai.com/v1/chat/completions",
+  modelAccessKey = process.env.OPENAI_API_KEY,
+  model = process.env.OPENAI_VISION_MODEL || "gpt-4o-mini",
   signal,
 }) {
   const validated = validateImageInput(image);

--- a/tests/imageService.test.js
+++ b/tests/imageService.test.js
@@ -32,7 +32,7 @@ test("image input rejects unsupported formats", () => {
   );
 });
 
-test("vision uses DigitalOcean inference with text, context, and image", async () => {
+test("vision uses OpenAI with text, context, and image", async () => {
   let request;
   const answer = await analyzeImage({
     image: tinyPng,
@@ -55,12 +55,12 @@ test("vision uses DigitalOcean inference with text, context, and image", async (
   assert.equal(answer, "Виждам тестова снимка.");
   assert.equal(
     request.url,
-    "https://inference.do-ai.run/v1/chat/completions",
+    "https://api.openai.com/v1/chat/completions",
   );
   assert.equal(request.options.headers.Authorization, "Bearer test-key");
 
   const body = JSON.parse(request.options.body);
-  assert.equal(body.model, "openai-gpt-4o-mini");
+  assert.equal(body.model, "gpt-4o-mini");
   assert.equal(body.stream, false);
   assert.equal(body.messages[0].content[0].type, "text");
   assert.match(body.messages[0].content[0].text, /Отговаряй на български/u);


### PR DESCRIPTION
## Какво е променено

- Функцията за анализ на снимки вече използва `OPENAI_API_KEY`.
- Заявките се изпращат към официалния OpenAI Chat Completions адрес.
- Моделът по подразбиране е `gpt-4o-mini` и може да се зададе чрез `OPENAI_VISION_MODEL`.
- Тестът е обновен за новия адрес и модел.

## Причина

DigitalOcean вече има защитено добавен `OPENAI_API_KEY`, но кодът очакваше `MODEL_ACCESS_KEY` и DigitalOcean Inference адрес.

## Проверка

Промяната е изолирана в отделен клон. Следва автоматичните проверки да потвърдят целия тестов пакет.