### PR TITLE
Включи MCP проверката в production readiness

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -88,8 +88,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl --fail --silent --show-error \
+          response="$(curl --fail --silent --show-error \
             --retry 3 --retry-delay 10 --retry-all-errors \
             --max-time 30 \
-            https://synchron.foundation/health/mcp-status \
-            | grep -Eq '"responding"[[:space:]]*:[[:space:]]*true'
+            https://synchron.foundation/health/ready)"
+          printf '%s' "${response}" | node -e '
+            let input = "";
+            process.stdin.on("data", (chunk) => { input += chunk; });
+            process.stdin.on("end", () => {
+              const bridge = JSON.parse(input).checks?.bridge;
+              if (!bridge?.configured || !bridge?.responding) process.exit(1);
+            });
+          '

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -66,6 +66,9 @@ export async function getReadinessStatus({
     memory = { ready: false, status: "unavailable" };
   }
 
+  const bridge = (
+    await getBridgeDiagnosticsStatus({ env, timeoutMs })
+  ).bridge;
   const ready = chatAgentReady && memory.ready;
   return {
     status: ready ? "ready" : "not-ready",
@@ -82,6 +85,7 @@ export async function getReadinessStatus({
         fallbackConfigured: openAiReady && digitalOceanAgentReady,
       },
       memory,
+      bridge,
     },
   };
 }

--- a/tests/healthRoutes.test.js
+++ b/tests/healthRoutes.test.js
@@ -26,6 +26,7 @@ test("readiness requires the chat agent and a healthy OpenSearch cluster", async
     env: {
       AGENT_URL: "https://agent.example",
       AGENT_KEY: "secret",
+      MCP_ACCESS_TOKEN: "m".repeat(48),
       APP_COMMIT_SHA: "abc123",
     },
     loadOpenSearchClient: () => ({
@@ -38,6 +39,8 @@ test("readiness requires the chat agent and a healthy OpenSearch cluster", async
   assert.equal(result.status, "ready");
   assert.equal(result.commit, "abc123");
   assert.equal(result.checks.memory.status, "green");
+  assert.equal(result.checks.bridge.configured, true);
+  assert.equal(result.checks.bridge.responding, true);
 });
 
 test("readiness accepts OpenAI as the primary chat provider", async () => {


### PR DESCRIPTION
## Какво се променя

- `/health/ready` вече връща безопасния MCP статус в `checks.bridge`;
- production smoke проверката използва работещия readiness адрес;
- MCP е успешен само ако production токенът е настроен и вътрешният handler отговаря;
- отделните диагностични маршрути остават за съвместимост.

## Причина

Run №16 и run №18 доказаха, че отделните `/health/bridge` и `/health/mcp-status` маршрути получават `504` по пътя Cloudflare/DigitalOcean. Същевременно `/health/ready` работи надеждно и вече може безопасно да носи същия вътрешен MCP self-check.

## Проверка

- синтактична проверка на health маршрута;
- 8/8 целеви health теста успешни;
- production smoke използва структурирания JSON и изисква едновременно `configured: true` и `responding: true`.

## Риск

Не се променят MCP инструментите, паметта, AI Core, OpenSearch данните или разрешенията.