### PR TITLE
Добави реален health check и видима версия

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -13,13 +13,27 @@ services:
     instance_size_slug: apps-s-1vcpu-0.5gb
     http_port: 8080
     health_check:
+      http_path: /health/ready
+      initial_delay_seconds: 20
+      period_seconds: 10
+      timeout_seconds: 5
+      success_threshold: 1
+      failure_threshold: 3
+    liveness_health_check:
       http_path: /health
+      initial_delay_seconds: 10
+      period_seconds: 10
+      timeout_seconds: 3
+      failure_threshold: 6
     envs:
       - key: NODE_ENV
         value: production
         scope: RUN_TIME
       - key: PORT
         value: "8080"
+        scope: RUN_TIME
+      - key: APP_COMMIT_SHA
+        value: ${_self.COMMIT_HASH}
         scope: RUN_TIME
       - key: OPENSEARCH_HOST
         scope: RUN_TIME

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -1,16 +1,101 @@
 import express from "express";
+import { getOpenSearchClient } from "../config/opensearch.js";
 import { isGitHubOAuthConfigured } from "../services/githubOAuthService.js";
 import { isToolExecutable } from "../tools/capabilityEngine.js";
 import { listTools, registerCoreTools } from "../tools/toolRegistry.js";
 
 const router = express.Router();
+const DEFAULT_READINESS_TIMEOUT_MS = 2_000;
+
+export function getRuntimeVersion(env = process.env) {
+  return {
+    version: env.npm_package_version || "1.0.0",
+    commit: env.APP_COMMIT_SHA || "unknown",
+  };
+}
 
 router.get("/", (req, res) => {
-  res.json({ status: "ok", message: "Health check passed" });
+  res.json({
+    status: "ok",
+    service: "synchron-backend",
+    ...getRuntimeVersion(),
+  });
 });
 
-function hasAllEnvironmentVariables(...names) {
-  return names.every((name) => Boolean(process.env[name]));
+function hasAllEnvironmentVariables(env, ...names) {
+  return names.every((name) => Boolean(env[name]));
+}
+
+async function withTimeout(promise, timeoutMs) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error("READINESS_TIMEOUT")), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function getReadinessStatus({
+  env = process.env,
+  loadOpenSearchClient = getOpenSearchClient,
+  timeoutMs = DEFAULT_READINESS_TIMEOUT_MS,
+} = {}) {
+  const chatAgentReady = hasAllEnvironmentVariables(
+    env,
+    "AGENT_URL",
+    "AGENT_KEY",
+  );
+  let memory = { ready: false, status: "unavailable" };
+
+  try {
+    const client = loadOpenSearchClient();
+    if (client) {
+      const response = await withTimeout(client.cluster.health(), timeoutMs);
+      const clusterStatus = response?.body?.status || response?.status;
+      memory = {
+        ready: Boolean(clusterStatus) && clusterStatus !== "red",
+        status: clusterStatus || "unknown",
+      };
+    }
+  } catch {
+    memory = { ready: false, status: "unavailable" };
+  }
+
+  const ready = chatAgentReady && memory.ready;
+  return {
+    status: ready ? "ready" : "not-ready",
+    ...getRuntimeVersion(env),
+    checks: {
+      chatAgent: {
+        ready: chatAgentReady,
+        status: chatAgentReady ? "configured" : "not-configured",
+      },
+      memory,
+    },
+  };
+}
+
+export function createReadinessHandler(options = {}) {
+  return async function readinessHandler(req, res) {
+    const result = await getReadinessStatus(options);
+    res.status(result.status === "ready" ? 200 : 503).json(result);
+  };
+}
+
+router.get("/ready", createReadinessHandler());
+
+function hasAllProcessEnvironmentVariables(...names) {
+  return hasAllEnvironmentVariables(process.env, ...names);
+}
+
+function resolveToolHealthStatus(tool, configuration = {}) {
+  if (!tool.enabled || !configuration.configured) return "unavailable";
+  if (configuration.authenticated === false) return "degraded";
+  return "healthy";
 }
 
 export function getIntegrationStatus() {
@@ -25,37 +110,34 @@ export function getIntegrationStatus() {
       authenticated: false,
     },
     "google-drive-read": {
-      configured: hasAllEnvironmentVariables(
+      configured: hasAllProcessEnvironmentVariables(
         "GOOGLE_CLIENT_ID",
         "GOOGLE_CLIENT_SECRET",
         "GOOGLE_REDIRECT_URI",
       ),
+      authenticated: false,
     },
     "google-calendar-read": {
-      configured:
-        hasAllEnvironmentVariables(
-          "GOOGLE_CLIENT_ID",
-          "GOOGLE_CLIENT_SECRET",
-          "GOOGLE_REDIRECT_URI",
-        ) ||
-        hasAllEnvironmentVariables(
-          "GOOGLE_CALENDAR_CLIENT_ID",
-          "GOOGLE_CALENDAR_CLIENT_SECRET",
-          "GOOGLE_CALENDAR_REFRESH_TOKEN",
-        ),
-    },
-    "gmail-read": {
-      configured: hasAllEnvironmentVariables(
+      configured: hasAllProcessEnvironmentVariables(
         "GOOGLE_CLIENT_ID",
         "GOOGLE_CLIENT_SECRET",
         "GOOGLE_REDIRECT_URI",
       ),
+      authenticated: false,
+    },
+    "gmail-read": {
+      configured: hasAllProcessEnvironmentVariables(
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "GOOGLE_REDIRECT_URI",
+      ),
+      authenticated: false,
     },
     "openai-web-search": {
       configured: Boolean(process.env.OPENAI_API_KEY),
     },
     "opensearch-memory": {
-      configured: hasAllEnvironmentVariables(
+      configured: hasAllProcessEnvironmentVariables(
         "OPENSEARCH_HOST",
         "OPENSEARCH_PORT",
         "OPENSEARCH_USERNAME",
@@ -66,9 +148,10 @@ export function getIntegrationStatus() {
 
   return {
     status: "ok",
+    ...getRuntimeVersion(),
     core: {
       chatAgent: {
-        configured: hasAllEnvironmentVariables("AGENT_URL", "AGENT_KEY"),
+        configured: hasAllProcessEnvironmentVariables("AGENT_URL", "AGENT_KEY"),
       },
       openai: {
         configured: Boolean(process.env.OPENAI_API_KEY),
@@ -82,7 +165,7 @@ export function getIntegrationStatus() {
       executable: isToolExecutable(tool.id),
       configured: Boolean(configuration[tool.id]?.configured),
       authenticated: configuration[tool.id]?.authenticated,
-      healthStatus: tool.healthStatus,
+      healthStatus: resolveToolHealthStatus(tool, configuration[tool.id]),
     })),
   };
 }

--- a/tests/healthRoutes.test.js
+++ b/tests/healthRoutes.test.js
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import express from "express";
+import request from "supertest";
+
+import {
+  createReadinessHandler,
+  getReadinessStatus,
+  getRuntimeVersion,
+} from "../src/routes/health.js";
+
+test("liveness version exposes the deployed commit without exposing secrets", () => {
+  assert.deepEqual(
+    getRuntimeVersion({
+      npm_package_version: "1.2.3",
+      APP_COMMIT_SHA: "abc123",
+    }),
+    { version: "1.2.3", commit: "abc123" },
+  );
+});
+
+test("readiness requires the chat agent and a healthy OpenSearch cluster", async () => {
+  const result = await getReadinessStatus({
+    env: {
+      AGENT_URL: "https://agent.example",
+      AGENT_KEY: "secret",
+      APP_COMMIT_SHA: "abc123",
+    },
+    loadOpenSearchClient: () => ({
+      cluster: {
+        health: async () => ({ body: { status: "green" } }),
+      },
+    }),
+  });
+
+  assert.equal(result.status, "ready");
+  assert.equal(result.commit, "abc123");
+  assert.equal(result.checks.memory.status, "green");
+});
+
+test("readiness returns 503 when a required dependency is unavailable", async () => {
+  const app = express();
+  app.get(
+    "/health/ready",
+    createReadinessHandler({
+      env: { AGENT_URL: "https://agent.example", AGENT_KEY: "secret" },
+      loadOpenSearchClient: () => null,
+    }),
+  );
+
+  const response = await request(app).get("/health/ready").expect(503);
+  assert.equal(response.body.status, "not-ready");
+  assert.equal(response.body.checks.memory.ready, false);
+});
+
+test("readiness rejects a red OpenSearch cluster", async () => {
+  const result = await getReadinessStatus({
+    env: { AGENT_URL: "https://agent.example", AGENT_KEY: "secret" },
+    loadOpenSearchClient: () => ({
+      cluster: {
+        health: async () => ({ body: { status: "red" } }),
+      },
+    }),
+  });
+
+  assert.equal(result.status, "not-ready");
+  assert.equal(result.checks.memory.status, "red");
+});


### PR DESCRIPTION
## Какво се променя

- запазва лек `/health` за liveness и добавя публикувания Git commit;
- добавя `/health/ready`, който реално проверява конфигурацията на AI агента и състоянието на OpenSearch;
- връща 503, когато основна зависимост не е готова;
- DigitalOcean използва readiness проверката при deployment и отделна liveness проверка за рестарт;
- статусът на инструментите вече се извежда от реалната конфигурация, а не е статично `healthy`;
- добавя автоматични тестове за зелена, червена и недостъпна памет и за commit версията.

## Защо

Старият `/health` винаги връщаше `ok`, дори когато AI агентът или паметта не работят. От сайта също не можеше да се докаже кой commit е публикуван.

## Проверка

- `node --check` за променените JavaScript файлове;
- Prettier проверка — успешно;
- пълният тестов пакет се изпълнява от GitHub Actions.

PR-ът е създаден като чернова до успешни проверки.