### PR TITLE
Добави работещи бутони за свързване

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -401,18 +401,67 @@ function openFocusDrawer() {
     </section>`;
 }
 
+function isGoogleTool(tool) {
+  return (
+    tool?.provider === "google" ||
+    tool?.id?.startsWith("google-") ||
+    tool?.id === "gmail-read"
+  );
+}
+
 function toolState(tool, googleConnected) {
-  const isGoogle = tool.provider === "google" || tool.id.startsWith("google-") || tool.id === "gmail-read";
   if (!tool.enabled || !tool.executable) {
     return { label: "Не е свързан", className: "deny" };
   }
   if (!tool.configured) {
     return { label: "Не е конфигуриран", className: "deny" };
   }
-  if (isGoogle && !googleConnected) {
+  if (isGoogleTool(tool) && !googleConnected) {
     return { label: "Иска свързване", className: "confirm" };
   }
   return { label: "Работи", className: "allow" };
+}
+
+function toolStatusActions(tool, status, googleConnected) {
+  let action = "";
+  if (isGoogleTool(tool) && !googleConnected && tool.configured) {
+    action =
+      '<button type="button" class="tool-connect-btn" data-connect-service="google">Свържи Google</button>';
+  } else if (tool.id === "github-write" && status.className === "deny") {
+    action =
+      '<button type="button" class="tool-connect-btn" data-connect-service="github">Настрой GitHub</button>';
+  }
+
+  return `
+    <div class="tool-status-actions">
+      <span class="permission-badge ${status.className}">${status.label}</span>
+      ${action}
+    </div>`;
+}
+
+function permissionAction(item, toolMap, googleConnected) {
+  const googlePermissions = new Set([
+    "calendar.read",
+    "calendar.write",
+    "drive.read",
+    "mail.read",
+  ]);
+  if (googlePermissions.has(item.action) && !googleConnected) {
+    return '<button type="button" class="tool-connect-btn" data-connect-service="google">Свържи Google</button>';
+  }
+
+  const githubWrite = toolMap.get("github-write");
+  if (
+    item.action === "github.write" &&
+    (!githubWrite?.configured || !githubWrite?.executable)
+  ) {
+    return '<button type="button" class="tool-connect-btn" data-connect-service="github">Настрой GitHub</button>';
+  }
+
+  if (item.decision === "confirm") {
+    return `<button type="button" class="permission-info-btn" data-permission-info="${escapeHtml(item.action)}">Как работи</button>`;
+  }
+  return "";
 }
 
 async function openToolsDrawer() {
@@ -457,7 +506,7 @@ async function openToolsDrawer() {
                   <strong>${escapeHtml(tool.name)}</strong>
                   <p>${escapeHtml(descriptions[tool.id] || "Инструмент на SYNCHRON-X.")}</p>
                 </div>
-                <span class="permission-badge ${status.className}">${status.label}</span>
+                ${toolStatusActions(tool, status, Boolean(googleData.connected))}
               </article>`;
           })
           .join("")}
@@ -548,9 +597,24 @@ async function openPermissionsDrawer() {
   openDataDrawer("Разрешения");
   renderDrawerLoading();
   try {
-    const response = await fetch("/permissions", { cache: "no-store" });
-    if (!response.ok) throw new Error("Разрешенията временно не са достъпни.");
-    const data = await response.json();
+    const [permissionsResponse, healthResponse, googleResponse] =
+      await Promise.all([
+        fetch("/permissions", { cache: "no-store" }),
+        fetch("/health/integrations", { cache: "no-store" }),
+        fetch("/api/google/status", { cache: "no-store" }).catch(() => null),
+      ]);
+    if (!permissionsResponse.ok || !healthResponse.ok) {
+      throw new Error("Разрешенията временно не са достъпни.");
+    }
+    const [data, healthData] = await Promise.all([
+      permissionsResponse.json(),
+      healthResponse.json(),
+    ]);
+    const googleData =
+      googleResponse?.ok ? await googleResponse.json().catch(() => ({})) : {};
+    const toolMap = new Map(
+      (healthData.tools || []).map((tool) => [tool.id, tool]),
+    );
     const labels = {
       allow: "Разрешено",
       confirm: "Иска потвърждение",
@@ -558,7 +622,8 @@ async function openPermissionsDrawer() {
     };
     elements.dataDrawerBody.innerHTML = `
             <div class="permission-default">
-                Непознатите действия са <strong>забранени по подразбиране</strong>.
+                Зеленото е активно. Оранжевото също работи, но пита преди рисково действие.
+                Несвързаните услуги имат отделен бутон за вход.
             </div>
             <section class="drawer-section permission-list">
                 ${(data.permissions || [])
@@ -569,9 +634,16 @@ async function openPermissionsDrawer() {
                             <strong>${escapeHtml(item.action)}</strong>
                             <p>${escapeHtml(item.reason)}</p>
                         </div>
-                        <span class="permission-badge ${escapeHtml(item.decision)}">
-                            ${labels[item.decision] || escapeHtml(item.decision)}
-                        </span>
+                        <div class="permission-card-actions">
+                          <span class="permission-badge ${escapeHtml(item.decision)}">
+                              ${labels[item.decision] || escapeHtml(item.decision)}
+                          </span>
+                          ${permissionAction(
+                            item,
+                            toolMap,
+                            Boolean(googleData.connected),
+                          )}
+                        </div>
                     </article>`,
                   )
                   .join("")}
@@ -581,7 +653,92 @@ async function openPermissionsDrawer() {
   }
 }
 
+function showGitHubSetup() {
+  openDataDrawer("Свързване на GitHub");
+  elements.dataDrawerBody.innerHTML = `
+    <section class="setup-guide">
+      <div class="permission-default">
+        GitHub Read работи. За GitHub Write липсва защитен достъп до хранилището.
+        За пилота използвай ограничен token само за
+        <strong>radostinvgeorgiev-commits/sunchron-backend</strong>.
+      </div>
+      <article class="setup-step">
+        <span>1</span>
+        <div>
+          <strong>Създай ограничен GitHub достъп</strong>
+          <p>Избери само това хранилище. Дай Contents: Read and write и Pull requests: Read and write.</p>
+          <a class="setup-action" href="https://github.com/settings/personal-access-tokens/new" target="_blank" rel="noopener noreferrer">
+            Отвори точната GitHub страница
+          </a>
+        </div>
+      </article>
+      <article class="setup-step">
+        <span>2</span>
+        <div>
+          <strong>Добави тайната в DigitalOcean</strong>
+          <p>Отвори приложението <strong>sunchron-backend</strong>, после Settings → App-Level Environment Variables → GITHUB_TOKEN. Стойността трябва да е отбелязана като Encrypt.</p>
+          <a class="setup-action" href="https://cloud.digitalocean.com/apps" target="_blank" rel="noopener noreferrer">
+            Отвори DigitalOcean Apps
+          </a>
+        </div>
+      </article>
+      <div class="setup-note">
+        След запазване DigitalOcean ще направи нов deployment. GitHub Write ще остане с потвърждение за всяка промяна.
+      </div>
+      <button type="button" class="permission-info-btn" data-back-tools>Назад към инструментите</button>
+    </section>`;
+}
+
+function showPermissionInfo(action) {
+  const messages = {
+    "calendar.write":
+      "Разрешението е подготвено, но записът в календара още не е реализиран. Свързването на Google активира четенето.",
+    "memory.write":
+      "Записът в паметта е активен. Преди постоянен запис SYNCHRON-X трябва да покаже точния текст и да поиска твоето потвърждение.",
+    "memory.delete":
+      "Изтриването е активно, но се изпълнява само след точно потвърждение за конкретния спомен.",
+    "external.send":
+      "Това е защитно правило за бъдещи имейли и публикации. Външно изпращане още не е свързано.",
+    payment:
+      "Това е защитно правило за бъдещи плащания и резервации. Платежен инструмент още не е свързан.",
+  };
+  openDataDrawer(action);
+  elements.dataDrawerBody.innerHTML = `
+    <section class="setup-guide">
+      <div class="permission-default">${escapeHtml(
+        messages[action] || "Това действие се изпълнява само след твое потвърждение.",
+      )}</div>
+      <button type="button" class="permission-info-btn" data-back-permissions>Назад към разрешенията</button>
+    </section>`;
+}
+
 async function handleDataDrawerAction(event) {
+  const connectionButton = event.target.closest("[data-connect-service]");
+  if (connectionButton) {
+    if (connectionButton.dataset.connectService === "google") {
+      window.location.href = "/api/google/connect";
+    } else if (connectionButton.dataset.connectService === "github") {
+      showGitHubSetup();
+    }
+    return;
+  }
+
+  if (event.target.closest("[data-back-tools]")) {
+    await openToolsDrawer();
+    return;
+  }
+
+  if (event.target.closest("[data-back-permissions]")) {
+    await openPermissionsDrawer();
+    return;
+  }
+
+  const permissionInfo = event.target.closest("[data-permission-info]");
+  if (permissionInfo) {
+    showPermissionInfo(permissionInfo.dataset.permissionInfo);
+    return;
+  }
+
   const button = event.target.closest("button[data-memory-delete]");
   if (!button) return;
   const item = state.memoryItems.find(

--- a/public/index.html
+++ b/public/index.html
@@ -12,8 +12,8 @@
       content="SYNCHRON-X — лична AI операционна система с контролирана памет и разрешени инструменти."
     />
     <title>SYNCHRON-X · Лична AI операционна система</title>
-    <link rel="stylesheet" href="/styles.css?v=20260727-focus-tools" />
-    <link rel="stylesheet" href="/appshell.css?v=20260727-focus-tools" />
+    <link rel="stylesheet" href="/styles.css?v=20260727-connection-actions" />
+    <link rel="stylesheet" href="/appshell.css?v=20260727-connection-actions" />
     <link rel="stylesheet" href="/search.css?v=20260726-search" />
     <link rel="stylesheet" href="/modules.css?v=20260726-modules" />
     <link
@@ -224,9 +224,9 @@
       </aside>
     </main>
 
-    <script src="/app.js?v=20260727-focus-tools"></script>
-    <script src="/google-drive.js?v=20260726-drive-files"></script>
-    <script src="/google-apps.js?v=20260726-google-apps"></script>
+    <script src="/app.js?v=20260727-connection-actions"></script>
+    <script src="/google-drive.js?v=20260727-connection-actions"></script>
+    <script src="/google-apps.js?v=20260727-connection-actions"></script>
     <script src="/search.js?v=20260726-search"></script>
     <script src="/modules.js?v=20260726-modules"></script>
   </body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1072,3 +1072,107 @@ input {
     object-fit: contain;
     border-radius: 12px;
 }
+
+
+.tool-status-actions,
+.permission-card-actions {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 9px;
+    flex: 0 0 auto;
+}
+
+.tool-connect-btn,
+.permission-info-btn,
+.setup-action {
+    min-height: 40px;
+    padding: 9px 14px;
+    border: 1px solid #cbd5df;
+    border-radius: 999px;
+    color: #14324a;
+    background: #f4f8fb;
+    font: inherit;
+    font-size: 13px;
+    font-weight: 750;
+    line-height: 1.2;
+    text-align: center;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.tool-connect-btn {
+    color: #075985;
+    border-color: #bae6fd;
+    background: #eaf8ff;
+}
+
+.setup-guide {
+    display: grid;
+    gap: 14px;
+}
+
+.setup-step {
+    display: grid;
+    grid-template-columns: 34px minmax(0, 1fr);
+    gap: 12px;
+    padding: 16px;
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    background: #fff;
+}
+
+.setup-step > span {
+    width: 34px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    color: #075985;
+    background: #e0f2fe;
+    font-weight: 800;
+}
+
+.setup-step strong,
+.setup-step p {
+    display: block;
+}
+
+.setup-step p {
+    margin: 6px 0 12px;
+    color: var(--muted);
+    line-height: 1.45;
+}
+
+.setup-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.setup-note {
+    padding: 14px 16px;
+    border-radius: 14px;
+    color: #78500a;
+    background: #fff7df;
+    line-height: 1.45;
+}
+
+@media (max-width: 520px) {
+    .permission-card {
+        align-items: flex-start;
+    }
+
+    .tool-status-actions,
+    .permission-card-actions {
+        width: 100%;
+        align-items: stretch;
+    }
+
+    .tool-connect-btn,
+    .permission-info-btn,
+    .setup-action {
+        width: 100%;
+    }
+}

--- a/tests/connectionActionsUi.test.js
+++ b/tests/connectionActionsUi.test.js
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("connection and permission controls lead to real setup actions", async () => {
+  const app = await readFile(new URL("../public/app.js", import.meta.url), "utf8");
+
+  assert.match(app, /data-connect-service="google"/u);
+  assert.match(app, /window\.location\.href = "\/api\/google\/connect"/u);
+  assert.match(app, /data-connect-service="github"/u);
+  assert.match(app, /github\.com\/settings\/personal-access-tokens\/new/u);
+  assert.match(app, /cloud\.digitalocean\.com\/apps/u);
+  assert.match(app, /GITHUB_TOKEN/u);
+  assert.match(app, /data-permission-info/u);
+  assert.match(app, /Оранжевото също работи, но пита/u);
+});


### PR DESCRIPTION
## Какво се променя

- Добавя работещ бутон „Свържи Google“, който отваря съществуващия OAuth вход.
- Добавя „Настрой GitHub“ с точните страници и минималните права за пилота.
- Разделя ясно разрешение от реално свързване.
- Прави оранжевите защитени действия обясними и активни, без да премахва потвърждението.
- Добавя автоматичен тест за връзките.

## Защо

Екранът „Разрешения“ изглеждаше като списък с неактивни бутони и смесваше правилата за безопасност със състоянието на външните връзки.

## Проверка

- JavaScript синтаксисът е проверен преди качване.
- GitHub Actions трябва да изпълни пълния тестов пакет.