### PR TITLE
Премахване на повтарящите се GitHub резултати

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -474,14 +474,25 @@ export function buildMemoryReply(memoryAction) {
 
 export function buildCapabilityReplies(capabilityResults) {
   const replies = [];
+  const seenReplyKeys = new Set();
+  const addUniqueReply = (reply) => {
+    if (typeof reply !== "string") return;
+    const trimmedReply = reply.trim();
+    if (!trimmedReply) return;
+    const key = trimmedReply.replace(/\s+/gu, " ");
+    if (seenReplyKeys.has(key)) return;
+    seenReplyKeys.add(key);
+    replies.push(trimmedReply);
+  };
+
   for (const capabilityResult of capabilityResults) {
     if (capabilityResult.status === "fulfilled") {
-      replies.push(capabilityResult.result.output);
+      addUniqueReply(capabilityResult.result.output);
       continue;
     }
     const { request, error } = capabilityResult;
     const message = formatCapabilityFailureMessage(error);
-    replies.push(
+    addUniqueReply(
       `Не успях да изпълня заявката за ${capabilityLabel(request.capability)}: ${message}`,
     );
   }
@@ -499,7 +510,7 @@ export function buildCapabilityReplies(capabilityResults) {
         failed: item.status === "rejected" || Boolean(existing?.failed),
       });
     }
-    replies.push(
+    addUniqueReply(
       [
         "Използвани инструменти:",
         ...[...statusByCapability.values()].map((status) => {

--- a/tests/chatCapabilityExecution.test.js
+++ b/tests/chatCapabilityExecution.test.js
@@ -118,6 +118,37 @@ test("complex 5-check command runs all checks, merges results, and asks memory-w
   );
 });
 
+test("collapses identical tool outputs into one visible reply", () => {
+  const request = {
+    capability: "code.read",
+    action: "github.read",
+    message: "Провери последната промяна в GitHub.",
+  };
+  const repeatedOutput = [
+    "Последната реална промяна в GitHub е:",
+    "• 691cc3c — Поправка на агентските задачи и опростяване на интерфейса (#53)",
+  ].join("\n");
+  const results = Array.from({ length: 5 }, () => ({
+    status: "fulfilled",
+    request,
+    result: {
+      output: repeatedOutput,
+      tool: { id: "github-read", name: "GitHub Read" },
+    },
+  }));
+
+  const replies = buildCapabilityReplies(results);
+
+  assert.equal(replies.length, 2);
+  assert.equal(replies[0], repeatedOutput);
+  assert.match(replies[1], /Използвани инструменти/u);
+  assert.equal(
+    replies.join("\n").split("Последната реална промяна в GitHub е:").length -
+      1,
+    1,
+  );
+});
+
 test("requires explicit memory-write confirmation prefix", () => {
   const commands = extractConfirmedMemoryWriteCommands(
     "Потвърждавам запис в постоянната памет: Запомни, че проектът е SYNCHRON-X.",


### PR DESCRIPTION
## Какво поправя

- показва еднакъв резултат от инструмент само веднъж;
- запазва общия отчет за използваните инструменти;
- добавя регресионен тест с пет еднакви GitHub отговора.

## Причина

Сложната GitHub проверка изпълнява няколко подзадачи, но GitHub Read може да върне един и същ текст за всяка. Предишната поправка ограничаваше само записващите задачи и не премахваше еднаквите готови отговори.

## Очаквана проверка

Пълният test suite трябва да мине, а пет еднакви GitHub резултата да се покажат като един.