### PR TITLE
Свързване на чата с Capability Engine

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -779,8 +779,16 @@ async function sendMessage() {
                     throw new Error(
                         parsed.data?.message || 'AI агентът върна грешка.'
                     );
+                } else if (
+                    parsed.event === 'activity' &&
+                    typeof parsed.data?.message === 'string'
+                ) {
+                    logAction(parsed.data.message);
                 } else if (parsed.event === 'done') {
                     completed = true;
+                    if (typeof parsed.data?.tool === 'string') {
+                        logAction('Използван инструмент: ' + parsed.data.tool);
+                    }
                 }
             }
         };

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -13,20 +13,13 @@ import {
   saveConversationTurn,
   saveProfileMemory,
 } from "../services/memoryService.js";
+import { GitHubServiceError, isGitHubReadRequest } from "../services/githubService.js";
+import { CalendarServiceError, isCalendarReadRequest } from "../services/calendarService.js";
+import { recordAuditEvent } from "../services/permissionService.js";
 import {
-  answerGitHubReadRequest,
-  GitHubServiceError,
-  isGitHubReadRequest,
-} from "../services/githubService.js";
-import {
-  answerCalendarReadRequest,
-  CalendarServiceError,
-  isCalendarReadRequest,
-} from "../services/calendarService.js";
-import {
-  evaluatePermission,
-  recordAuditEvent,
-} from "../services/permissionService.js";
+  CapabilityError,
+  executeCapability,
+} from "../tools/capabilityEngine.js";
 import {
   analyzeImage,
   ImageServiceError,
@@ -377,76 +370,71 @@ router.post("/chat", async (req, res) => {
 
   try {
     const wantsCalendarRead = isCalendarReadRequest(cleanMessage);
-    const calendarPermission = wantsCalendarRead
-      ? evaluatePermission("calendar.read")
-      : null;
-    if (calendarPermission && calendarPermission.decision !== "allow") {
-      throw new CalendarServiceError(
-        calendarPermission.reason,
-        403,
-        "PERMISSION_DENIED",
-      );
-    }
-    const calendarReply = wantsCalendarRead
-      ? await answerCalendarReadRequest(cleanMessage)
-      : null;
-    if (calendarReply) {
-      await saveConversationTurn(cleanSessionId, cleanMessage, calendarReply);
+    if (wantsCalendarRead) {
+      sendEvent("activity", {
+        message: "Проверявам календара чрез Capability Engine",
+      });
+      const result = await executeCapability("calendar.read", {
+        message: cleanMessage,
+      });
+      await saveConversationTurn(cleanSessionId, cleanMessage, result.output);
       await auditAction({
         action: "calendar.read",
-        decision: calendarPermission.decision,
+        decision: result.permission.decision,
         outcome: "succeeded",
-        resource: "chat-tool",
+        resource: result.tool.id,
         sessionId: cleanSessionId,
       });
-      sendEvent("token", { token: calendarReply });
-      sendEvent("done", { ok: true, tool: "calendar", mode: "read-only" });
+      sendEvent("token", { token: result.output });
+      sendEvent("done", {
+        ok: true,
+        capability: result.capability,
+        tool: result.tool.id,
+        mode: "read-only",
+      });
       res.end();
       return;
     }
 
     const wantsGitHubRead = isGitHubReadRequest(cleanMessage);
-    const githubPermission = wantsGitHubRead
-      ? evaluatePermission("github.read")
-      : null;
-    if (githubPermission && githubPermission.decision !== "allow") {
-      await auditAction({
-        action: "github.read",
-        decision: githubPermission.decision,
-        outcome: "blocked",
-        resource: "chat-tool",
-        sessionId: cleanSessionId,
+    if (wantsGitHubRead) {
+      sendEvent("activity", {
+        message: "Проверявам GitHub чрез Capability Engine",
       });
-      throw new GitHubServiceError(
-        githubPermission.reason,
-        403,
-        "PERMISSION_DENIED",
-      );
-    }
-
-    const githubReply = wantsGitHubRead
-      ? await answerGitHubReadRequest(cleanMessage)
-      : null;
-    if (githubReply) {
-      await saveConversationTurn(cleanSessionId, cleanMessage, githubReply);
+      const result = await executeCapability("code.read", {
+        message: cleanMessage,
+      });
+      await saveConversationTurn(cleanSessionId, cleanMessage, result.output);
       await auditAction({
         action: "github.read",
-        decision: githubPermission.decision,
+        decision: result.permission.decision,
         outcome: "succeeded",
-        resource: "chat-tool",
+        resource: result.tool.id,
         sessionId: cleanSessionId,
       });
-      sendEvent("token", { token: githubReply });
-      sendEvent("done", { ok: true, tool: "github", mode: "read-only" });
+      sendEvent("token", { token: result.output });
+      sendEvent("done", {
+        ok: true,
+        capability: result.capability,
+        tool: result.tool.id,
+        mode: "read-only",
+      });
       res.end();
       return;
     }
   } catch (error) {
-    const message =
-      error instanceof GitHubServiceError
+    const isKnownToolError =
+      error instanceof GitHubServiceError ||
+      error instanceof CalendarServiceError ||
+      error instanceof CapabilityError;
+    sendEvent("error", {
+      message: isKnownToolError
         ? error.message
-        : "GitHub модулът временно не е достъпен.";
-    sendEvent("error", { message, tool: "github" });
+        : "Избраният инструмент временно не е достъпен.",
+      capability: isCalendarReadRequest(cleanMessage)
+        ? "calendar.read"
+        : "code.read",
+    });
     res.end();
     return;
   }

--- a/src/tools/capabilityEngine.js
+++ b/src/tools/capabilityEngine.js
@@ -1,4 +1,6 @@
 import { evaluatePermission } from "../services/permissionService.js";
+import { answerCalendarReadRequest } from "../services/calendarService.js";
+import { answerGitHubReadRequest } from "../services/githubService.js";
 import {
   findToolsByCapability,
   registerCoreTools,
@@ -70,4 +72,33 @@ export function resolveCapability(capability, options = {}) {
     requiresConfirmation:
       tool.requiresConfirmation || permission.decision === "confirm",
   });
+}
+
+const executors = Object.freeze({
+  "google-calendar-read": async ({ message }) =>
+    answerCalendarReadRequest(message),
+  "github-read": async ({ message }) => answerGitHubReadRequest(message),
+});
+
+export async function executeCapability(capability, input = {}, options = {}) {
+  const resolved = resolveCapability(capability, options);
+  if (resolved.requiresConfirmation && options.confirmed !== true) {
+    throw new CapabilityError(
+      `Способността "${capability}" изисква потвърждение.`,
+      "CAPABILITY_CONFIRMATION_REQUIRED",
+      409,
+    );
+  }
+
+  const executor = executors[resolved.tool.id];
+  if (!executor) {
+    throw new CapabilityError(
+      `Инструментът "${resolved.tool.name}" още няма изпълнима връзка.`,
+      "CAPABILITY_NOT_EXECUTABLE",
+      503,
+    );
+  }
+
+  const output = await executor(input);
+  return Object.freeze({ ...resolved, output });
 }

--- a/tests/capabilityEngine.test.js
+++ b/tests/capabilityEngine.test.js
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   CapabilityError,
+  executeCapability,
   resolveCapability,
 } from "../src/tools/capabilityEngine.js";
 import { resetToolRegistryForTests } from "../src/tools/toolRegistry.js";
@@ -27,5 +28,46 @@ test("блокира липсваща способност по подразби
     (error) =>
       error instanceof CapabilityError &&
       error.code === "CAPABILITY_UNAVAILABLE",
+  );
+});
+
+test("изпълнява GitHub четене чрез избрания инструмент", async () => {
+  const originalFetch = global.fetch;
+  const originalApiUrl = process.env.GITHUB_API_URL;
+  process.env.GITHUB_API_URL = "https://github.test";
+  global.fetch = async () =>
+    new Response(
+      JSON.stringify([
+        {
+          sha: "fa21ebb1234567890",
+          commit: {
+            message: "Capability Core",
+            author: { name: "Codex", date: "2026-07-26T00:00:00Z" },
+          },
+          html_url: "https://github.test/commit/fa21ebb",
+        },
+      ]),
+      { status: 200 },
+    );
+
+  try {
+    const result = await executeCapability("code.read", {
+      message: "Покажи последните commit-и в GitHub.",
+    });
+    assert.equal(result.tool.id, "github-read");
+    assert.match(result.output, /fa21ebb/u);
+  } finally {
+    global.fetch = originalFetch;
+    if (originalApiUrl === undefined) delete process.env.GITHUB_API_URL;
+    else process.env.GITHUB_API_URL = originalApiUrl;
+  }
+});
+
+test("не изпълнява способност за потвърждение без разрешение", async () => {
+  await assert.rejects(
+    () => executeCapability("memory.delete"),
+    (error) =>
+      error instanceof CapabilityError &&
+      error.code === "CAPABILITY_CONFIRMATION_REQUIRED",
   );
 });


### PR DESCRIPTION
## Какво се променя

- Чатът заявява способности вместо да избира директно GitHub и Calendar.
- Capability Engine избира и изпълнява правилния инструмент.
- Интерфейсът показва използвания инструмент в дневника.
- Потвържденията за опасни действия остават задължителни.

## Какво не се променя

- AI разговорът
- постоянната памет
- OpenSearch
- работещите маршрути извън тази връзка

## Проверка

- 84 от 84 теста минават успешно.