### PR TITLE
Добави production dependency security проверка

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run checks
         run: npm test
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high


### PR DESCRIPTION
## Какво се променя

- обновява официалните GitHub Actions до Node 24-базираните `checkout@v5` и `setup-node@v5`;
- след 153-те функционални теста изпълнява `npm audit --omit=dev --audit-level=high`;
- CI вече блокира high или critical уязвимост в зависимостите, които действително се инсталират в DigitalOcean production;
- dev-only предупрежденията остават видими, но не се смесват с production риска.

## Защо

Последният зелен тест показа 22 high предупреждения в целия пакет. DigitalOcean използва `npm ci --omit=dev`, затова отделната production проверка е точната граница за публикувания код.

PR-ът остава чернова до успешна проверка.