### PR TITLE
Поправи връзката на чата с GitHub почистването

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -27,6 +27,9 @@ import {
   parseGitHubCookies,
 } from "../services/githubOAuthService.js";
 import {
+  isMergedBranchCleanupPlanRequest,
+} from "../services/githubBranchCleanupService.js";
+import {
   confirmCopilotTask,
   CopilotTaskError,
   extractCopilotConfirmationId,
@@ -243,7 +246,8 @@ function isExplicitGitHubReadSubtask(subtask, hasGitHubContext) {
 export function detectCapabilityRequests(message) {
   const requests = [];
   const subtasks = splitCapabilitySubtasks(message);
-  const hasGitHubContext = isGitHubReadRequest(message);
+  const hasGitHubContext =
+    isGitHubReadRequest(message) || isMergedBranchCleanupPlanRequest(message);
   const hasGitHubWriteIntent = isGitHubWriteRequest(message);
   let writeTaskReadAdded = false;
   const hasExplicitNumberedChecks =
@@ -338,9 +342,19 @@ export function detectCapabilityRequests(message) {
       /(?:tool\s+registry|capability\s+engine|(?:кои\s+)?инструменти.*регистрирани|регистрирани\s+инструменти|разрешения.*инструмент|чатът.*capability|последно\s+поправен.*проблем)/iu.test(
         subtask,
       );
+    const mergedBranchCleanupPlan =
+      isMergedBranchCleanupPlanRequest(subtask) ||
+      (hasGitHubContext &&
+        (/(?:слет|merged).{0,50}(?:клон|branch)|(?:клон|branch).{0,50}(?:слет|merged)/iu.test(
+          subtask,
+        ) &&
+        /(?:подготви|покажи|намери|изброй|списък|провери|безопасн)/iu.test(
+          subtask,
+        )));
     const wantsGitHubRead =
       !/(?:използва\s+успешно|кои\s+са\s+достъпни)/iu.test(subtask) &&
-      (isGitHubReadRequest(subtask) ||
+      (mergedBranchCleanupPlan ||
+        isGitHubReadRequest(subtask) ||
         (hasGitHubContext && repositoryInspectionSubtask) ||
         (hasGitHubWriteIntent &&
           isExplicitGitHubReadSubtask(subtask, hasGitHubContext)));

--- a/src/services/githubBranchCleanupService.js
+++ b/src/services/githubBranchCleanupService.js
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { createDurableConfirmation } from "./confirmationService.js";
 import { getLatestAuthorizedGitHubSession } from "./githubOAuthService.js";
 import { GitHubServiceError } from "./githubService.js";
 
@@ -60,6 +61,61 @@ async function allPages(path, session, fetchImpl) {
 
 function branchFingerprint(branches) {
   return createHash("sha256").update(branches.join("\n")).digest("hex");
+}
+
+export function isMergedBranchCleanupPlanRequest(message) {
+  const text = typeof message === "string" ? message.trim().toLowerCase() : "";
+  if (!text) return false;
+  const hasBranchTarget = /(?:github|гит[\s-]*хъб|клон|branch)/iu.test(text);
+  const hasMergedConstraint = /(?:слет|merged|pull\s*request|\bpr\b)/iu.test(
+    text,
+  );
+  const asksForSafePlan =
+    /(?:подготви|покажи|намери|изброй|списък|провери|безопасн)/iu.test(text);
+  const forbidsDeletion =
+    /(?:не\s+изтривай|без\s+изтриване|нищо\s+не\s+изтривай)/iu.test(text);
+  return (
+    hasBranchTarget &&
+    hasMergedConstraint &&
+    (asksForSafePlan || forbidsDeletion)
+  );
+}
+
+export async function prepareMergedBranchCleanup({
+  ownerId,
+  buildPlan = buildMergedBranchCleanupPlan,
+  createConfirmation = createDurableConfirmation,
+} = {}) {
+  const cleanOwnerId =
+    typeof ownerId === "string" && ownerId.trim() ? ownerId.trim() : "";
+  if (!cleanOwnerId) {
+    throw new GitHubServiceError(
+      "Липсва удостоверен собственик за GitHub почистването.",
+      401,
+      "GITHUB_OWNER_REQUIRED",
+    );
+  }
+  const plan = await buildPlan();
+  const confirmation = await createConfirmation({
+    sessionId: cleanOwnerId,
+    action: "github.write:delete_merged_branches",
+    resource: {
+      repository: plan.repository,
+      count: plan.count,
+      fingerprint: plan.fingerprint,
+    },
+    params: { branchNames: plan.branchNames },
+  });
+  const branches = plan.branchNames.length
+    ? plan.branchNames.map((name) => `• ${name}`)
+    : ["• Няма клонове, които отговарят на всички защити."];
+  return [
+    `Намерени са ${plan.count} безопасни за изтриване клона от вече слети Pull Request-и:`,
+    ...branches,
+    "",
+    "Нищо не е изтрито.",
+    `За изтриване е нужно отделно еднократно потвърждение: ${confirmation.id}`,
+  ].join("\n");
 }
 
 export async function buildMergedBranchCleanupPlan({

--- a/src/tools/capabilityEngine.js
+++ b/src/tools/capabilityEngine.js
@@ -21,6 +21,10 @@ import {
   searchWeb,
 } from "../services/webSearchService.js";
 import { prepareCopilotTask } from "../services/copilotTaskService.js";
+import {
+  isMergedBranchCleanupPlanRequest,
+  prepareMergedBranchCleanup,
+} from "../services/githubBranchCleanupService.js";
 import { checkSupabaseStatus } from "../services/supabaseService.js";
 import { findToolsByCapability, registerCoreTools } from "./toolRegistry.js";
 
@@ -90,7 +94,12 @@ export function resolveCapability(capability, options = {}) {
 }
 
 const executors = Object.freeze({
-  "github-read": async ({ input }) => answerGitHubReadRequest(input.message),
+  "github-read": async ({ input }) => {
+    if (isMergedBranchCleanupPlanRequest(input.message)) {
+      return prepareMergedBranchCleanup({ ownerId: input.ownerId });
+    }
+    return answerGitHubReadRequest(input.message);
+  },
   "github-write": async ({ input }) => {
     const prepared = await prepareCopilotTask({
       sessionId: input.sessionId,

--- a/tests/chatCapabilityExecution.test.js
+++ b/tests/chatCapabilityExecution.test.js
@@ -74,6 +74,17 @@ test("recognizes common Bulgarian GitHub spellings as a real tool request", () =
   }
 });
 
+test("routes safe merged-branch cleanup planning from chat to GitHub Read", () => {
+  const message =
+    "Подготви безопасен списък за изтриване само на GitHub клоновете от вече слети PR-и. Не изтривай нищо.";
+  const requests = detectCapabilityRequests(message);
+
+  assert.deepEqual(
+    requests.map(({ capability, action }) => ({ capability, action })),
+    [{ capability: "code.read", action: "github.read" }],
+  );
+});
+
 test("разпознава изрична проверка на Supabase", () => {
   assert.deepEqual(
     detectCapabilityRequests("Провери дали Supabase е свързан и работи.").map(

--- a/tests/githubBranchCleanupService.test.js
+++ b/tests/githubBranchCleanupService.test.js
@@ -3,6 +3,8 @@ import test from "node:test";
 import {
   buildMergedBranchCleanupPlan,
   executeMergedBranchCleanup,
+  isMergedBranchCleanupPlanRequest,
+  prepareMergedBranchCleanup,
 } from "../src/services/githubBranchCleanupService.js";
 
 const repository = "radostinvgeorgiev-commits/sunchron-backend";
@@ -98,4 +100,41 @@ test("cleanup refuses a changed or forged branch list", async () => {
     }),
     (error) => error.code === "BRANCH_CLEANUP_PLAN_CHANGED",
   );
+});
+
+test("recognizes a safe merged-branch cleanup plan request", () => {
+  assert.equal(
+    isMergedBranchCleanupPlanRequest(
+      "Подготви безопасен списък за изтриване само на GitHub клоновете от вече слети PR-и. Не изтривай нищо.",
+    ),
+    true,
+  );
+  assert.equal(
+    isMergedBranchCleanupPlanRequest("Покажи последния GitHub commit."),
+    false,
+  );
+});
+
+test("prepares the exact cleanup plan without deleting branches", async () => {
+  const confirmations = [];
+  const output = await prepareMergedBranchCleanup({
+    ownerId: "github:owner",
+    buildPlan: async () => ({
+      repository,
+      defaultBranch: "main",
+      branchNames: ["merged-safe"],
+      count: 1,
+      fingerprint: "fingerprint",
+    }),
+    createConfirmation: async (data) => {
+      confirmations.push(data);
+      return { ...data, id: "confirmation-1" };
+    },
+  });
+
+  assert.match(output, /merged-safe/u);
+  assert.match(output, /Нищо не е изтрито/u);
+  assert.match(output, /confirmation-1/u);
+  assert.equal(confirmations[0].sessionId, "github:owner");
+  assert.deepEqual(confirmations[0].params.branchNames, ["merged-safe"]);
 });


### PR DESCRIPTION
## Какво е поправено

Чатът на SYNCHRON-X вече разпознава заявката за безопасен списък на клонове от слети PR-и и я изпраща към реалния GitHub Read адаптер.

## Причина

Екранът „Инструменти“ показваше работещ GitHub, но детекторът на чат задачи не разпознаваше тази конкретна заявка. Тя стигаше до AI разговора без извикване на GitHub.

## Защита

- подготовката е само за четене;
- `main`, защитени клонове, клонове с отворен PR и несляти клонове остават блокирани;
- връща точен списък и еднократно потвърждение;
- не изтрива нищо.

## Проверки

- 33 целеви теста: успешни;
- синтактични проверки: успешни;
- пълният локален пакет беше блокиран от повреден npm кеш в средата; GitHub Actions трябва да изпълни чистия пълен пакет.