### PR TITLE
Поправи GitHub OAuth Write върху текущия main

### DIFF
--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -1,7 +1,12 @@
 import express from "express";
 import { getOpenSearchClient } from "../config/opensearch.js";
 import { resolveRuntimeVersion } from "../config/runtimeVersion.js";
-import { isGitHubOAuthConfigured } from "../services/githubOAuthService.js";
+import {
+  getGitHubSession,
+  isAuthorizedGitHubLogin,
+  isGitHubOAuthConfigured,
+  parseGitHubCookies,
+} from "../services/githubOAuthService.js";
 import { createMcpRequestHandler } from "../services/mcpReadService.js";
 import { isToolExecutable } from "../tools/capabilityEngine.js";
 import { listTools, registerCoreTools } from "../tools/toolRegistry.js";
@@ -162,7 +167,7 @@ function resolveToolHealthStatus(tool, configuration = {}) {
   return "healthy";
 }
 
-export function getIntegrationStatus() {
+export function getIntegrationStatus({ githubAuthenticated = false } = {}) {
   registerCoreTools();
   const configuration = {
     "github-read": {
@@ -171,7 +176,7 @@ export function getIntegrationStatus() {
     },
     "github-write": {
       configured: isGitHubOAuthConfigured(),
-      authenticated: false,
+      authenticated: githubAuthenticated,
     },
     "google-drive-read": {
       configured: hasAllProcessEnvironmentVariables(
@@ -250,8 +255,13 @@ export function getIntegrationStatus() {
   };
 }
 
-router.get("/integrations", (req, res) => {
-  res.json(getIntegrationStatus());
+router.get("/integrations", async (req, res) => {
+  const cookies = parseGitHubCookies(req.headers.cookie);
+  const session = await getGitHubSession(cookies.synchron_github_session);
+  const githubAuthenticated = Boolean(
+    session && isAuthorizedGitHubLogin(session.login),
+  );
+  res.json(getIntegrationStatus({ githubAuthenticated }));
 });
 
 export default router;

--- a/src/services/githubOAuthService.js
+++ b/src/services/githubOAuthService.js
@@ -4,6 +4,7 @@ import { getOpenSearchClient } from "../config/opensearch.js";
 const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const GITHUB_USER_URL = "https://api.github.com/user";
+const GITHUB_OAUTH_SCOPE = "public_repo";
 export const DEFAULT_GITHUB_REDIRECT_URI =
   "https://synchron.foundation/api/github/callback";
 const DEFAULT_GITHUB_REPOSITORY =
@@ -111,6 +112,7 @@ export function buildGitHubAuthorizationUrl(state) {
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
+    scope: GITHUB_OAUTH_SCOPE,
     state,
   });
   return `${GITHUB_AUTHORIZE_URL}?${params}`;

--- a/tests/githubOAuthService.test.js
+++ b/tests/githubOAuthService.test.js
@@ -46,7 +46,7 @@ test("builds GitHub OAuth URL with exact callback state", () => {
     url.searchParams.get("redirect_uri"),
     process.env.GITHUB_REDIRECT_URI,
   );
-  assert.equal(url.searchParams.has("scope"), false);
+  assert.equal(url.searchParams.get("scope"), "public_repo");
   assert.equal(url.searchParams.get("state"), "state-123");
 });
 

--- a/tests/integrationHealth.test.js
+++ b/tests/integrationHealth.test.js
@@ -46,7 +46,32 @@ test("integration status reports configuration without exposing secret values", 
     assert.equal(githubWrite.enabled, true);
     assert.equal(githubWrite.executable, true);
     assert.equal(githubWrite.configured, true);
+    assert.equal(githubWrite.authenticated, false);
+    assert.equal(githubWrite.healthStatus, "degraded");
     assert.doesNotMatch(JSON.stringify(status), /secret-/u);
+  } finally {
+    for (const [name, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    resetToolRegistryForTests();
+  }
+});
+
+test("GitHub Write reports the authenticated owner session", () => {
+  const original = Object.fromEntries(
+    ENV_NAMES.map((name) => [name, process.env[name]]),
+  );
+  process.env.GITHUB_CLIENT_ID = "client-id";
+  process.env.GITHUB_CLIENT_SECRET = "client-secret";
+  resetToolRegistryForTests();
+
+  try {
+    const status = getIntegrationStatus({ githubAuthenticated: true });
+    const githubWrite = status.tools.find((tool) => tool.id === "github-write");
+    assert.equal(githubWrite.configured, true);
+    assert.equal(githubWrite.authenticated, true);
+    assert.equal(githubWrite.healthStatus, "healthy");
   } finally {
     for (const [name, value] of Object.entries(original)) {
       if (value === undefined) delete process.env[name];


### PR DESCRIPTION
## Какво се поправя

- GitHub OAuth заявява `public_repo`, нужно за потвърдените write задачи към публичното хранилище.
- `/health/integrations` отчита GitHub Write според реалната разрешена owner OAuth сесия.
- Запазва защитения поток: потвърждение → отделен branch → Pull Request; без автоматично сливане.

## Защо е нов PR

Замества конфликтния PR №100. Промяната е пренесена чисто върху текущия `main` след слетите PR-и №102–№106, без връщане на стар health/MCP код.

## Проверка

- `git diff --check` — успешно
- 255 теста
- 254 успешни
- 0 неуспешни
- 1 пропуснат локален OpenSearch тест поради липса на production credentials

Не се променят production данни, памет, OpenSearch записи или тайни.