### PR TITLE
fix(frontend): зареждай работещия Marked UMD файл

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
     />
-    <script src="https://cdn.jsdelivr.net/npm/marked@18.0.7/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked@18.0.7/lib/marked.umd.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.12/dist/purify.min.js"></script>
   </head>
   <body>

--- a/tests/markdownSecurity.test.js
+++ b/tests/markdownSecurity.test.js
@@ -11,6 +11,10 @@ const rendererSource = await readFile(
   new URL("../public/markdown-renderer.js", import.meta.url),
   "utf8",
 );
+const indexSource = await readFile(
+  new URL("../public/index.html", import.meta.url),
+  "utf8",
+);
 
 function createRenderer() {
   const context = { console };
@@ -59,6 +63,18 @@ test("normal markdown keeps headings, lists, safe links, and code", () => {
     "https://example.com",
   );
   assert.equal(element.querySelector("code")?.textContent, "код");
+});
+
+test("browser loads the pinned Marked UMD build before the safe renderer", () => {
+  const markedPosition = indexSource.indexOf("marked@18.0.7/lib/marked.umd.js");
+  const purifierPosition = indexSource.indexOf(
+    "dompurify@3.4.12/dist/purify.min.js",
+  );
+  const rendererPosition = indexSource.indexOf("/markdown-renderer.js");
+
+  assert.ok(markedPosition >= 0);
+  assert.ok(purifierPosition > markedPosition);
+  assert.ok(rendererPosition > purifierPosition);
 });
 
 test("script elements are removed before insertion", () => {


### PR DESCRIPTION
Follow-up към #80 и #85.

- Поправя фиксирания Marked CDN път към съществуващия UMD build.
- Добавя регресионен тест за точните версии и реда Marked → DOMPurify → safe renderer.

Проверки:
- CDN URL: HTTP 200.
- Markdown security: 8 успешни, 0 неуспешни.
- Пълен пакет: 200 успешни, 0 неуспешни, 1 пропуснат OpenSearch интеграционен тест.