### PR TITLE
Поправка на изтриването на памет

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -508,7 +508,7 @@ async function handleDataDrawerAction(event) {
                 method: 'DELETE',
                 headers: {
                     'x-confirm-memory-delete':
-                        'Потвърждавам изтриването на постоянната памет'
+                        'confirm-delete-profile-memory'
                 }
             }
         );

--- a/src/routes/memoryRouter.js
+++ b/src/routes/memoryRouter.js
@@ -12,7 +12,7 @@ import { recordAuditEvent } from "../services/permissionService.js";
 const router = express.Router();
 
 export const CLEAR_MEMORY_CONFIRMATION =
-  "Потвърждавам изтриването на постоянната памет";
+  "confirm-delete-profile-memory";
 
 export function hasClearMemoryConfirmation(req) {
   return req.get("x-confirm-memory-delete") === CLEAR_MEMORY_CONFIRMATION;

--- a/tests/memoryRouter.test.js
+++ b/tests/memoryRouter.test.js
@@ -28,3 +28,7 @@ test("memory API deletion requires exact explicit confirmation", () => {
     true,
   );
 });
+
+test("memory deletion confirmation is safe for an HTTP header", () => {
+  assert.match(CLEAR_MEMORY_CONFIRMATION, /^[\x20-\x7E]+$/u);
+});


### PR DESCRIPTION
## Какво е поправено
- заменена е кирилицата в защитния HTTP header с безопасна ASCII стойност
- клиентът и сървърът използват една и съща точна стойност
- добавен е тест, който не допуска отново невалидни символи в header-а

## Причина
Мобилният браузър прекъсваше заявката още преди изпращане и показваше `Type error`, защото стойността на HTTP header-а съдържаше кирилица.

## Проверка
- 65 теста минават успешно
- синтактичните проверки минават успешно