### PR TITLE
Поправка на грешките при свързване на Google Calendar

### DIFF
--- a/src/services/googleDriveService.js
+++ b/src/services/googleDriveService.js
@@ -305,6 +305,30 @@ async function driveFetch(id, path, options = {}, fetchImpl = fetch) {
   );
 }
 
+function googleConnectLink(label = "Свържи Google") {
+  const url =
+    process.env.GOOGLE_CONNECT_URL ||
+    "https://synchron.foundation/api/google/connect";
+  return `[${label}](${url})`;
+}
+
+async function googleErrorDetails(response) {
+  try {
+    const data = await response.json();
+    const errors = Array.isArray(data?.error?.errors)
+      ? data.error.errors
+      : [];
+    return {
+      message: String(data?.error?.message || ""),
+      reasons: errors
+        .map((item) => String(item?.reason || ""))
+        .filter(Boolean),
+    };
+  } catch {
+    return { message: "", reasons: [] };
+  }
+}
+
 async function googleFetch(
   id,
   url,
@@ -317,17 +341,48 @@ async function googleFetch(
     ...options,
     headers: { ...(options.headers || {}), Authorization: `Bearer ${token}` },
   });
-  if (!response.ok) {
-    const reconnect = response.status === 401 || response.status === 403;
+  if (response.ok) return response;
+
+  const details = await googleErrorDetails(response);
+  const reasonText = [details.message, ...details.reasons]
+    .join(" ")
+    .toLowerCase();
+
+  if (response.status === 401) {
+    sessions.delete(id);
     throw new GoogleDriveError(
-      reconnect
-        ? `${serviceName} трябва да бъде разрешен чрез ново свързване.`
-        : `${serviceName} временно не е достъпен.`,
-      reconnect ? 401 : 502,
-      "GOOGLE_REQUEST_FAILED",
+      `Google връзката е изтекла. ${googleConnectLink("Свържи Google отново")}.`,
+      401,
+      "GOOGLE_RECONNECT_REQUIRED",
     );
   }
-  return response;
+
+  if (response.status === 403) {
+    const apiDisabled =
+      /accessnotconfigured|api has not been used|api is disabled|service_disabled/u.test(
+        reasonText,
+      );
+    if (apiDisabled) {
+      throw new GoogleDriveError(
+        `${serviceName} API не е включен в Google Cloud. Отвори настройката на Google проекта и включи услугата.`,
+        503,
+        "GOOGLE_API_DISABLED",
+      );
+    }
+    throw new GoogleDriveError(
+      `${serviceName} няма дадено разрешение. ${googleConnectLink(
+        `Разреши ${serviceName}`,
+      )}.`,
+      403,
+      "GOOGLE_SCOPE_REQUIRED",
+    );
+  }
+
+  throw new GoogleDriveError(
+    `${serviceName} временно не е достъпен (Google грешка ${response.status}).`,
+    502,
+    "GOOGLE_REQUEST_FAILED",
+  );
 }
 
 export async function hasSession(id) {

--- a/tests/googleDriveService.test.js
+++ b/tests/googleDriveService.test.js
@@ -176,3 +176,69 @@ test("encrypts persisted Google sessions without exposing OAuth tokens", () => {
     }
   }
 });
+
+
+test("calendar permission error includes a direct reconnect link", async () => {
+  const sessionId = await createSession({
+    access_token: "token",
+    expires_in: 3600,
+  });
+
+  await assert.rejects(
+    () =>
+      listGoogleCalendarEvents(sessionId, 7, 10, async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 403,
+              message: "Request had insufficient authentication scopes.",
+              errors: [{ reason: "forbidden" }],
+            },
+          }),
+          {
+            status: 403,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ),
+    (error) => {
+      assert.equal(error.code, "GOOGLE_SCOPE_REQUIRED");
+      assert.match(error.message, /Разреши Google Calendar/u);
+      assert.match(error.message, /\/api\/google\/connect/u);
+      return true;
+    },
+  );
+});
+
+test("calendar disabled API is not reported as an expired connection", async () => {
+  const sessionId = await createSession({
+    access_token: "token",
+    expires_in: 3600,
+  });
+
+  await assert.rejects(
+    () =>
+      listGoogleCalendarEvents(sessionId, 7, 10, async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 403,
+              message:
+                "Google Calendar API has not been used in project or it is disabled.",
+              errors: [{ reason: "accessNotConfigured" }],
+            },
+          }),
+          {
+            status: 403,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ),
+    (error) => {
+      assert.equal(error.code, "GOOGLE_API_DISABLED");
+      assert.match(error.message, /API не е включен/u);
+      assert.doesNotMatch(error.message, /ново свързване/u);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## Какво е поправено

- различава изтекла Google сесия от липсващо Calendar разрешение;
- различава изключено Google Calendar API от OAuth проблем;
- при липсващо разрешение връща директен линк към реалното Google свързване;
- добавя регресионни тестове за двата вида 403 грешки.

## Причина

Досега всяка Google грешка 403 се представяше като нужда от ново свързване, без да се прочете реалната причина от Google.

## Обхват

Променени са само Google service обработката на грешки и тестовете. Паметта, AI Core, Logic Core, Chat и данните не са променяни.

## Проверка

GitHub Actions трябва да изпълни пълния `npm test` пакет.