### PR TITLE
Поправка на реалната Supabase статус проверка

### DIFF
--- a/src/services/supabaseService.js
+++ b/src/services/supabaseService.js
@@ -66,24 +66,24 @@ export async function checkSupabaseStatus({
   const startedAt = Date.now();
 
   try {
-    const response = await fetchImpl(`${url}/rest/v1/`, {
+    const response = await fetchImpl(`${url}/auth/v1/settings`, {
       method: "GET",
       headers: {
         apikey: publishableKey.trim(),
-        Accept: "application/openapi+json, application/json",
+        Accept: "application/json",
       },
       signal: controller.signal,
     });
     if (!response.ok) {
       throw new SupabaseServiceError(
-        `Supabase Data API върна грешка ${response.status}.`,
+        `Supabase API върна грешка ${response.status}.`,
         502,
         "SUPABASE_UPSTREAM_ERROR",
       );
     }
     return Object.freeze({
       status: "healthy",
-      service: "Supabase Data API",
+      service: "Supabase API",
       responseTimeMs: Date.now() - startedAt,
     });
   } catch (error) {

--- a/tests/supabaseService.test.js
+++ b/tests/supabaseService.test.js
@@ -6,20 +6,21 @@ import {
   SupabaseServiceError,
 } from "../src/services/supabaseService.js";
 
-test("проверява Supabase Data API без да връща ключа", async () => {
+test("проверява Supabase API без да връща ключа", async () => {
   const result = await checkSupabaseStatus({
     projectUrl: "https://project.supabase.co",
     publishableKey: "test-publishable-key",
     fetchImpl: async (url, options) => {
-      assert.equal(url, "https://project.supabase.co/rest/v1/");
+      assert.equal(url, "https://project.supabase.co/auth/v1/settings");
       assert.equal(options.headers.apikey, "test-publishable-key");
+      assert.equal(options.headers.Accept, "application/json");
       assert.equal(options.headers.Authorization, undefined);
       return new Response("{}", { status: 200 });
     },
   });
 
   assert.equal(result.status, "healthy");
-  assert.equal(result.service, "Supabase Data API");
+  assert.equal(result.service, "Supabase API");
   assert.equal("publishableKey" in result, false);
 });
 


### PR DESCRIPTION
## Какво поправя

Supabase спря да връща OpenAPI схемата през публичен ключ. Старият статус адрес връща 401, въпреки че проектът и ключът са валидни.

## Промяна

- проверката използва безопасния `GET /auth/v1/settings` адрес;
- публичният ключ остава само в `apikey` header;
- не се четат и не се променят таблици или данни;
- OpenSearch, AI Core и паметта не са променяни.

## Проверка

- 231 теста: 230 успешни, 0 неуспешни, 1 пропуснат;
- реален тест към проекта SYNCHRON-X: `healthy`.