### PR TITLE
GitHub OAuth да работи само с Client ID и Secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,10 @@ OPENAI_DOCUMENT_MODEL=gpt-4o-mini
 # GitHub OAuth App (Required for confirmed Copilot coding tasks)
 GITHUB_CLIENT_ID=your-github-app-client-id
 GITHUB_CLIENT_SECRET=your-github-app-client-secret
-GITHUB_REDIRECT_URI=https://synchron.foundation/api/github/callback
-GITHUB_SESSION_ENCRYPTION_KEY=your-long-random-session-encryption-key
+# Optional overrides. Production defaults to synchron.foundation and derives
+# the session encryption key from the GitHub client secret when omitted.
+GITHUB_REDIRECT_URI=
+GITHUB_SESSION_ENCRYPTION_KEY=
 GITHUB_REPOSITORY=radostinvgeorgiev-commits/sunchron-backend
 
 # Google OAuth (Required for Drive, Gmail and the connected Calendar)

--- a/src/routes/githubOAuthRouter.js
+++ b/src/routes/githubOAuthRouter.js
@@ -7,6 +7,7 @@ import {
   exchangeGitHubCode,
   getGitHubSession,
   GitHubOAuthError,
+  isGitHubOAuthConfigured,
   parseGitHubCookies,
 } from "../services/githubOAuthService.js";
 
@@ -73,11 +74,7 @@ router.get("/status", async (req, res) => {
   try {
     const session = await getGitHubSession(sessionId(req));
     res.json({
-      configured: Boolean(
-        process.env.GITHUB_CLIENT_ID &&
-        process.env.GITHUB_CLIENT_SECRET &&
-        process.env.GITHUB_REDIRECT_URI,
-      ),
+      configured: isGitHubOAuthConfigured(),
       connected: Boolean(session),
       login: session?.login || null,
     });

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -1,4 +1,5 @@
 import express from "express";
+import { isGitHubOAuthConfigured } from "../services/githubOAuthService.js";
 import { isToolExecutable } from "../tools/capabilityEngine.js";
 import { listTools, registerCoreTools } from "../tools/toolRegistry.js";
 
@@ -20,11 +21,7 @@ export function getIntegrationStatus() {
       authenticated: true,
     },
     "github-write": {
-      configured: hasAllEnvironmentVariables(
-        "GITHUB_CLIENT_ID",
-        "GITHUB_CLIENT_SECRET",
-        "GITHUB_REDIRECT_URI",
-      ),
+      configured: isGitHubOAuthConfigured(),
       authenticated: false,
     },
     "google-drive-read": {

--- a/src/services/githubOAuthService.js
+++ b/src/services/githubOAuthService.js
@@ -4,6 +4,8 @@ import { getOpenSearchClient } from "../config/opensearch.js";
 const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const GITHUB_USER_URL = "https://api.github.com/user";
+export const DEFAULT_GITHUB_REDIRECT_URI =
+  "https://synchron.foundation/api/github/callback";
 const GITHUB_SESSION_INDEX =
   process.env.GITHUB_SESSION_INDEX || "synchron-github-sessions-v1";
 const sessions = new Map();
@@ -20,8 +22,9 @@ export class GitHubOAuthError extends Error {
 function configuration() {
   const clientId = process.env.GITHUB_CLIENT_ID;
   const clientSecret = process.env.GITHUB_CLIENT_SECRET;
-  const redirectUri = process.env.GITHUB_REDIRECT_URI;
-  if (!clientId || !clientSecret || !redirectUri) {
+  const redirectUri =
+    process.env.GITHUB_REDIRECT_URI || DEFAULT_GITHUB_REDIRECT_URI;
+  if (!clientId || !clientSecret) {
     throw new GitHubOAuthError(
       "GitHub връзката не е конфигурирана.",
       503,
@@ -29,6 +32,12 @@ function configuration() {
     );
   }
   return { clientId, clientSecret, redirectUri };
+}
+
+export function isGitHubOAuthConfigured() {
+  return Boolean(
+    process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET,
+  );
 }
 
 function sessionEncryptionKey() {

--- a/tests/githubOAuthService.test.js
+++ b/tests/githubOAuthService.test.js
@@ -40,6 +40,15 @@ test("builds GitHub OAuth URL with exact callback state", () => {
   assert.equal(url.searchParams.get("state"), "state-123");
 });
 
+test("uses the production callback when no redirect variable is set", () => {
+  delete process.env.GITHUB_REDIRECT_URI;
+  const url = new URL(buildGitHubAuthorizationUrl("state-123"));
+  assert.equal(
+    url.searchParams.get("redirect_uri"),
+    "https://synchron.foundation/api/github/callback",
+  );
+});
+
 test("exchanges the authorization code without exposing credentials", async () => {
   let requestBody;
   const tokens = await exchangeGitHubCode("code-123", async (_url, options) => {

--- a/tests/integrationHealth.test.js
+++ b/tests/integrationHealth.test.js
@@ -53,3 +53,25 @@ test("integration status reports configuration without exposing secret values", 
     resetToolRegistryForTests();
   }
 });
+
+test("GitHub Write is configured with client id and secret only", () => {
+  const original = Object.fromEntries(
+    ENV_NAMES.map((name) => [name, process.env[name]]),
+  );
+  process.env.GITHUB_CLIENT_ID = "client-id";
+  process.env.GITHUB_CLIENT_SECRET = "client-secret";
+  delete process.env.GITHUB_REDIRECT_URI;
+  resetToolRegistryForTests();
+
+  try {
+    const status = getIntegrationStatus();
+    const githubWrite = status.tools.find((tool) => tool.id === "github-write");
+    assert.equal(githubWrite.configured, true);
+  } finally {
+    for (const [name, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    resetToolRegistryForTests();
+  }
+});


### PR DESCRIPTION
## Промяна

- Използва `https://synchron.foundation/api/github/callback` като безопасен стандартен callback.
- GitHub Write се счита за конфигуриран само с `GITHUB_CLIENT_ID` и `GITHUB_CLIENT_SECRET`.
- Запазва възможността за отделни override стойности.
- Добавя тестове за реалната конфигурация в DigitalOcean.

## Проверка

- `npm test`
- 129/129 теста успешни.

Не променя AI Core, паметта, интерфейса или разрешенията.