### PR TITLE
Поправи GitHub OAuth за agent write

### DIFF
--- a/src/services/githubOAuthService.js
+++ b/src/services/githubOAuthService.js
@@ -6,6 +6,7 @@ const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const GITHUB_USER_URL = "https://api.github.com/user";
 export const DEFAULT_GITHUB_REDIRECT_URI =
   "https://synchron.foundation/api/github/callback";
+const GITHUB_OAUTH_SCOPE = "public_repo";
 const GITHUB_SESSION_INDEX =
   process.env.GITHUB_SESSION_INDEX || "synchron-github-sessions-v1";
 const sessions = new Map();
@@ -19,11 +20,27 @@ export class GitHubOAuthError extends Error {
   }
 }
 
+export function resolveGitHubRedirectUri(
+  value = process.env.GITHUB_REDIRECT_URI,
+) {
+  const candidate = typeof value === "string" ? value.trim() : "";
+  if (!candidate) return DEFAULT_GITHUB_REDIRECT_URI;
+
+  try {
+    const url = new URL(candidate);
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return DEFAULT_GITHUB_REDIRECT_URI;
+    }
+    return candidate;
+  } catch {
+    return DEFAULT_GITHUB_REDIRECT_URI;
+  }
+}
+
 function configuration() {
   const clientId = process.env.GITHUB_CLIENT_ID;
   const clientSecret = process.env.GITHUB_CLIENT_SECRET;
-  const redirectUri =
-    process.env.GITHUB_REDIRECT_URI || DEFAULT_GITHUB_REDIRECT_URI;
+  const redirectUri = resolveGitHubRedirectUri();
   if (!clientId || !clientSecret) {
     throw new GitHubOAuthError(
       "GitHub връзката не е конфигурирана.",
@@ -71,6 +88,7 @@ export function buildGitHubAuthorizationUrl(state) {
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
+    scope: GITHUB_OAUTH_SCOPE,
     state,
   });
   return `${GITHUB_AUTHORIZE_URL}?${params}`;

--- a/tests/githubOAuthService.test.js
+++ b/tests/githubOAuthService.test.js
@@ -8,6 +8,7 @@ import {
   encryptGitHubSession,
   exchangeGitHubCode,
   getGitHubSession,
+  resolveGitHubRedirectUri,
   resetGitHubSessionsForTests,
 } from "../src/services/githubOAuthService.js";
 
@@ -37,11 +38,30 @@ test("builds GitHub OAuth URL with exact callback state", () => {
   assert.equal(url.origin, "https://github.com");
   assert.equal(url.pathname, "/login/oauth/authorize");
   assert.equal(url.searchParams.get("client_id"), "client-id");
+  assert.equal(
+    url.searchParams.get("redirect_uri"),
+    process.env.GITHUB_REDIRECT_URI,
+  );
+  assert.equal(url.searchParams.get("scope"), "public_repo");
   assert.equal(url.searchParams.get("state"), "state-123");
 });
 
 test("uses the production callback when no redirect variable is set", () => {
   delete process.env.GITHUB_REDIRECT_URI;
+  const url = new URL(buildGitHubAuthorizationUrl("state-123"));
+  assert.equal(
+    url.searchParams.get("redirect_uri"),
+    "https://synchron.foundation/api/github/callback",
+  );
+});
+
+test("falls back to the production callback when the redirect variable is invalid", () => {
+  process.env.GITHUB_REDIRECT_URI = process.env.GITHUB_CLIENT_ID;
+  assert.equal(
+    resolveGitHubRedirectUri(),
+    "https://synchron.foundation/api/github/callback",
+  );
+
   const url = new URL(buildGitHubAuthorizationUrl("state-123"));
   assert.equal(
     url.searchParams.get("redirect_uri"),


### PR DESCRIPTION
## Какво променя

- валидира `GITHUB_REDIRECT_URI` и използва production callback при невалидна стойност;
- заявява минималния `public_repo` OAuth scope за запис в публичното хранилище;
- добавя регресионен тест за грешната стойност, наблюдавана в production.

## Причина

Живият OAuth поток изпращаше Client ID като `redirect_uri`, а без OAuth scope токенът оставаше само за четене.

## Проверка

- `npm test` — 130/130 успешни теста;
- `prettier --check` за двата променени файла;
- diff: само OAuth услугата и тестът ѝ.

PR е оставен като чернова и не задейства deployment преди преглед и сливане.