### PR TITLE
Покажи безопасния MCP статус в production smoke

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -97,6 +97,9 @@ jobs:
             process.stdin.on("data", (chunk) => { input += chunk; });
             process.stdin.on("end", () => {
               const bridge = JSON.parse(input).checks?.bridge;
+              console.log(
+                `MCP configured=${Boolean(bridge?.configured)} responding=${Boolean(bridge?.responding)}`,
+              );
               if (!bridge?.configured || !bridge?.responding) process.exit(1);
             });
           '


### PR DESCRIPTION
## Какво се променя

При неуспешна MCP проверка workflow-ът показва само:

- дали production токенът е конфигуриран;
- дали вътрешният MCP handler отговаря.

Не се показват токени, стойности на променливи, лични данни или други тайни.

## Причина

Run №19 потвърди точния production commit, сайта, health и readiness, но MCP условието отказа. Този ред различава липсваща настройка от кодов проблем.

## Риск

Променя се само диагностичният текст в GitHub Actions.