### PR TITLE
Поправи показването на AI търсенето

### DIFF
--- a/public/search.js
+++ b/public/search.js
@@ -66,10 +66,10 @@
           .map((source) => "- [" + source.title.replace(/[\[\]]/g, "") + "](" + source.url + ")")
           .join("\n");
       }
-      pending.querySelector(".message-content").innerHTML = marked.parse(answer);
+      renderAgentText(pending, answer);
       logAction("AI търсене в интернет");
     } catch (error) {
-      pending.querySelector(".message-content").textContent = "❌ " + error.message;
+      renderAgentText(pending, "❌ " + error.message);
     } finally {
       state.chatBusy = false;
       elements.sendBtn.disabled = false;


### PR DESCRIPTION
## Какво е поправено

- AI търсенето вече записва резултата директно в върнатия елемент на съобщението.
- Същата логика показва коректно и грешките от търсенето.

## Причина

`appendMessage("agent", ...)` връща директно `.message.agent`, но `public/search.js` търсеше несъществуващ вложен `.message-content`. Това прекъсваше интерфейса и той оставаше на „Търся в интернет…“.

## Обхват

Променен е само `public/search.js`. Паметта, AI Core, инструментите и интеграциите не са променяни.

## Проверка

Изчакват се автоматичните GitHub проверки върху Pull Request-а.