### PR TITLE
Поправи фалшивия pipefail на production smoke

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -58,11 +58,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl --fail --silent --show-error \
+          page="$(curl --fail --silent --show-error \
             --retry 3 --retry-delay 10 --retry-all-errors \
             --max-time 30 \
-            https://synchron.foundation/ \
-            | grep -qi "Synchron"
+            https://synchron.foundation/)"
+          grep -qi "Synchron" <<< "${page}"
 
       - name: Check application health
         shell: bash


### PR DESCRIPTION
## Какво се поправя

Началната страница вече се записва в променлива и едва след това се проверява за `Synchron`.

## Причина

Production run №17 доказа точния публикуван commit `21d84f1`. След това `grep` намери търсения текст и затвори pipe-а, а `curl` върна код 23. При `set -o pipefail` това се отчете като фалшив провал.

## Риск

Променя се само една shell стъпка в GitHub Actions. Сайтът, AI Core, паметта и production данните не се променят.

## Проверка

След merge автоматичният smoke run трябва да провери последователно точния commit, сайта, health, readiness и MCP status.