### PR TITLE
Fix complex capability subtask execution

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -108,13 +108,51 @@ export function isOverviewQuestion(message, subject) {
   ).test(normalizedQuestion);
 }
 
+function normalizeSubtaskText(text) {
+  return text
+    .replace(/^\s*(?:[-*•]\s*)?/u, "")
+    .replace(/^\s*\d+[\).:-]\s*/u, "")
+    .trim();
+}
+
+export function splitCapabilitySubtasks(message) {
+  if (typeof message !== "string") return [];
+  const normalized = message.replace(/\r\n/g, "\n").trim();
+  if (!normalized) return [];
+
+  const byLine = normalized
+    .split(/\n+/u)
+    .flatMap((line) => line.split(/;/u))
+    .flatMap((part) => part.split(/(?<=[.!?])\s+/u))
+    .flatMap((part) =>
+      part.split(
+        /,\s+(?=(?:провери|покажи|изброй|дай|върни|виж|check|show|list)\b)/iu,
+      ),
+    )
+    .map(normalizeSubtaskText)
+    .filter(Boolean);
+
+  return byLine.length ? byLine : [normalized];
+}
+
 export function detectCapabilityRequests(message) {
   const requests = [];
-  if (isCalendarReadRequest(message)) {
-    requests.push({ capability: "calendar.read", action: "calendar.read" });
-  }
-  if (isGitHubReadRequest(message)) {
-    requests.push({ capability: "code.read", action: "github.read" });
+  const subtasks = splitCapabilitySubtasks(message);
+  for (const subtask of subtasks) {
+    if (isCalendarReadRequest(subtask)) {
+      requests.push({
+        capability: "calendar.read",
+        action: "calendar.read",
+        message: subtask,
+      });
+    }
+    if (isGitHubReadRequest(subtask)) {
+      requests.push({
+        capability: "code.read",
+        action: "github.read",
+        message: subtask,
+      });
+    }
   }
   return requests;
 }
@@ -139,15 +177,28 @@ export function extractConfirmedMemoryWriteCommands(message) {
   return extractPersistentMemoryCommands(payload);
 }
 
-export async function executeDetectedCapabilities(message, executeFn) {
-  const requests = detectCapabilityRequests(message);
+export async function executeDetectedCapabilities(
+  message,
+  executeFn,
+  requests = detectCapabilityRequests(message),
+) {
   const results = [];
-  for (const request of requests) {
+  for (const [index, request] of requests.entries()) {
+    const requestMessage = request.message || message;
+    console.info(
+      `[CapabilityExecution] Start #${index + 1}/${requests.length}: ${request.capability}`,
+    );
     try {
-      const result = await executeFn(request.capability, { message });
+      const result = await executeFn(request.capability, { message: requestMessage });
       results.push({ status: "fulfilled", request, result });
+      console.info(
+        `[CapabilityExecution] Success #${index + 1}/${requests.length}: ${request.capability}`,
+      );
     } catch (error) {
       results.push({ status: "rejected", request, error });
+      console.info(
+        `[CapabilityExecution] Failure #${index + 1}/${requests.length}: ${request.capability}`,
+      );
     }
   }
   return results;
@@ -173,6 +224,55 @@ function formatCapabilityFailureMessage(error) {
     return "Инструментът за тази заявка временно не е достъпен.";
   }
   return "Избраният инструмент временно не е достъпен.";
+}
+
+export function buildMemoryReply(memoryAction) {
+  if (!memoryAction) return null;
+  if (memoryAction.type === "write-confirmation-required") {
+    return [
+      "Искаш запис в постоянната памет.",
+      `За потвърждение изпрати точно: ${MEMORY_WRITE_CONFIRM_PREFIX} <съдържание>`,
+    ].join("\n");
+  }
+  if (memoryAction.type === "clear-confirmation-required") {
+    return "Това ще изтрие цялата постоянна памет. За да потвърдиш, напиши точно: „Потвърждавам изтриването на цялата постоянна памет“.";
+  }
+  if (memoryAction.type === "cleared") {
+    return "Изчистих постоянната памет.";
+  }
+  if (memoryAction.type === "forgot") {
+    return memoryAction.deleted
+      ? `Забравих: ${memoryAction.fact}.`
+      : "Не намерих такъв запис в постоянната памет.";
+  }
+  if (memoryAction.type === "batch") {
+    const updatedCount = memoryAction.items.filter((item) => item.replaced).length;
+    const updatedSuffix = updatedCount ? `, от които ${updatedCount} обновени` : "";
+    return [
+      `Записах ${memoryAction.items.length} факта в постоянната памет${updatedSuffix}:`,
+      ...memoryAction.items.map(({ fact }) => `• ${fact}`),
+    ].join("\n");
+  }
+  if (memoryAction.type === "updated") {
+    return `Поправих постоянната памет: ${memoryAction.fact}.`;
+  }
+  return `Запомних: ${memoryAction.fact}.`;
+}
+
+export function buildCapabilityReplies(capabilityResults) {
+  const replies = [];
+  for (const capabilityResult of capabilityResults) {
+    if (capabilityResult.status === "fulfilled") {
+      replies.push(capabilityResult.result.output);
+      continue;
+    }
+    const { request, error } = capabilityResult;
+    const message = formatCapabilityFailureMessage(error);
+    replies.push(
+      `Не успях да изпълня заявката за ${capabilityLabel(request.capability)}: ${message}`,
+    );
+  }
+  return replies;
 }
 
 function extractTokenFromAgentEvent(rawEvent) {
@@ -366,39 +466,8 @@ router.post("/chat", async (req, res) => {
     return;
   }
 
-  let memoryReply = null;
+  const memoryReply = buildMemoryReply(memoryAction);
   if (memoryAction) {
-    if (memoryAction.type === "write-confirmation-required") {
-      memoryReply = [
-        "Искаш запис в постоянната памет.",
-        `За потвърждение изпрати точно: ${MEMORY_WRITE_CONFIRM_PREFIX} <съдържание>`,
-      ].join("\n");
-    } else if (memoryAction.type === "clear-confirmation-required") {
-      memoryReply =
-        "Това ще изтрие цялата постоянна памет. За да потвърдиш, напиши точно: „Потвърждавам изтриването на цялата постоянна памет“.";
-    } else if (memoryAction.type === "cleared") {
-      memoryReply = "Изчистих постоянната памет.";
-    } else if (memoryAction.type === "forgot") {
-      memoryReply = memoryAction.deleted
-        ? `Забравих: ${memoryAction.fact}.`
-        : "Не намерих такъв запис в постоянната памет.";
-    } else if (memoryAction.type === "batch") {
-      const updatedCount = memoryAction.items.filter(
-        (item) => item.replaced,
-      ).length;
-      const updatedSuffix = updatedCount
-        ? `, от които ${updatedCount} обновени`
-        : "";
-      memoryReply = [
-        `Записах ${memoryAction.items.length} факта в постоянната памет${updatedSuffix}:`,
-        ...memoryAction.items.map(({ fact }) => `• ${fact}`),
-      ].join("\n");
-    } else if (memoryAction.type === "updated") {
-      memoryReply = `Поправих постоянната памет: ${memoryAction.fact}.`;
-    } else {
-      memoryReply = `Запомних: ${memoryAction.fact}.`;
-    }
-
     const isDeleteAction =
       memoryAction.type === "cleared" ||
       memoryAction.type === "forgot" ||
@@ -452,20 +521,30 @@ router.post("/chat", async (req, res) => {
     await saveConversationTurn(cleanSessionId, cleanMessage, fullReply);
     sendEvent("token", { token: fullReply });
     sendEvent("done", { ok: true, memoryCount: scopedMemories.length });
+    console.info(`[Chat] Response completed (memory overview) for ${cleanSessionId}`);
     res.end();
     return;
   }
 
-  const capabilityReplies = [];
+  const detectedCapabilityRequests = detectCapabilityRequests(cleanMessage);
+  console.info(
+    `[Chat] Detected ${detectedCapabilityRequests.length} capability subtasks for ${cleanSessionId}: ${detectedCapabilityRequests
+      .map((request, index) => `#${index + 1}:${request.capability}`)
+      .join(", ")}`,
+  );
   const capabilityResults = await executeDetectedCapabilities(
     cleanMessage,
     executeCapability,
+    detectedCapabilityRequests,
   );
+  const capabilityReplies = buildCapabilityReplies(capabilityResults);
   if (capabilityResults.length) {
-    for (const capabilityResult of capabilityResults) {
+    for (const [index, capabilityResult] of capabilityResults.entries()) {
       if (capabilityResult.status === "fulfilled") {
         const { request, result } = capabilityResult;
-        capabilityReplies.push(result.output);
+        console.info(
+          `[Chat] Subtask result #${index + 1}/${capabilityResults.length}: ${request.capability} -> success`,
+        );
         await auditAction({
           action: request.action,
           decision: result.permission.decision,
@@ -475,9 +554,8 @@ router.post("/chat", async (req, res) => {
         });
       } else {
         const { request, error } = capabilityResult;
-        const message = formatCapabilityFailureMessage(error);
-        capabilityReplies.push(
-          `Не успях да изпълня заявката за ${capabilityLabel(request.capability)}: ${message}`,
+        console.info(
+          `[Chat] Subtask result #${index + 1}/${capabilityResults.length}: ${request.capability} -> failed`,
         );
         await auditAction({
           action: request.action,
@@ -501,6 +579,9 @@ router.post("/chat", async (req, res) => {
       capabilities: capabilityResults.map(({ request }) => request.capability),
       mode: capabilityResults.length ? "read-only" : undefined,
     });
+    console.info(
+      `[Chat] Response completed (memory/capabilities shortcut) for ${cleanSessionId}`,
+    );
     res.end();
     return;
   }
@@ -598,6 +679,7 @@ router.post("/chat", async (req, res) => {
       autoMemoryCount,
     });
     console.log(`[Agent] Stream success for ${cleanSessionId}`);
+    console.info(`[Chat] Response completed (agent stream) for ${cleanSessionId}`);
   } catch (error) {
     if (abortController.signal.aborted && !timedOut) return;
     console.error(`[Agent] Failure for ${cleanSessionId}:`, error);

--- a/tests/chatCapabilityExecution.test.js
+++ b/tests/chatCapabilityExecution.test.js
@@ -2,18 +2,35 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  buildCapabilityReplies,
+  buildMemoryReply,
   detectCapabilityRequests,
   executeDetectedCapabilities,
   extractConfirmedMemoryWriteCommands,
+  splitCapabilitySubtasks,
 } from "../src/routes/chat.js";
 
 test("detects multiple capability subtasks in one message", () => {
   const requests = detectCapabilityRequests(
     "Провери календара и GitHub commit-ите от днес.",
   );
-  assert.deepEqual(requests, [
+  assert.deepEqual(
+    requests.map(({ capability, action }) => ({ capability, action })),
+    [
     { capability: "calendar.read", action: "calendar.read" },
     { capability: "code.read", action: "github.read" },
+    ],
+  );
+});
+
+test("splits a complex command into independent subtasks", () => {
+  const subtasks = splitCapabilitySubtasks(
+    "1) Провери GitHub последните commit-и; 2) Провери GitHub подробностите за последния commit.\n3) Провери GitHub кои файлове са пипани.",
+  );
+  assert.deepEqual(subtasks, [
+    "Провери GitHub последните commit-и",
+    "Провери GitHub подробностите за последния commit.",
+    "Провери GitHub кои файлове са пипани.",
   ]);
 });
 
@@ -40,6 +57,58 @@ test("executes all detected subtasks sequentially even after a failure", async (
   assert.equal(results[0].error.message, "calendar temporary failure");
   assert.equal(results[1].status, "fulfilled");
   assert.equal(results[1].result.output, "GitHub result");
+});
+
+test("complex 5-check command runs all checks, merges results, and asks memory-write confirmation", async () => {
+  const message =
+    [
+      "Провери GitHub последните commit-и;",
+      "Провери GitHub подробности за последния commit;",
+      "Провери GitHub променените файлове;",
+      "Провери GitHub историята за днес;",
+      "Провери GitHub последната реална промяна;",
+      "Запомни, че трябва да пуснем деплой след merge.",
+    ].join(" ");
+
+  const calls = [];
+  const results = await executeDetectedCapabilities(message, async (capability, options) => {
+    calls.push({ capability, message: options.message });
+    return {
+      output: `Result ${calls.length}: ${options.message}`,
+      permission: { decision: "allow" },
+      tool: { id: "github-read" },
+    };
+  });
+
+  assert.equal(calls.length, 5);
+  assert.deepEqual(
+    calls.map((call) => call.capability),
+    ["code.read", "code.read", "code.read", "code.read", "code.read"],
+  );
+
+  const capabilityReplies = buildCapabilityReplies(results);
+  assert.equal(capabilityReplies.length, 5);
+  assert.match(capabilityReplies[0], /Result 1/u);
+  assert.match(capabilityReplies[4], /Result 5/u);
+
+  const memoryReply = buildMemoryReply({
+    type: "write-confirmation-required",
+    items: [{ fact: "трябва да пуснем деплой след merge" }],
+  });
+  assert.match(memoryReply, /Искаш запис в постоянната памет/u);
+  assert.match(memoryReply, /За потвърждение изпрати точно/u);
+
+  const fullReply = [memoryReply, ...capabilityReplies].join("\n\n");
+  assert.match(fullReply, /Result 1/u);
+  assert.match(fullReply, /Result 5/u);
+  assert.match(fullReply, /потвърждение/u);
+
+  assert.deepEqual(
+    extractConfirmedMemoryWriteCommands(
+      "Запомни, че трябва да пуснем деплой след merge.",
+    ),
+    [],
+  );
 });
 
 test("requires explicit memory-write confirmation prefix", () => {


### PR DESCRIPTION
## Какво е поправено
- разделя сложна заявка на отделни capability подзадачи
- изпълнява всички подзадачи последователно
- обединява всички резултати в един отговор
- изисква потвърждение преди запис в постоянната памет
- добавя регресионен тест за пет GitHub проверки

## Обхват
Само `src/routes/chat.js` и `tests/chatCapabilityExecution.test.js`. Няма промяна по OpenSearch.

## Проверка
Логиката е пренесена от проверения вариант на PR #47, където са отчетени 89/89 успешни теста. PR е оставен като Draft за окончателна проверка.