### PR TITLE
Bridge & Diagnostics: защитен MCP статус и реален smoke test

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -30,8 +30,22 @@ jobs:
           set -euo pipefail
           curl --fail --silent --show-error             --retry 3 --retry-delay 10 --retry-all-errors             --max-time 30             https://synchron.foundation/health             | grep -Eq '"status"[[:space:]]*:[[:space:]]*"ok"'
 
-      - name: Check persistent-memory service
+      - name: Check production readiness
         shell: bash
         run: |
           set -euo pipefail
-          curl --fail --silent --show-error             --retry 3 --retry-delay 10 --retry-all-errors             --max-time 30             https://synchron.foundation/opensearch-status             | grep -Eq '"status"[[:space:]]*:[[:space:]]*"(green|yellow)"'
+          curl --fail --silent --show-error \
+            --retry 3 --retry-delay 10 --retry-all-errors \
+            --max-time 30 \
+            https://synchron.foundation/health/ready \
+            | grep -Eq '"status"[[:space:]]*:[[:space:]]*"ready"'
+
+      - name: Check MCP bridge diagnostics
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            --retry 3 --retry-delay 10 --retry-all-errors \
+            --max-time 30 \
+            https://synchron.foundation/health/bridge \
+            | grep -Eq '"responding"[[:space:]]*:[[:space:]]*true'

--- a/docs/BRIDGE_AND_DIAGNOSTICS.md
+++ b/docs/BRIDGE_AND_DIAGNOSTICS.md
@@ -1,0 +1,41 @@
+# SYNCHRON-X Bridge & Diagnostics
+
+## Какво работи
+
+SYNCHRON-X има MCP Streamable HTTP адрес `/mcp` и четири инструмента само за
+четене:
+
+- `get_personal_context`;
+- `get_project_context`;
+- `list_synchron_conversations`;
+- `get_synchron_conversation`.
+
+Достъпът е ограничен с `MCP_ACCESS_TOKEN`. Токенът не се показва в
+диагностиката, логовете или отговорите.
+
+## Диагностика
+
+`GET /health/bridge` различава:
+
+- `configured` — има валиден сървърен MCP токен;
+- `reachable` — публичният диагностичен маршрут е достижим;
+- `responding` — MCP обработчикът отговаря на `initialize`;
+- `chatgptOAuthReady` — готово ли е поддържано свързване от ChatGPT.
+
+Диагностиката не чете лична памет и не изпълнява AI заявка.
+
+## Важна граница
+
+Статичният bearer токен позволява защитен технически MCP достъп, но не е
+завършен поддържан OAuth поток за лични данни в ChatGPT.
+
+За `chatgptOAuthReady: true` са нужни отделно:
+
+1. OAuth 2.1 authorization server с PKCE;
+2. protected resource metadata;
+3. `securitySchemes` за всеки инструмент;
+4. проверка на issuer, audience, срок и scopes за всеки access token;
+5. реален end-to-end тест от ChatGPT до четирите read инструмента.
+
+Тази стъпка не трябва да се симулира и не трябва да се реализира чрез
+публичен достъп до личната памет.

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -2,6 +2,7 @@ import express from "express";
 import { getOpenSearchClient } from "../config/opensearch.js";
 import { resolveRuntimeVersion } from "../config/runtimeVersion.js";
 import { isGitHubOAuthConfigured } from "../services/githubOAuthService.js";
+import { createMcpRequestHandler } from "../services/mcpReadService.js";
 import { isToolExecutable } from "../tools/capabilityEngine.js";
 import { listTools, registerCoreTools } from "../tools/toolRegistry.js";
 
@@ -93,6 +94,54 @@ export function createReadinessHandler(options = {}) {
 }
 
 router.get("/ready", createReadinessHandler());
+
+export async function getBridgeDiagnosticsStatus({
+  env = process.env,
+  handleMcpRequest = createMcpRequestHandler(),
+} = {}) {
+  const configured =
+    typeof env.MCP_ACCESS_TOKEN === "string" &&
+    env.MCP_ACCESS_TOKEN.length >= 32;
+  let responding = false;
+
+  try {
+    const response = await handleMcpRequest(
+      { jsonrpc: "2.0", id: "diagnostics", method: "initialize" },
+      env.MEMORY_OWNER_ID || "primary-user",
+    );
+    responding = response?.result?.serverInfo?.name === "synchron-x-memory";
+  } catch {
+    responding = false;
+  }
+
+  return {
+    status: configured && responding ? "operational" : "incomplete",
+    ...getRuntimeVersion(env),
+    bridge: {
+      protocol: "mcp-streamable-http",
+      endpoint: "/mcp",
+      configured,
+      reachable: true,
+      responding,
+      readOnly: true,
+      tools: 4,
+      authentication: {
+        mode: "static-bearer",
+        chatgptOAuthReady: false,
+        reason: "oauth-2.1-authorization-server-required",
+      },
+    },
+  };
+}
+
+export function createBridgeDiagnosticsHandler(options = {}) {
+  return async function bridgeDiagnosticsHandler(_req, res) {
+    const result = await getBridgeDiagnosticsStatus(options);
+    res.status(result.status === "operational" ? 200 : 503).json(result);
+  };
+}
+
+router.get("/bridge", createBridgeDiagnosticsHandler());
 
 function hasAllProcessEnvironmentVariables(...names) {
   return hasAllEnvironmentVariables(process.env, ...names);

--- a/tests/healthRoutes.test.js
+++ b/tests/healthRoutes.test.js
@@ -4,7 +4,9 @@ import express from "express";
 import request from "supertest";
 
 import {
+  createBridgeDiagnosticsHandler,
   createReadinessHandler,
+  getBridgeDiagnosticsStatus,
   getReadinessStatus,
   getRuntimeVersion,
 } from "../src/routes/health.js";
@@ -83,4 +85,47 @@ test("readiness rejects a red OpenSearch cluster", async () => {
 
   assert.equal(result.status, "not-ready");
   assert.equal(result.checks.memory.status, "red");
+});
+
+test("bridge diagnostics distinguish configuration, response and ChatGPT OAuth readiness", async () => {
+  const result = await getBridgeDiagnosticsStatus({
+    env: {
+      MCP_ACCESS_TOKEN: "m".repeat(48),
+      APP_COMMIT_SHA: "bridge123",
+    },
+    handleMcpRequest: async () => ({
+      result: { serverInfo: { name: "synchron-x-memory" } },
+    }),
+  });
+
+  assert.equal(result.status, "operational");
+  assert.equal(result.commit, "bridge123");
+  assert.equal(result.bridge.configured, true);
+  assert.equal(result.bridge.reachable, true);
+  assert.equal(result.bridge.responding, true);
+  assert.equal(result.bridge.readOnly, true);
+  assert.equal(result.bridge.authentication.chatgptOAuthReady, false);
+  assert.equal(
+    result.bridge.authentication.reason,
+    "oauth-2.1-authorization-server-required",
+  );
+});
+
+test("bridge diagnostics fail honestly when the token is missing", async () => {
+  const app = express();
+  app.get(
+    "/health/bridge",
+    createBridgeDiagnosticsHandler({
+      env: {},
+      handleMcpRequest: async () => ({
+        result: { serverInfo: { name: "synchron-x-memory" } },
+      }),
+    }),
+  );
+
+  const response = await request(app).get("/health/bridge").expect(503);
+  assert.equal(response.body.status, "incomplete");
+  assert.equal(response.body.bridge.configured, false);
+  assert.equal(response.body.bridge.responding, true);
+  assert.equal(response.body.bridge.authentication.chatgptOAuthReady, false);
 });


### PR DESCRIPTION
## Какво се променя

- добавя публична безопасна диагностика `/health/bridge`;
- различава `configured`, `reachable`, `responding` и реалната OAuth готовност за ChatGPT;
- запазва съществуващия MCP мост само за четене и не излага токени или лични данни;
- поправя production smoke проверката да използва `/health/ready`, вместо защитения `/opensearch-status`;
- добавя отделна проверка на MCP обработчика;
- документира точната оставаща OAuth 2.1 граница.

## Причина

Предишният smoke workflow извикваше owner-защитен адрес без сесия и можеше да отчита фалшив `401`. Съществуващият MCP маршрут работи със статичен bearer token, но това не доказва поддържано ChatGPT OAuth свързване. Диагностиката вече казва честно кое е реално готово.

## Проверка

- `npm test`
- 250 теста: 249 успешни, 0 неуспешни, 1 пропуснат поради липсващ локален production OpenSearch.

## Риск и граници

Не се променят AI Core, паметта, OpenSearch данните или production настройките. PR-ът не симулира OAuth и не отваря анонимен достъп до личната памет.