### PR TITLE
Добави защитено почистване на слети клонове през MCP моста

### DIFF
--- a/src/services/confirmationService.js
+++ b/src/services/confirmationService.js
@@ -11,7 +11,10 @@ const CONFIRMATION_INDEX =
 
 // Only the OAuth-backed Copilot flow may create GitHub confirmations.
 // Legacy direct write actions are intentionally blocked by default.
-const ALLOWED_ACTIONS = new Set(["github.copilot:start_task"]);
+const ALLOWED_ACTIONS = new Set([
+  "github.copilot:start_task",
+  "github.write:delete_merged_branches",
+]);
 
 // Fields that must never be stored in a confirmation (audit safety)
 const SENSITIVE_PARAM_KEYS = new Set([

--- a/src/services/githubBranchCleanupService.js
+++ b/src/services/githubBranchCleanupService.js
@@ -1,0 +1,145 @@
+import { createHash } from "node:crypto";
+import { getLatestAuthorizedGitHubSession } from "./githubOAuthService.js";
+import { GitHubServiceError } from "./githubService.js";
+
+const DEFAULT_REPOSITORY = "radostinvgeorgiev-commits/sunchron-backend";
+const DEFAULT_API_URL = "https://api.github.com";
+
+function configuredRepository() {
+  return (process.env.GITHUB_REPOSITORY || DEFAULT_REPOSITORY).trim();
+}
+
+function assertAllowedRepository(repository) {
+  if (repository !== configuredRepository()) {
+    throw new GitHubServiceError(
+      "Това GitHub хранилище не е разрешено.",
+      403,
+      "REPOSITORY_NOT_ALLOWED",
+    );
+  }
+}
+
+async function requestGitHub(path, { accessToken, method = "GET" }, fetchImpl) {
+  const apiUrl = (process.env.GITHUB_API_URL || DEFAULT_API_URL).replace(
+    /\/+$/u,
+    "",
+  );
+  const response = await fetchImpl(`${apiUrl}${path}`, {
+    method,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${accessToken}`,
+      "User-Agent": "Synchron-X",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!response.ok && response.status !== 204) {
+    throw new GitHubServiceError(
+      `GitHub върна грешка ${response.status}.`,
+      response.status,
+      "GITHUB_API_ERROR",
+    );
+  }
+  return response.status === 204 ? null : response.json();
+}
+
+async function allPages(path, session, fetchImpl) {
+  const items = [];
+  for (let page = 1; page <= 20; page += 1) {
+    const separator = path.includes("?") ? "&" : "?";
+    const batch = await requestGitHub(
+      `${path}${separator}per_page=100&page=${page}`,
+      session,
+      fetchImpl,
+    );
+    items.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return items;
+}
+
+function branchFingerprint(branches) {
+  return createHash("sha256").update(branches.join("\n")).digest("hex");
+}
+
+export async function buildMergedBranchCleanupPlan({
+  repository = configuredRepository(),
+  fetchImpl = fetch,
+  getSession = getLatestAuthorizedGitHubSession,
+} = {}) {
+  assertAllowedRepository(repository);
+  const session = await getSession();
+  if (!session?.accessToken) {
+    throw new GitHubServiceError(
+      "Липсва активна GitHub owner сесия.",
+      401,
+      "GITHUB_OWNER_SESSION_REQUIRED",
+    );
+  }
+  const encodedRepo = repository.split("/").map(encodeURIComponent).join("/");
+  const [repo, branches, openPulls, closedPulls] = await Promise.all([
+    requestGitHub(`/repos/${encodedRepo}`, session, fetchImpl),
+    allPages(`/repos/${encodedRepo}/branches`, session, fetchImpl),
+    allPages(`/repos/${encodedRepo}/pulls?state=open`, session, fetchImpl),
+    allPages(`/repos/${encodedRepo}/pulls?state=closed`, session, fetchImpl),
+  ]);
+  const openHeads = new Set(openPulls.map((pull) => pull.head?.ref).filter(Boolean));
+  const mergedHeads = new Set(
+    closedPulls
+      .filter((pull) => pull.merged_at && pull.head?.repo?.full_name === repository)
+      .map((pull) => pull.head.ref),
+  );
+  const branchNames = branches
+    .filter(
+      (branch) =>
+        branch.name !== repo.default_branch &&
+        !branch.protected &&
+        mergedHeads.has(branch.name) &&
+        !openHeads.has(branch.name),
+    )
+    .map((branch) => branch.name)
+    .sort();
+  return {
+    repository,
+    defaultBranch: repo.default_branch,
+    branchNames,
+    count: branchNames.length,
+    fingerprint: branchFingerprint(branchNames),
+  };
+}
+
+export async function executeMergedBranchCleanup({
+  repository,
+  branchNames,
+  fingerprint,
+  fetchImpl = fetch,
+  getSession = getLatestAuthorizedGitHubSession,
+}) {
+  const current = await buildMergedBranchCleanupPlan({
+    repository,
+    fetchImpl,
+    getSession,
+  });
+  if (
+    fingerprint !== branchFingerprint(branchNames) ||
+    branchNames.some((name) => !current.branchNames.includes(name))
+  ) {
+    throw new GitHubServiceError(
+      "Списъкът вече не е безопасен. Направи нова проверка.",
+      409,
+      "BRANCH_CLEANUP_PLAN_CHANGED",
+    );
+  }
+  const session = await getSession();
+  const encodedRepo = repository.split("/").map(encodeURIComponent).join("/");
+  const deleted = [];
+  for (const branch of branchNames) {
+    await requestGitHub(
+      `/repos/${encodedRepo}/git/refs/heads/${encodeURIComponent(branch)}`,
+      { ...session, method: "DELETE" },
+      fetchImpl,
+    );
+    deleted.push(branch);
+  }
+  return { repository, deleted, count: deleted.length };
+}

--- a/src/services/githubOAuthService.js
+++ b/src/services/githubOAuthService.js
@@ -295,6 +295,33 @@ export async function hasGitHubSession(id) {
   return Boolean(await getGitHubSession(id));
 }
 
+export async function getLatestAuthorizedGitHubSession() {
+  const cached = [...sessions.values()]
+    .filter((session) => isAuthorizedGitHubLogin(session.login))
+    .sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0))[0];
+  if (cached?.accessToken) return cached;
+
+  const client = getOpenSearchClient();
+  if (!client) return null;
+  const response = await client.search({
+    index: GITHUB_SESSION_INDEX,
+    body: { size: 20, sort: [{ updatedAt: { order: "desc" } }] },
+  });
+  const hits = response.body?.hits?.hits ?? response.hits?.hits ?? [];
+  for (const hit of hits) {
+    try {
+      const session = decryptGitHubSession(hit._source);
+      if (session?.accessToken && isAuthorizedGitHubLogin(session.login)) {
+        sessions.set(hit._id, session);
+        return session;
+      }
+    } catch {
+      // Ignore stale or unreadable sessions and continue fail-closed.
+    }
+  }
+  return null;
+}
+
 export async function disconnectGitHubSession(id) {
   if (id) sessions.delete(id);
   const client = getOpenSearchClient();

--- a/src/services/mcpReadService.js
+++ b/src/services/mcpReadService.js
@@ -5,6 +5,15 @@ import {
   listProfileMemories,
 } from "./memoryService.js";
 import { recordAuditEvent } from "./permissionService.js";
+import {
+  createDurableConfirmation,
+  markDurableConfirmationUsed,
+  validateDurableConfirmation,
+} from "./confirmationService.js";
+import {
+  buildMergedBranchCleanupPlan,
+  executeMergedBranchCleanup,
+} from "./githubBranchCleanupService.js";
 
 export const MCP_PROTOCOL_VERSION = "2025-06-18";
 
@@ -13,6 +22,12 @@ const READ_ONLY_ANNOTATIONS = Object.freeze({
   destructiveHint: false,
   openWorldHint: false,
   idempotentHint: true,
+});
+const DESTRUCTIVE_ANNOTATIONS = Object.freeze({
+  readOnlyHint: false,
+  destructiveHint: true,
+  openWorldHint: true,
+  idempotentHint: false,
 });
 
 export const MCP_TOOLS = Object.freeze([
@@ -61,6 +76,29 @@ export const MCP_TOOLS = Object.freeze([
     },
     annotations: READ_ONLY_ANNOTATIONS,
   },
+  {
+    name: "prepare_github_merged_branch_cleanup",
+    title: "Подготви почистване на слети GitHub клонове",
+    description:
+      "Проверява кои клонове са от слети PR-и, без отворен PR и без защита. Не изтрива нищо; връща точен списък и еднократно потвърждение.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    annotations: READ_ONLY_ANNOTATIONS,
+  },
+  {
+    name: "confirm_github_merged_branch_cleanup",
+    title: "Потвърди изтриването на проверените GitHub клонове",
+    description:
+      "Изтрива само точния предварително проверен списък след еднократно потвърждение и повторна проверка.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        confirmationId: { type: "string", minLength: 1, maxLength: 100 },
+      },
+      required: ["confirmationId"],
+      additionalProperties: false,
+    },
+    annotations: DESTRUCTIVE_ANNOTATIONS,
+  },
 ]);
 
 function textResult(data, summary) {
@@ -88,6 +126,11 @@ export function createMcpRequestHandler({
   listConversations = listConversationSummaries,
   listMessages = listConversationMessages,
   audit = recordAuditEvent,
+  buildCleanupPlan = buildMergedBranchCleanupPlan,
+  executeCleanup = executeMergedBranchCleanup,
+  createConfirmation = createDurableConfirmation,
+  validateConfirmation = validateDurableConfirmation,
+  consumeConfirmation = markDurableConfirmationUsed,
 } = {}) {
   async function callTool(name, args, ownerId) {
     let result;
@@ -120,6 +163,52 @@ export function createMcpRequestHandler({
         { sessionId, items },
         `Прочетени са ${items.length} съобщения от избрания разговор.`,
       );
+    } else if (name === "prepare_github_merged_branch_cleanup") {
+      const plan = await buildCleanupPlan();
+      const confirmation = await createConfirmation({
+        sessionId: ownerId,
+        action: "github.write:delete_merged_branches",
+        resource: {
+          repository: plan.repository,
+          count: plan.count,
+          fingerprint: plan.fingerprint,
+        },
+        params: { branchNames: plan.branchNames },
+      });
+      result = textResult(
+        {
+          ...plan,
+          confirmationId: confirmation.id,
+          expiresAt: new Date(confirmation.expiresAt).toISOString(),
+        },
+        `Намерени са ${plan.count} безопасни за изтриване клона. Нищо не е изтрито.`,
+      );
+    } else if (name === "confirm_github_merged_branch_cleanup") {
+      const confirmationId =
+        typeof args?.confirmationId === "string"
+          ? args.confirmationId.trim()
+          : "";
+      if (!confirmationId) {
+        throw Object.assign(new Error("Липсва confirmationId."), {
+          code: -32602,
+        });
+      }
+      const confirmation = await validateConfirmation(confirmationId, ownerId);
+      if (confirmation.action !== "github.write:delete_merged_branches") {
+        throw Object.assign(new Error("Невалидно потвърждение."), {
+          code: -32602,
+        });
+      }
+      await consumeConfirmation(confirmationId);
+      const cleanup = await executeCleanup({
+        repository: confirmation.resource.repository,
+        branchNames: confirmation.params.branchNames,
+        fingerprint: confirmation.resource.fingerprint,
+      });
+      result = textResult(
+        cleanup,
+        `Изтрити са ${cleanup.count} клона от вече слети Pull Request-и.`,
+      );
     } else {
       throw Object.assign(new Error("Непознат MCP инструмент."), {
         code: -32601,
@@ -128,7 +217,7 @@ export function createMcpRequestHandler({
 
     await audit({
       actor: "chatgpt-mcp",
-      action: "memory.read",
+      action: name.includes("github") ? "github.write" : "memory.read",
       decision: "allow",
       outcome: "succeeded",
       resource: name,

--- a/tests/githubBranchCleanupService.test.js
+++ b/tests/githubBranchCleanupService.test.js
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildMergedBranchCleanupPlan,
+  executeMergedBranchCleanup,
+} from "../src/services/githubBranchCleanupService.js";
+
+const repository = "radostinvgeorgiev-commits/sunchron-backend";
+
+function response(data, status = 200) {
+  return new Response(status === 204 ? null : JSON.stringify(data), { status });
+}
+
+function fixtureFetch(deleted = []) {
+  return async (url, options = {}) => {
+    const parsed = new URL(url);
+    const path = parsed.pathname;
+    if (options.method === "DELETE") {
+      deleted.push(decodeURIComponent(path.split("/").at(-1)));
+      return response(null, 204);
+    }
+    if (path === `/repos/${repository}`) {
+      return response({ default_branch: "main" });
+    }
+    if (path.endsWith("/branches")) {
+      return response([
+        { name: "main", protected: true },
+        { name: "merged-safe", protected: false },
+        { name: "merged-open", protected: false },
+        { name: "protected-merged", protected: true },
+        { name: "never-merged", protected: false },
+      ]);
+    }
+    const state = parsed.searchParams.get("state");
+    if (path.endsWith("/pulls") && state === "open") {
+      return response([{ head: { ref: "merged-open" } }]);
+    }
+    if (path.endsWith("/pulls") && state === "closed") {
+      return response([
+        {
+          merged_at: "2026-07-30T00:00:00Z",
+          head: { ref: "merged-safe", repo: { full_name: repository } },
+        },
+        {
+          merged_at: "2026-07-30T00:00:00Z",
+          head: { ref: "merged-open", repo: { full_name: repository } },
+        },
+        {
+          merged_at: "2026-07-30T00:00:00Z",
+          head: { ref: "protected-merged", repo: { full_name: repository } },
+        },
+      ]);
+    }
+    throw new Error(`Unexpected request: ${url}`);
+  };
+}
+
+test("cleanup plan includes only safe merged branches", async () => {
+  const plan = await buildMergedBranchCleanupPlan({
+    repository,
+    fetchImpl: fixtureFetch(),
+    getSession: async () => ({ accessToken: "owner-token" }),
+  });
+  assert.deepEqual(plan.branchNames, ["merged-safe"]);
+  assert.equal(plan.count, 1);
+  assert.equal(plan.defaultBranch, "main");
+  assert.equal(plan.fingerprint.length, 64);
+});
+
+test("cleanup revalidates the exact plan before deleting", async () => {
+  const deleted = [];
+  const fetchImpl = fixtureFetch(deleted);
+  const getSession = async () => ({ accessToken: "owner-token" });
+  const plan = await buildMergedBranchCleanupPlan({
+    repository,
+    fetchImpl,
+    getSession,
+  });
+  const result = await executeMergedBranchCleanup({
+    repository,
+    branchNames: plan.branchNames,
+    fingerprint: plan.fingerprint,
+    fetchImpl,
+    getSession,
+  });
+  assert.deepEqual(deleted, ["merged-safe"]);
+  assert.equal(result.count, 1);
+});
+
+test("cleanup refuses a changed or forged branch list", async () => {
+  await assert.rejects(
+    executeMergedBranchCleanup({
+      repository,
+      branchNames: ["main"],
+      fingerprint: "invalid",
+      fetchImpl: fixtureFetch(),
+      getSession: async () => ({ accessToken: "owner-token" }),
+    }),
+    (error) => error.code === "BRANCH_CLEANUP_PLAN_CHANGED",
+  );
+});

--- a/tests/mcpReadService.test.js
+++ b/tests/mcpReadService.test.js
@@ -14,7 +14,7 @@ test("MCP token validation is fail-closed and timing-safe compatible", () => {
   assert.equal(isValidMcpToken(`Bearer ${token}`, "short"), false);
 });
 
-test("MCP exposes only four read-only tools", () => {
+test("MCP exposes four read tools and a two-step cleanup flow", () => {
   assert.deepEqual(
     MCP_TOOLS.map((tool) => tool.name),
     [
@@ -22,10 +22,15 @@ test("MCP exposes only four read-only tools", () => {
       "get_project_context",
       "list_synchron_conversations",
       "get_synchron_conversation",
+      "prepare_github_merged_branch_cleanup",
+      "confirm_github_merged_branch_cleanup",
     ],
   );
-  assert.ok(MCP_TOOLS.every((tool) => tool.annotations.readOnlyHint === true));
-  assert.ok(MCP_TOOLS.every((tool) => tool.annotations.destructiveHint === false));
+  const confirm = MCP_TOOLS.find(
+    (tool) => tool.name === "confirm_github_merged_branch_cleanup",
+  );
+  assert.equal(confirm.annotations.readOnlyHint, false);
+  assert.equal(confirm.annotations.destructiveHint, true);
 });
 
 test("MCP reads owner-scoped personal memory and audits the call", async () => {
@@ -77,4 +82,66 @@ test("MCP rejects invalid conversation identifiers without reading", async () =>
   );
   assert.equal(response.error.code, -32602);
   assert.equal(reads, 0);
+});
+
+test("MCP cleanup requires the exact one-time confirmation", async () => {
+  const consumed = [];
+  const handle = createMcpRequestHandler({
+    buildCleanupPlan: async () => ({
+      repository: "radostinvgeorgiev-commits/sunchron-backend",
+      defaultBranch: "main",
+      branchNames: ["merged-safe"],
+      count: 1,
+      fingerprint: "fingerprint",
+    }),
+    createConfirmation: async (data) => ({
+      ...data,
+      id: "confirmation-1",
+      expiresAt: Date.now() + 60_000,
+    }),
+    validateConfirmation: async (id, ownerId) => ({
+      id,
+      sessionId: ownerId,
+      action: "github.write:delete_merged_branches",
+      resource: {
+        repository: "radostinvgeorgiev-commits/sunchron-backend",
+        fingerprint: "fingerprint",
+      },
+      params: { branchNames: ["merged-safe"] },
+    }),
+    consumeConfirmation: async (id) => consumed.push(id),
+    executeCleanup: async ({ branchNames }) => ({
+      deleted: branchNames,
+      count: branchNames.length,
+    }),
+    audit: async () => {},
+  });
+  const prepared = await handle(
+    {
+      jsonrpc: "2.0",
+      id: 9,
+      method: "tools/call",
+      params: {
+        name: "prepare_github_merged_branch_cleanup",
+        arguments: {},
+      },
+    },
+    "primary-user",
+  );
+  assert.equal(prepared.result.structuredContent.confirmationId, "confirmation-1");
+
+  const confirmed = await handle(
+    {
+      jsonrpc: "2.0",
+      id: 10,
+      method: "tools/call",
+      params: {
+        name: "confirm_github_merged_branch_cleanup",
+        arguments: { confirmationId: "confirmation-1" },
+      },
+    },
+    "primary-user",
+  );
+  assert.equal(confirmed.result.structuredContent.count, 1);
+  assert.deepEqual(consumed, ["confirmation-1"]);
 });


### PR DESCRIPTION
## Какво добавя
- MCP команда за read-only преглед на безопасните за почистване клонове
- отделна destructive команда с еднократно server-side потвърждение
- повторна проверка непосредствено преди изтриване
- използване само на разрешената GitHub owner OAuth сесия, без нов GITHUB_TOKEN

## Твърди защити
- никога не включва default/main
- изключва защитени клонове
- изключва клонове с отворен PR
- допуска само клонове от реално слети PR-и в същото хранилище
- отказва изпълнение при променен или подменен списък

## Проверка
- 259 теста общо
- 258 успешни
- 0 неуспешни
- 1 пропуснат, защото локално няма production OpenSearch

Този PR не изтрива клонове и не променя AI Core, Chat или Memory.