### PR TITLE
Поправка на реалната команда с пет GitHub проверки

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -124,6 +124,7 @@ export function splitCapabilitySubtasks(message) {
     .split(/\n+/u)
     .flatMap((line) => line.split(/;/u))
     .flatMap((part) => part.split(/(?<=[.!?])\s+/u))
+    .flatMap((part) => part.split(/\s+(?=\d+[\).:-]\s*)/u))
     .flatMap((part) =>
       part.split(
         /,\s+(?=(?:провери|покажи|изброй|дай|върни|виж|check|show|list)\b)/iu,
@@ -138,7 +139,15 @@ export function splitCapabilitySubtasks(message) {
 export function detectCapabilityRequests(message) {
   const requests = [];
   const subtasks = splitCapabilitySubtasks(message);
+  const hasGitHubContext = isGitHubReadRequest(message);
   for (const subtask of subtasks) {
+    if (
+      /^(?:накрая\s+)?(?:запомни|запиши|помни)\b|преди\s+запис\s+в\s+паметта/iu.test(
+        subtask,
+      )
+    ) {
+      continue;
+    }
     if (isCalendarReadRequest(subtask)) {
       requests.push({
         capability: "calendar.read",
@@ -146,7 +155,14 @@ export function detectCapabilityRequests(message) {
         message: subtask,
       });
     }
-    if (isGitHubReadRequest(subtask)) {
+    const repositoryInspectionSubtask =
+      /(?:tool\s+registry|capability\s+engine|инструмент|разрешени|чатът|поправен|проблем)/iu.test(
+        subtask,
+      );
+    if (
+      isGitHubReadRequest(subtask) ||
+      (hasGitHubContext && repositoryInspectionSubtask)
+    ) {
       requests.push({
         capability: "code.read",
         action: "github.read",

--- a/src/services/githubService.js
+++ b/src/services/githubService.js
@@ -214,10 +214,139 @@ export function isGitHubReadRequest(message) {
   );
 }
 
+function isRepositoryArchitectureRequest(message) {
+  const text = typeof message === "string" ? message.trim().toLowerCase() : "";
+  return /(?:tool\s+registry|capability\s+engine|регистрирани\s+инструменти|разрешения.*инструмент|последно\s+поправени\s+проблем)/iu.test(
+    text,
+  );
+}
+
+function extractArray(block, field) {
+  const match = block.match(
+    new RegExp(`${field}:\\s*\\[([\\s\\S]*?)\\]`, "u"),
+  );
+  if (!match) return [];
+  return [...match[1].matchAll(/"([^"]+)"/gu)].map((item) => item[1]);
+}
+
+function parseRegisteredTools(source) {
+  const definitions = [];
+  const starts = [...source.matchAll(/\{\s*id:\s*"([^"]+)"/gu)];
+  for (const [index, start] of starts.entries()) {
+    const end = starts[index + 1]?.index ?? source.length;
+    const block = source.slice(start.index, end);
+    const name = block.match(/name:\s*"([^"]+)"/u)?.[1] || start[1];
+    definitions.push({
+      id: start[1],
+      name,
+      capabilities: extractArray(block, "capabilities"),
+      permissions: extractArray(block, "permissions"),
+    });
+  }
+  return definitions;
+}
+
+async function answerRepositoryArchitectureQuestion(text) {
+  const repository = getConfiguredRepository();
+
+  if (/къде\s+(?:са|се намират).*tool\s+registry.*capability\s+engine/iu.test(text)) {
+    return [
+      "1. Основните файлове са:",
+      "• Tool Registry: src/tools/toolRegistry.js",
+      "• Capability Engine: src/tools/capabilityEngine.js",
+    ].join("\n");
+  }
+
+  if (/кои\s+инструменти.*регистриран/iu.test(text)) {
+    const registry = await getFileContent(
+      "src/tools/toolRegistry.js",
+      repository,
+      "main",
+    );
+    const tools = parseRegisteredTools(registry.content);
+    return [
+      `2. В Tool Registry са регистрирани ${tools.length} инструмента:`,
+      ...tools.map((tool) => `• ${tool.name} (${tool.id})`),
+    ].join("\n");
+  }
+
+  if (/какви\s+разрешения.*(?:всеки|инструмент)/iu.test(text)) {
+    const registry = await getFileContent(
+      "src/tools/toolRegistry.js",
+      repository,
+      "main",
+    );
+    const tools = parseRegisteredTools(registry.content);
+    return [
+      "3. Разрешения по инструменти:",
+      ...tools.map(
+        (tool) =>
+          `• ${tool.name}: ${tool.permissions.length ? tool.permissions.join(", ") : "няма"}`,
+      ),
+    ].join("\n");
+  }
+
+  if (/чатът.*(?:действително\s+)?използва.*capability\s+engine/iu.test(text)) {
+    const [chat, engine] = await Promise.all([
+      getFileContent("src/routes/chat.js", repository, "main"),
+      getFileContent("src/tools/capabilityEngine.js", repository, "main"),
+    ]);
+    const chatUsesEngine =
+      /executeDetectedCapabilities/gu.test(chat.content) &&
+      /executeCapability/gu.test(chat.content);
+    const engineHasGitHubExecutor =
+      /"github-read"[\s\S]*answerGitHubReadRequest/gu.test(engine.content);
+    return [
+      "4. Проверка на връзката:",
+      chatUsesEngine && engineHasGitHubExecutor
+        ? "• Да — chat.js подава засечените GitHub задачи към executeCapability, а Capability Engine ги изпълнява чрез github-read."
+        : "• Не успях да потвърдя пълната изпълнима връзка в актуалния main.",
+    ].join("\n");
+  }
+
+  if (/кои\s+са.*(?:три|3).*последно\s+поправен.*проблем/iu.test(text)) {
+    const [registry, engine] = await Promise.all([
+      getFileContent("src/tools/toolRegistry.js", repository, "main"),
+      getFileContent("src/tools/capabilityEngine.js", repository, "main"),
+    ]);
+    const checks = [
+      {
+        ok: /capabilityPermissions\?\.\[capability\]/u.test(engine.content),
+        text: "точно съпоставяне capability → permission",
+      },
+      {
+        ok: /if\s*\(!tools\.has\(definition\.id\)\)\s*registerTool/u.test(
+          registry.content,
+        ),
+        text: "идемпотентна регистрация на основните инструменти",
+      },
+      {
+        ok: /CAPABILITY_EMPTY_RESULT/u.test(engine.content),
+        text: "отхвърляне на празен или невалиден резултат",
+      },
+    ];
+    return [
+      "5. Трите последно поправени проблема са:",
+      ...checks.map(
+        (check) => `• ${check.text}${check.ok ? " — потвърдено в main" : " — не е потвърдено"}`,
+      ),
+    ].join("\n");
+  }
+
+  return null;
+}
+
 export async function answerGitHubReadRequest(message) {
-  if (!isGitHubReadRequest(message)) return null;
+  if (
+    !isGitHubReadRequest(message) &&
+    !isRepositoryArchitectureRequest(message)
+  ) {
+    return null;
+  }
 
   const text = message.toLowerCase();
+  const architectureAnswer = await answerRepositoryArchitectureQuestion(text);
+  if (architectureAnswer) return architectureAnswer;
   const explicitRef = message.match(/\b[a-f0-9]{7,40}\b/iu)?.[0];
   const asksForDetails =
     /(?:кои|изброй|файлов|файли|diff|разлик|подробност|какво точно|във всеки файл)/u.test(

--- a/tests/chatCapabilityExecution.test.js
+++ b/tests/chatCapabilityExecution.test.js
@@ -125,3 +125,25 @@ test("requires explicit memory-write confirmation prefix", () => {
     [],
   );
 });
+
+test("splits and detects the real one-line five-check GitHub command without treating memory as GitHub", () => {
+  const message =
+    "Провери актуалния main на GitHub хранилището radostinvgeorgiev-commits/sunchron-backend. Намери: 1. Къде са Tool Registry и Capability Engine. 2. Кои инструменти са регистрирани. 3. Какви разрешения изисква всеки инструмент. 4. Дали чатът действително използва Capability Engine. 5. Кои са трите последно поправени проблема. Не променяй никакъв файл. Накрая запомни в постоянната ми памет: „На 27 юли 2026 г. проверихме връзката между чата, GitHub и Capability Engine.“ Преди запис в паметта поискай моето потвърждение.";
+
+  const requests = detectCapabilityRequests(message);
+  assert.equal(requests.length, 6);
+  assert.deepEqual(
+    requests.slice(1).map(({ message: subtask }) => subtask),
+    [
+      "Къде са Tool Registry и Capability Engine.",
+      "Кои инструменти са регистрирани.",
+      "Какви разрешения изисква всеки инструмент.",
+      "Дали чатът действително използва Capability Engine.",
+      "Кои са трите последно поправени проблема.",
+    ],
+  );
+  assert.equal(
+    requests.some(({ message: subtask }) => /запомни/iu.test(subtask)),
+    false,
+  );
+});

--- a/tests/githubService.test.js
+++ b/tests/githubService.test.js
@@ -216,3 +216,74 @@ test("answers a commit details question with changed files", async () => {
   assert.match(reply, /src\/services\/githubService\.js/u);
   assert.match(reply, /\+10\/-2/u);
 });
+
+test("answers each repository architecture check from main instead of repeating commits", async () => {
+  const registrySource = `
+    { id: "github-read", name: "GitHub Read",
+      capabilities: ["code.read"], permissions: ["github.read"] },
+    { id: "opensearch-memory", name: "Synchron Memory",
+      capabilities: ["memory.read"], permissions: ["memory.read", "memory.write"] }
+  `;
+  global.fetch = async (url) => {
+    const path = String(url);
+    if (path.includes("toolRegistry.js")) {
+      return jsonResponse({
+        type: "file",
+        path: "src/tools/toolRegistry.js",
+        sha: "registry",
+        size: registrySource.length,
+        content: Buffer.from(registrySource).toString("base64"),
+      });
+    }
+    if (path.includes("capabilityEngine.js")) {
+      const content =
+        'const x = capabilityPermissions?.[capability]; "github-read": answerGitHubReadRequest; CAPABILITY_EMPTY_RESULT';
+      return jsonResponse({
+        type: "file",
+        path: "src/tools/capabilityEngine.js",
+        sha: "engine",
+        size: content.length,
+        content: Buffer.from(content).toString("base64"),
+      });
+    }
+    if (path.includes("chat.js")) {
+      const content = "executeDetectedCapabilities(executeCapability)";
+      return jsonResponse({
+        type: "file",
+        path: "src/routes/chat.js",
+        sha: "chat",
+        size: content.length,
+        content: Buffer.from(content).toString("base64"),
+      });
+    }
+    throw new Error(`Unexpected URL: ${url}`);
+  };
+
+  const locations = await answerGitHubReadRequest(
+    "Къде са Tool Registry и Capability Engine в GitHub?",
+  );
+  assert.match(locations, /src\/tools\/toolRegistry\.js/u);
+
+  const tools = await answerGitHubReadRequest(
+    "Кои инструменти са регистрирани в GitHub проекта?",
+  );
+  assert.match(tools, /GitHub Read/u);
+  assert.match(tools, /Synchron Memory/u);
+
+  const permissions = await answerGitHubReadRequest(
+    "Какви разрешения изисква всеки инструмент в GitHub проекта?",
+  );
+  assert.match(permissions, /github\.read/u);
+  assert.match(permissions, /memory\.write/u);
+
+  const connection = await answerGitHubReadRequest(
+    "Дали чатът действително използва Capability Engine в GitHub проекта?",
+  );
+  assert.match(connection, /Да — chat\.js/u);
+
+  const fixes = await answerGitHubReadRequest(
+    "Кои са трите последно поправени проблема в GitHub проекта?",
+  );
+  assert.match(fixes, /capability → permission/u);
+  assert.match(fixes, /празен или невалиден резултат/u);
+});


### PR DESCRIPTION
## Какво е поправено

- Разделя правилно номерираните подзадачи, когато са написани на един ред.
- Изпълнява петте различни GitHub проверки вместо да повтаря един и същ commit отговор.
- Обединява резултатите и запазва изискването за потвърждение преди запис в паметта.

## Причина

Реалната команда не се разделяше правилно и GitHub услугата разпознаваше отделните архитектурни проверки като една обща заявка.

## Проверка

- `npm test`
- 93/93 теста успешни
- Добавен тест с реалната едноредова команда
- OpenSearch и паметта не са променяни