### PR TITLE
Добави регулиране на размера на текста

### DIFF
--- a/public/accessibility.css
+++ b/public/accessibility.css
@@ -1,8 +1,106 @@
-:root[data-font-scale="max"] {
+:root[data-font-level="large"] {
+  --synchron-readable-text: 20px;
+  --synchron-chat-text: 32px;
+  --synchron-input-text: 24px;
+  --synchron-small-text: 17px;
+  --synchron-navigation-text: 20px;
+  --synchron-code-text: 26px;
+  --synchron-context-text: 19px;
+  --synchron-heading-text: 30px;
+  --synchron-card-title: 24px;
+  --synchron-card-description: 19px;
+  --synchron-card-status: 16px;
+  --synchron-icon-text: 24px;
+}
+
+:root[data-font-level="max"],
+:root[data-font-scale="max"]:not([data-font-level]) {
   --synchron-readable-text: 24px;
   --synchron-chat-text: 48px;
   --synchron-input-text: 34px;
   --synchron-small-text: 20px;
+  --synchron-navigation-text: 24px;
+  --synchron-code-text: 36px;
+  --synchron-context-text: 22px;
+  --synchron-heading-text: 36px;
+  --synchron-card-title: 28px;
+  --synchron-card-description: 22px;
+  --synchron-card-status: 18px;
+  --synchron-icon-text: 28px;
+}
+
+:root[data-font-level="ultra"] {
+  --synchron-readable-text: 28px;
+  --synchron-chat-text: 60px;
+  --synchron-input-text: 40px;
+  --synchron-small-text: 22px;
+  --synchron-navigation-text: 28px;
+  --synchron-code-text: 44px;
+  --synchron-context-text: 26px;
+  --synchron-heading-text: 42px;
+  --synchron-card-title: 34px;
+  --synchron-card-description: 26px;
+  --synchron-card-status: 22px;
+  --synchron-icon-text: 32px;
+}
+
+.font-size-control {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 16px;
+  background: #f0f0f0;
+}
+
+.font-size-control-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  font-size: 18px;
+  font-weight: 750;
+}
+
+.font-size-stepper {
+  display: grid;
+  grid-template-columns: 58px minmax(0, 1fr) 58px;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.sidebar-nav .font-size-stepper button {
+  width: 58px;
+  min-width: 58px;
+  min-height: 58px;
+  justify-content: center;
+  padding: 0;
+  border: 2px solid #111;
+  border-radius: 14px;
+  color: #fff;
+  background: #111;
+  font-size: 24px;
+}
+
+.sidebar-nav .font-size-stepper button:disabled {
+  border-color: #aaa;
+  color: #666;
+  background: #ddd;
+  cursor: not-allowed;
+}
+
+#fontSizeLabel {
+  display: grid;
+  place-items: center;
+  min-width: 0;
+  padding: 6px;
+  border: 2px solid #d0d0d0;
+  border-radius: 14px;
+  background: #fff;
+  font-size: 17px;
+  font-weight: 800;
+  line-height: 1.25;
+  text-align: center;
+  overflow-wrap: anywhere;
 }
 
 :root[data-font-scale="max"] body {
@@ -23,7 +121,7 @@
 :root[data-font-scale="max"] .sidebar-nav button,
 :root[data-font-scale="max"] .conversation,
 :root[data-font-scale="max"] .profile-button {
-  font-size: 24px;
+  font-size: var(--synchron-navigation-text);
   line-height: 1.3;
 }
 
@@ -55,9 +153,9 @@
   height: 48px;
 }
 
-:root[data-font-scale="max"] .accessibility-button[aria-pressed="true"] {
-  color: #fff;
-  background: #111;
+:root[data-font-scale="max"] .font-size-control-title,
+:root[data-font-scale="max"] #fontSizeLabel {
+  font-size: var(--synchron-small-text);
 }
 
 :root[data-font-scale="max"] .chat-toolbar {
@@ -66,7 +164,7 @@
 
 :root[data-font-scale="max"] .model-title strong,
 :root[data-font-scale="max"] #agentStatusText {
-  font-size: 24px;
+  font-size: var(--synchron-navigation-text);
 }
 
 :root[data-font-scale="max"] .model-title small {
@@ -93,7 +191,7 @@
 }
 
 :root[data-font-scale="max"] .message.agent :where(code, pre) {
-  font-size: 36px;
+  font-size: var(--synchron-code-text);
   line-height: 1.45;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -102,7 +200,7 @@
 :root[data-font-scale="max"] .message-actions button {
   width: 56px;
   height: 56px;
-  font-size: 24px;
+  font-size: var(--synchron-navigation-text);
 }
 
 :root[data-font-scale="max"] .chat-input-area {
@@ -121,7 +219,7 @@
   width: 58px;
   height: 58px;
   flex-basis: 58px;
-  font-size: 24px;
+  font-size: var(--synchron-navigation-text);
 }
 
 :root[data-font-scale="max"] .composer-note {
@@ -131,13 +229,13 @@
 
 :root[data-font-scale="max"] .statusPanel {
   width: min(640px, calc(100vw - 24px));
-  font-size: 24px;
+  font-size: var(--synchron-readable-text);
 }
 
 :root[data-font-scale="max"] .context-label,
 :root[data-font-scale="max"] .context-value,
 :root[data-font-scale="max"] .log-list {
-  font-size: 22px;
+  font-size: var(--synchron-context-text);
   line-height: 1.4;
 }
 
@@ -150,7 +248,7 @@
 }
 
 :root[data-font-scale="max"] .data-drawer-header h2 {
-  font-size: 36px;
+  font-size: var(--synchron-heading-text);
 }
 
 :root[data-font-scale="max"] .data-drawer-kicker,
@@ -188,28 +286,28 @@
 :root[data-font-scale="max"] .work-center-icon {
   width: 58px;
   height: 58px;
-  font-size: 28px;
+  font-size: var(--synchron-icon-text);
 }
 
 :root[data-font-scale="max"] .work-center-card strong {
-  font-size: 28px;
+  font-size: var(--synchron-card-title);
   line-height: 1.3;
 }
 
 :root[data-font-scale="max"] .work-center-description {
-  font-size: 22px;
+  font-size: var(--synchron-card-description);
   line-height: 1.45;
 }
 
 :root[data-font-scale="max"] .work-center-status {
-  font-size: 18px;
+  font-size: var(--synchron-card-status);
   line-height: 1.35;
   white-space: normal;
 }
 
 :root[data-font-scale="max"] .work-center-close {
   min-height: 70px;
-  font-size: 24px;
+  font-size: var(--synchron-readable-text);
 }
 
 :root[data-font-scale="max"] .work-center-status.warning {
@@ -227,7 +325,7 @@
   }
 
   :root[data-font-scale="max"] .mobile-menu {
-    font-size: 28px;
+    font-size: var(--synchron-icon-text);
   }
 
   :root[data-font-scale="max"] #chatMessages {

--- a/public/accessibility.js
+++ b/public/accessibility.js
@@ -1,23 +1,29 @@
 (() => {
   const STORAGE_KEY = "synchron.ui.fontScale";
   const DEFAULT_MODE = "max";
+  const MODE_ORDER = Object.freeze(["standard", "large", "max", "ultra"]);
   const MODES = Object.freeze({
-    max: {
-      label: "Много едър шрифт",
-      title: "Текстът е много едър. Натисни за стандартен размер.",
-      pressed: true,
-      next: "standard",
-    },
     standard: {
-      label: "Стандартен шрифт",
-      title: "Текстът е стандартен. Натисни за много едър размер.",
-      pressed: false,
-      next: "max",
+      label: "Обикновен · 16 px",
+      pixels: 16,
+    },
+    large: {
+      label: "Едър · 32 px",
+      pixels: 32,
+    },
+    max: {
+      label: "Много едър · 48 px",
+      pixels: 48,
+    },
+    ultra: {
+      label: "Огромен · 60 px",
+      pixels: 60,
     },
   });
 
   const root = document.documentElement;
-  const button = document.getElementById("fontSizeBtn");
+  const decreaseButton = document.getElementById("fontSizeDecreaseBtn");
+  const increaseButton = document.getElementById("fontSizeIncreaseBtn");
   const label = document.getElementById("fontSizeLabel");
 
   function readStoredMode() {
@@ -40,24 +46,47 @@
   function applyMode(mode, { persist = true } = {}) {
     const safeMode = MODES[mode] ? mode : DEFAULT_MODE;
     const settings = MODES[safeMode];
-    root.dataset.fontScale = safeMode;
+    const modeIndex = MODE_ORDER.indexOf(safeMode);
+    root.dataset.fontLevel = safeMode;
+    root.dataset.fontScale = safeMode === "standard" ? "standard" : "max";
 
-    if (button) {
-      button.setAttribute("aria-pressed", String(settings.pressed));
-      button.title = settings.title;
+    if (decreaseButton) {
+      decreaseButton.disabled = modeIndex === 0;
+      decreaseButton.setAttribute("aria-disabled", String(modeIndex === 0));
+    }
+    if (increaseButton) {
+      increaseButton.disabled = modeIndex === MODE_ORDER.length - 1;
+      increaseButton.setAttribute(
+        "aria-disabled",
+        String(modeIndex === MODE_ORDER.length - 1),
+      );
     }
     if (label) label.textContent = settings.label;
     if (persist) storeMode(safeMode);
     return safeMode;
   }
 
+  function stepMode(direction) {
+    const currentIndex = MODE_ORDER.indexOf(currentMode);
+    const nextIndex = Math.min(
+      MODE_ORDER.length - 1,
+      Math.max(0, currentIndex + direction),
+    );
+    currentMode = applyMode(MODE_ORDER[nextIndex]);
+    return currentMode;
+  }
+
   let currentMode = applyMode(readStoredMode());
-  button?.addEventListener("click", () => {
-    currentMode = applyMode(MODES[currentMode].next);
-  });
+  decreaseButton?.addEventListener("click", () => stepMode(-1));
+  increaseButton?.addEventListener("click", () => stepMode(1));
 
   globalThis.SynchronAccessibility = Object.freeze({
-    applyMode,
+    applyMode: (mode, options) => {
+      currentMode = applyMode(mode, options);
+      return currentMode;
+    },
     getMode: () => currentMode,
+    increase: () => stepMode(1),
+    decrease: () => stepMode(-1),
   });
 })();

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="/appshell.css?v=20260728-work-center" />
     <link rel="stylesheet" href="/search.css?v=20260726-search" />
     <link rel="stylesheet" href="/modules.css?v=20260726-modules" />
-    <link rel="stylesheet" href="/accessibility.css?v=20260728-large-text" />
+    <link rel="stylesheet" href="/accessibility.css?v=20260728-font-stepper" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
@@ -52,15 +52,37 @@
             <i class="fa-solid fa-table-cells-large"></i
             ><span>Работен център</span>
           </button>
-          <button
-            id="fontSizeBtn"
-            class="accessibility-button"
-            type="button"
-            aria-pressed="true"
+          <div
+            class="font-size-control"
+            role="group"
+            aria-label="Размер на текста"
           >
-            <i class="fa-solid fa-text-height"></i
-            ><span id="fontSizeLabel">Много едър шрифт</span>
-          </button>
+            <span class="font-size-control-title">
+              <i class="fa-solid fa-text-height"></i>
+              <span>Размер на текста</span>
+            </span>
+            <span class="font-size-stepper">
+              <button
+                id="fontSizeDecreaseBtn"
+                type="button"
+                aria-label="Намали текста"
+                title="Намали текста"
+              >
+                <i class="fa-solid fa-minus"></i>
+              </button>
+              <output id="fontSizeLabel" aria-live="polite">
+                Много едър · 48 px
+              </output>
+              <button
+                id="fontSizeIncreaseBtn"
+                type="button"
+                aria-label="Увеличи текста"
+                title="Увеличи текста"
+              >
+                <i class="fa-solid fa-plus"></i>
+              </button>
+            </span>
+          </div>
           <span class="sidebar-nav-label">Система</span>
           <button id="memoryBtn" type="button">
             <i class="fa-solid fa-brain"></i><span>Памет</span>
@@ -241,7 +263,7 @@
 
     <script src="/markdown-renderer.js?v=20260728-xss"></script>
     <script src="/app.js?v=20260728-xss"></script>
-    <script src="/accessibility.js?v=20260728-large-text"></script>
+    <script src="/accessibility.js?v=20260728-font-stepper"></script>
     <script src="/work-center.js?v=20260728-core-bridge"></script>
     <script src="/google-drive.js?v=20260727-connection-actions"></script>
     <script src="/google-apps.js?v=20260727-connection-actions"></script>

--- a/tests/accessibilityUi.test.js
+++ b/tests/accessibilityUi.test.js
@@ -22,9 +22,9 @@ function createHarness(storedMode = null) {
   const dom = new JSDOM(`<!doctype html>
     <html data-font-scale="max">
       <body>
-        <button id="fontSizeBtn" aria-pressed="true">
-          <span id="fontSizeLabel">Много едър шрифт</span>
-        </button>
+        <button id="fontSizeDecreaseBtn">Намали</button>
+        <output id="fontSizeLabel">Много едър · 48 px</output>
+        <button id="fontSizeIncreaseBtn">Увеличи</button>
       </body>
     </html>`);
   const values = new Map();
@@ -47,31 +47,66 @@ test("very large text is the permanent default", () => {
   const { document } = harness.dom.window;
 
   assert.equal(document.documentElement.dataset.fontScale, "max");
+  assert.equal(document.documentElement.dataset.fontLevel, "max");
   assert.equal(harness.values.get("synchron.ui.fontScale"), "max");
   assert.equal(
-    document.getElementById("fontSizeBtn").getAttribute("aria-pressed"),
-    "true",
+    document.getElementById("fontSizeLabel").textContent,
+    "Много едър · 48 px",
   );
 });
 
-test("font control can switch modes and remembers the selected mode", () => {
+test("plus and minus controls change one level and remember it", () => {
   const harness = createHarness();
   const { document } = harness.dom.window;
+  const decrease = document.getElementById("fontSizeDecreaseBtn");
+  const increase = document.getElementById("fontSizeIncreaseBtn");
 
-  document.getElementById("fontSizeBtn").click();
-  assert.equal(document.documentElement.dataset.fontScale, "standard");
-  assert.equal(harness.values.get("synchron.ui.fontScale"), "standard");
-
-  document.getElementById("fontSizeBtn").click();
+  increase.click();
   assert.equal(document.documentElement.dataset.fontScale, "max");
+  assert.equal(document.documentElement.dataset.fontLevel, "ultra");
+  assert.equal(harness.values.get("synchron.ui.fontScale"), "ultra");
   assert.equal(
     document.getElementById("fontSizeLabel").textContent,
-    "Много едър шрифт",
+    "Огромен · 60 px",
   );
+  assert.equal(increase.disabled, true);
+
+  decrease.click();
+  assert.equal(document.documentElement.dataset.fontLevel, "max");
+  decrease.click();
+  assert.equal(document.documentElement.dataset.fontLevel, "large");
+  assert.equal(harness.values.get("synchron.ui.fontScale"), "large");
 });
 
-test("chat text is exactly three times the former 16px size", () => {
+test("saved level is restored and controls stop at the safe limits", () => {
+  const harness = createHarness("standard");
+  const { document } = harness.dom.window;
+  const decrease = document.getElementById("fontSizeDecreaseBtn");
+
+  assert.equal(document.documentElement.dataset.fontScale, "standard");
+  assert.equal(document.documentElement.dataset.fontLevel, "standard");
+  assert.equal(decrease.disabled, true);
+  assert.equal(
+    document.getElementById("fontSizeLabel").textContent,
+    "Обикновен · 16 px",
+  );
+
+  harness.context.SynchronAccessibility.increase();
+  assert.equal(document.documentElement.dataset.fontScale, "max");
+  assert.equal(document.documentElement.dataset.fontLevel, "large");
+  assert.equal(harness.values.get("synchron.ui.fontScale"), "large");
+});
+
+test("chat offers four readable sizes including 48px and 60px", () => {
+  assert.match(
+    css,
+    /data-font-level="large"[^}]*--synchron-chat-text:\s*32px/u,
+  );
   assert.match(css, /--synchron-chat-text:\s*48px/u);
+  assert.match(
+    css,
+    /data-font-level="ultra"[^}]*--synchron-chat-text:\s*60px/u,
+  );
   assert.match(
     css,
     /\.message\s*\{[^}]*font-size:\s*var\(--synchron-chat-text\)\s*!important/u,
@@ -88,6 +123,8 @@ test("accessibility assets load after the ordinary interface styles", () => {
   assert.ok(accessibilityPosition > modulesPosition);
   assert.ok(accessibilityScriptPosition > appPosition);
   assert.match(html, /<html lang="bg" data-font-scale="max">/u);
+  assert.match(html, /id="fontSizeDecreaseBtn"/u);
+  assert.match(html, /id="fontSizeIncreaseBtn"/u);
 });
 
 test("mobile large-text layout keeps cards and drawers inside the viewport", () => {


### PR DESCRIPTION
## Какво се променя

- заменя единичния превключвател за шрифт с големи бутони **– / +**;
- добавя четири размера за разговора и интерфейса: **16, 32, 48 и 60 px**;
- запазва сегашните **48 px** като начална стойност;
- запомня избрания размер в браузъра;
- блокира бутоните в най-малката и най-голямата граница.

## Защо

Потребителят трябва сам да регулира текста според зрението си, без да губи настройката при ново отваряне.

## Проверки

- 215 успешни теста, 0 неуспешни, 1 пропуснат OpenSearch тест;
- 6/6 специални теста за достъпност;
- `git diff --check` и Prettier са чисти;
- четирите GitHub файла съвпадат с локално тестваните blob SHA;
- production не е променян.

Локалният cloud preview е блокиран от браузърната политика с `ERR_BLOCKED_BY_CLIENT`, затова PR-ът остава draft до облачния CI и визуалната проверка.