### PR TITLE
Стабилизирай MCP production диагностиката

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -84,12 +84,12 @@ jobs:
             https://synchron.foundation/health/ready \
             | grep -Eq '"status"[[:space:]]*:[[:space:]]*"ready"'
 
-      - name: Check MCP bridge diagnostics
+      - name: Check MCP status
         shell: bash
         run: |
           set -euo pipefail
           curl --fail --silent --show-error \
             --retry 3 --retry-delay 10 --retry-all-errors \
             --max-time 30 \
-            https://synchron.foundation/health/bridge \
+            https://synchron.foundation/health/mcp-status \
             | grep -Eq '"responding"[[:space:]]*:[[:space:]]*true'

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -98,6 +98,7 @@ router.get("/ready", createReadinessHandler());
 export async function getBridgeDiagnosticsStatus({
   env = process.env,
   handleMcpRequest = createMcpRequestHandler(),
+  timeoutMs = 1_000,
 } = {}) {
   const configured =
     typeof env.MCP_ACCESS_TOKEN === "string" &&
@@ -105,9 +106,12 @@ export async function getBridgeDiagnosticsStatus({
   let responding = false;
 
   try {
-    const response = await handleMcpRequest(
-      { jsonrpc: "2.0", id: "diagnostics", method: "initialize" },
-      env.MEMORY_OWNER_ID || "primary-user",
+    const response = await withTimeout(
+      handleMcpRequest(
+        { jsonrpc: "2.0", id: "diagnostics", method: "initialize" },
+        env.MEMORY_OWNER_ID || "primary-user",
+      ),
+      timeoutMs,
     );
     responding = response?.result?.serverInfo?.name === "synchron-x-memory";
   } catch {
@@ -142,6 +146,7 @@ export function createBridgeDiagnosticsHandler(options = {}) {
 }
 
 router.get("/bridge", createBridgeDiagnosticsHandler());
+router.get("/mcp-status", createBridgeDiagnosticsHandler());
 
 function hasAllProcessEnvironmentVariables(...names) {
   return hasAllEnvironmentVariables(process.env, ...names);

--- a/tests/healthRoutes.test.js
+++ b/tests/healthRoutes.test.js
@@ -129,3 +129,17 @@ test("bridge diagnostics fail honestly when the token is missing", async () => {
   assert.equal(response.body.bridge.responding, true);
   assert.equal(response.body.bridge.authentication.chatgptOAuthReady, false);
 });
+
+test("bridge diagnostics stop a blocked self-check within the configured timeout", async () => {
+  const startedAt = Date.now();
+  const result = await getBridgeDiagnosticsStatus({
+    env: { MCP_ACCESS_TOKEN: "m".repeat(48) },
+    handleMcpRequest: () => new Promise(() => {}),
+    timeoutMs: 10,
+  });
+
+  assert.equal(result.status, "incomplete");
+  assert.equal(result.bridge.configured, true);
+  assert.equal(result.bridge.responding, false);
+  assert.ok(Date.now() - startedAt < 1_000);
+});


### PR DESCRIPTION
## Какво се поправя

- MCP self-check вече има 1-секунден timeout и не може да блокира health заявка;
- добавя се нов публичен безопасен адрес `/health/mcp-status`;
- старият `/health/bridge` остава за съвместимост;
- production smoke проверката използва новия status адрес;
- добавен е тест за блокирал вътрешен MCP self-check.

## Причина

Production run №16 доказа точния публикуван commit, здрав сайт и readiness, но `/health/bridge` връщаше повтарящ се `504`. Повторният run потвърди, че проблемът не е временен рестарт.

## Проверка

- синтактична проверка на `src/routes/health.js`;
- 8/8 целеви health теста успешни;
- след PR GitHub пуска пълния Node.js пакет.

## Риск

Не се променят MCP инструментите, паметта, AI Core, OpenSearch данните или удостоверяването. Променя се само диагностичният self-check и production smoke адресът.