### PR TITLE
Добави пълен DigitalOcean одит само за четене

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -26,9 +26,7 @@ import {
   GitHubOAuthError,
   parseGitHubCookies,
 } from "../services/githubOAuthService.js";
-import {
-  isMergedBranchCleanupPlanRequest,
-} from "../services/githubBranchCleanupService.js";
+import { isMergedBranchCleanupPlanRequest } from "../services/githubBranchCleanupService.js";
 import {
   confirmCopilotTask,
   CopilotTaskError,
@@ -342,7 +340,7 @@ export function detectCapabilityRequests(message) {
       /(?:digitalocean|digital\s*ocean|дигитал\s*океан|дижитал\s*окен)/iu.test(
         subtask,
       ) &&
-      /(?:провери|покажи|статус|работи|деплой|deployment|публикуван|последн)/iu.test(
+      /(?:провери|покажи|статус|работи|деплой|deployment|публикуван|последн|направи|одит|акаунт|ресурс|droplet|сървър|баз|мреж|firewall|защит|разход|billing|storage|volume|snapshot|kubernetes)/iu.test(
         subtask,
       )
     ) {
@@ -369,12 +367,12 @@ export function detectCapabilityRequests(message) {
     const mergedBranchCleanupPlan =
       isMergedBranchCleanupPlanRequest(subtask) ||
       (hasGitHubContext &&
-        (/(?:слет|merged).{0,50}(?:клон|branch)|(?:клон|branch).{0,50}(?:слет|merged)/iu.test(
+        /(?:слет|merged).{0,50}(?:клон|branch)|(?:клон|branch).{0,50}(?:слет|merged)/iu.test(
           subtask,
         ) &&
         /(?:подготви|покажи|намери|изброй|списък|провери|безопасн)/iu.test(
           subtask,
-        )));
+        ));
     const wantsGitHubRead =
       !/(?:използва\s+успешно|кои\s+са\s+достъпни)/iu.test(subtask) &&
       (mergedBranchCleanupPlan ||

--- a/src/services/agentPlannerService.js
+++ b/src/services/agentPlannerService.js
@@ -30,7 +30,7 @@ const PLANNER_INSTRUCTIONS = [
   "- code.read: четене и проверка на разрешеното GitHub хранилище",
   "- code.write: промяна в GitHub; може да е недостъпна и винаги изисква потвърждение",
   "- database.status: проверка дали Supabase е свързан и отговаря",
-  "- infrastructure.digitalocean.read: статус и последни деплои в DigitalOcean App Platform",
+  "- infrastructure.digitalocean.read: статус, деплои и пълен одит само за четене на DigitalOcean ресурсите, сигурността и разходите",
   "- infrastructure.cloudflare.read: статус на Cloudflare зоната и DNS записите",
   "- calendar.read: четене на Google Calendar",
   "- files.read: четене на Google Drive",

--- a/src/services/digitalOceanService.js
+++ b/src/services/digitalOceanService.js
@@ -9,24 +9,39 @@ export class DigitalOceanError extends Error {
   }
 }
 
-function requiredConfig(env = process.env) {
+function requiredToken(env = process.env) {
   const token = env.DIGITALOCEAN_API_TOKEN || env.DIGITALOCEAN_TOKEN;
-  const appId = env.DIGITALOCEAN_APP_ID;
-  if (!token || !appId) {
+  if (!token) {
     throw new DigitalOceanError(
-      "DigitalOcean мостът не е конфигуриран. Нужни са DIGITALOCEAN_API_TOKEN и DIGITALOCEAN_APP_ID.",
+      "DigitalOcean мостът не е конфигуриран. Нужен е DIGITALOCEAN_API_TOKEN.",
       503,
       "DIGITALOCEAN_NOT_CONFIGURED",
+    );
+  }
+  return token;
+}
+
+function requiredAppConfig(env = process.env) {
+  const token = requiredToken(env);
+  const appId = env.DIGITALOCEAN_APP_ID;
+  if (!appId) {
+    throw new DigitalOceanError(
+      "Липсва DIGITALOCEAN_APP_ID за проверката на приложението.",
+      503,
+      "DIGITALOCEAN_APP_NOT_CONFIGURED",
     );
   }
   return { token, appId };
 }
 
 async function request(path, { env = process.env, fetchImpl = fetch } = {}) {
-  const { token } = requiredConfig(env);
+  const token = requiredToken(env);
   const response = await fetchImpl(
     `${env.DIGITALOCEAN_API_URL || DEFAULT_API_URL}${path}`,
-    { headers: { Accept: "application/json", Authorization: `Bearer ${token}` } },
+    {
+      method: "GET",
+      headers: { Accept: "application/json", Authorization: `Bearer ${token}` },
+    },
   );
   if (!response.ok) {
     throw new DigitalOceanError(
@@ -39,10 +54,13 @@ async function request(path, { env = process.env, fetchImpl = fetch } = {}) {
 }
 
 export async function getDigitalOceanAppStatus(options = {}) {
-  const { appId } = requiredConfig(options.env);
+  const { appId } = requiredAppConfig(options.env);
   const [appData, deploymentsData] = await Promise.all([
     request(`/apps/${encodeURIComponent(appId)}`, options),
-    request(`/apps/${encodeURIComponent(appId)}/deployments?page=1&per_page=5`, options),
+    request(
+      `/apps/${encodeURIComponent(appId)}/deployments?page=1&per_page=5`,
+      options,
+    ),
   ]);
   const app = appData.app || {};
   const deployments = (deploymentsData.deployments || []).slice(0, 5);
@@ -74,6 +92,479 @@ export async function getDigitalOceanAppStatus(options = {}) {
   };
 }
 
+const AUDIT_RESOURCES = Object.freeze([
+  ["account", "/account"],
+  ["apps", "/apps?per_page=200"],
+  ["droplets", "/droplets?per_page=200"],
+  ["databases", "/databases?per_page=200"],
+  ["volumes", "/volumes?per_page=200"],
+  ["snapshots", "/snapshots?per_page=200"],
+  ["vpcs", "/vpcs?per_page=200"],
+  ["firewalls", "/firewalls?per_page=200"],
+  ["domains", "/domains?per_page=200"],
+  ["loadBalancers", "/load_balancers?per_page=200"],
+  ["reservedIps", "/reserved_ips?per_page=200"],
+  ["kubernetes", "/kubernetes/clusters?per_page=200"],
+  ["certificates", "/certificates?per_page=200"],
+  ["cdnEndpoints", "/cdn/endpoints?per_page=200"],
+  ["functions", "/functions/namespaces?per_page=200"],
+  ["customImages", "/images?private=true&per_page=200"],
+  ["sshKeys", "/account/keys?per_page=200"],
+  ["tags", "/tags?per_page=200"],
+  ["uptimeChecks", "/uptime/checks?per_page=200"],
+  ["registry", "/registry"],
+  ["projects", "/projects?per_page=200"],
+  ["actions", "/actions?per_page=50"],
+  ["balance", "/customers/my/balance"],
+]);
+
+function safeArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function regionSlug(resource) {
+  return resource?.region?.slug || resource?.region || null;
+}
+
+function mapApp(app) {
+  return {
+    id: app.id,
+    name: app.spec?.name || app.name || "неименувано приложение",
+    region: app.region?.slug || app.region || app.spec?.region || null,
+    tier: app.tier_slug || app.tier || null,
+    liveUrl: app.live_url || null,
+    activeDeploymentPhase: app.active_deployment?.phase || null,
+    inProgressDeploymentPhase: app.in_progress_deployment?.phase || null,
+  };
+}
+
+function mapDroplet(droplet) {
+  return {
+    id: droplet.id,
+    name: droplet.name,
+    status: droplet.status,
+    region: regionSlug(droplet),
+    size: droplet.size_slug || droplet.size?.slug || null,
+    monthlyPrice: droplet.size?.price_monthly ?? null,
+    backupsEnabled: safeArray(droplet.features).includes("backups"),
+    locked: Boolean(droplet.locked),
+    vpcAttached: Boolean(droplet.vpc_uuid),
+  };
+}
+
+function mapDatabase(database) {
+  return {
+    id: database.id,
+    name: database.name,
+    status: database.status,
+    engine: database.engine,
+    version: database.version,
+    region: database.region || null,
+    size: database.size || null,
+    nodeCount: database.num_nodes ?? null,
+    privateNetworkAttached: Boolean(database.private_network_uuid),
+  };
+}
+
+function mapVolume(volume) {
+  return {
+    id: volume.id,
+    name: volume.name,
+    sizeGigabytes: volume.size_gigabytes,
+    region: regionSlug(volume),
+    filesystemType: volume.filesystem_type || null,
+    attachedDroplets: safeArray(volume.droplet_ids).length,
+  };
+}
+
+function mapSnapshot(snapshot) {
+  return {
+    id: snapshot.id,
+    name: snapshot.name,
+    resourceType: snapshot.resource_type,
+    sizeGigabytes: snapshot.size_gigabytes,
+    regions: safeArray(snapshot.regions),
+    createdAt: snapshot.created_at,
+  };
+}
+
+function mapVpc(vpc) {
+  return {
+    id: vpc.id,
+    name: vpc.name,
+    region: vpc.region || null,
+    isDefault: Boolean(vpc.default),
+    createdAt: vpc.created_at,
+  };
+}
+
+function mapFirewall(firewall) {
+  return {
+    id: firewall.id,
+    name: firewall.name,
+    status: firewall.status,
+    attachedDroplets: safeArray(firewall.droplet_ids).length,
+    tags: safeArray(firewall.tags),
+    inboundRules: safeArray(firewall.inbound_rules).length,
+    outboundRules: safeArray(firewall.outbound_rules).length,
+  };
+}
+
+function mapDomain(domain) {
+  return {
+    name: domain.name,
+    ttl: domain.ttl ?? null,
+    zoneFileAvailable: Boolean(domain.zone_file),
+  };
+}
+
+function mapLoadBalancer(loadBalancer) {
+  return {
+    id: loadBalancer.id,
+    name: loadBalancer.name,
+    status: loadBalancer.status,
+    region: regionSlug(loadBalancer),
+    attachedDroplets: safeArray(loadBalancer.droplet_ids).length,
+  };
+}
+
+function mapReservedIp(reservedIp) {
+  return {
+    region: regionSlug(reservedIp),
+    assigned: Boolean(reservedIp.droplet),
+    projectId: reservedIp.project_id || null,
+  };
+}
+
+function mapKubernetesCluster(cluster) {
+  return {
+    id: cluster.id,
+    name: cluster.name,
+    region: cluster.region || null,
+    version: cluster.version || null,
+    status: cluster.status?.state || cluster.status || null,
+    nodePools: safeArray(cluster.node_pools).length,
+  };
+}
+
+function mapCertificate(certificate) {
+  return {
+    id: certificate.id,
+    name: certificate.name,
+    state: certificate.state || null,
+    type: certificate.type || null,
+    notAfter: certificate.not_after || null,
+  };
+}
+
+function mapCdnEndpoint(endpoint) {
+  return {
+    id: endpoint.id,
+    origin: endpoint.origin || null,
+    ttl: endpoint.ttl ?? null,
+    certificateId: endpoint.certificate_id || null,
+    createdAt: endpoint.created_at || null,
+  };
+}
+
+function mapFunctionNamespace(namespace) {
+  return {
+    namespace: namespace.namespace || namespace.label || null,
+    region: namespace.region || null,
+    createdAt: namespace.created_at || null,
+  };
+}
+
+function mapCustomImage(image) {
+  return {
+    id: image.id,
+    name: image.name,
+    status: image.status || null,
+    type: image.type || null,
+    regions: safeArray(image.regions),
+    sizeGigabytes: image.size_gigabytes ?? null,
+    createdAt: image.created_at || null,
+  };
+}
+
+function mapSshKey(key) {
+  return {
+    id: key.id,
+    name: key.name,
+    fingerprint: key.fingerprint || null,
+  };
+}
+
+function mapTag(tag) {
+  return {
+    name: tag.name,
+    resourceCount: tag.resources
+      ? Object.values(tag.resources).reduce(
+          (total, resource) => total + Number(resource?.count || 0),
+          0,
+        )
+      : 0,
+  };
+}
+
+function mapUptimeCheck(check) {
+  return {
+    id: check.id,
+    name: check.name,
+    type: check.type || null,
+    enabled: check.enabled !== false,
+    regions: safeArray(check.regions),
+  };
+}
+
+function mapProject(project) {
+  return {
+    id: project.id,
+    name: project.name,
+    purpose: project.purpose || null,
+    environment: project.environment || null,
+    isDefault: Boolean(project.is_default),
+  };
+}
+
+function mapAction(action) {
+  return {
+    id: action.id,
+    status: action.status,
+    type: action.type,
+    resourceType: action.resource_type || null,
+    region: regionSlug(action),
+    startedAt: action.started_at,
+    completedAt: action.completed_at,
+  };
+}
+
+function buildFindings(audit) {
+  const findings = [];
+  const dropletsWithoutBackups = audit.droplets.filter(
+    (droplet) => !droplet.backupsEnabled,
+  );
+  if (dropletsWithoutBackups.length) {
+    findings.push({
+      severity: "warning",
+      code: "DROPLETS_WITHOUT_BACKUPS",
+      message: `${dropletsWithoutBackups.length} Droplet(а) са без включени автоматични backups.`,
+    });
+  }
+  const unhealthyDroplets = audit.droplets.filter(
+    (droplet) => droplet.status !== "active",
+  );
+  if (unhealthyDroplets.length) {
+    findings.push({
+      severity: "warning",
+      code: "DROPLETS_NOT_ACTIVE",
+      message: `${unhealthyDroplets.length} Droplet(а) не са със статус active.`,
+    });
+  }
+  if (audit.droplets.length && !audit.firewalls.length) {
+    findings.push({
+      severity: "warning",
+      code: "NO_CLOUD_FIREWALLS",
+      message: "Има Droplets, но няма открити Cloud Firewalls.",
+    });
+  }
+  const unattachedVolumes = audit.volumes.filter(
+    (volume) => volume.attachedDroplets === 0,
+  );
+  if (unattachedVolumes.length) {
+    findings.push({
+      severity: "info",
+      code: "UNATTACHED_VOLUMES",
+      message: `${unattachedVolumes.length} volume(а) не са свързани към Droplet.`,
+    });
+  }
+  const inactiveApps = audit.apps.filter(
+    (app) =>
+      app.activeDeploymentPhase &&
+      !["ACTIVE", "SUPERSEDED"].includes(app.activeDeploymentPhase),
+  );
+  if (inactiveApps.length) {
+    findings.push({
+      severity: "warning",
+      code: "APPS_NOT_ACTIVE",
+      message: `${inactiveApps.length} приложение(я) нямат активен успешен deployment.`,
+    });
+  }
+  const failedActions = audit.actions.filter(
+    (action) => action.status === "errored",
+  );
+  if (failedActions.length) {
+    findings.push({
+      severity: "warning",
+      code: "RECENT_FAILED_ACTIONS",
+      message: `${failedActions.length} от последните действия са завършили с грешка.`,
+    });
+  }
+  const invalidCertificates = audit.certificates.filter(
+    (certificate) =>
+      certificate.state && !["verified", "pending"].includes(certificate.state),
+  );
+  if (invalidCertificates.length) {
+    findings.push({
+      severity: "warning",
+      code: "CERTIFICATES_NOT_VERIFIED",
+      message: `${invalidCertificates.length} сертификат(а) не са verified.`,
+    });
+  }
+  const disabledUptimeChecks = audit.uptimeChecks.filter(
+    (check) => !check.enabled,
+  );
+  if (disabledUptimeChecks.length) {
+    findings.push({
+      severity: "info",
+      code: "UPTIME_CHECKS_DISABLED",
+      message: `${disabledUptimeChecks.length} uptime проверка(и) са изключени.`,
+    });
+  }
+  if (!findings.length) {
+    findings.push({
+      severity: "ok",
+      code: "NO_OBVIOUS_RISKS",
+      message: "Не са открити очевидни проблеми в наличните данни.",
+    });
+  }
+  return findings;
+}
+
+export async function getDigitalOceanAccountAudit(options = {}) {
+  requiredToken(options.env);
+  const settled = await Promise.all(
+    AUDIT_RESOURCES.map(async ([name, path]) => {
+      try {
+        return [name, { ok: true, data: await request(path, options) }];
+      } catch (error) {
+        return [
+          name,
+          {
+            ok: false,
+            error: {
+              code: error?.code || "DIGITALOCEAN_UPSTREAM_ERROR",
+              status: error?.status || 502,
+              message: error?.message || "Неизвестна грешка.",
+            },
+          },
+        ];
+      }
+    }),
+  );
+  const successfulRequests = settled.filter(([, result]) => result.ok).length;
+  if (!successfulRequests) {
+    const firstFailure = settled.find(([, result]) => !result.ok)?.[1]?.error;
+    throw new DigitalOceanError(
+      firstFailure?.message || "DigitalOcean API не върна достъпни данни.",
+      firstFailure?.status || 502,
+      firstFailure?.code || "DIGITALOCEAN_UPSTREAM_ERROR",
+    );
+  }
+  const results = Object.fromEntries(settled);
+  const read = (name, key) =>
+    results[name]?.ok ? safeArray(results[name].data?.[key]) : [];
+  const account = results.account?.ok
+    ? results.account.data?.account || {}
+    : {};
+  const balance = results.balance?.ok ? results.balance.data || {} : {};
+  const audit = {
+    checkedAt: new Date().toISOString(),
+    account: {
+      status: account.status || null,
+      emailVerified:
+        typeof account.email_verified === "boolean"
+          ? account.email_verified
+          : null,
+      dropletLimit: account.droplet_limit ?? null,
+      volumeLimit: account.volume_limit ?? null,
+    },
+    billing: {
+      currency: balance.currency || null,
+      monthToDateUsage: balance.month_to_date_usage || null,
+      accountBalance: balance.account_balance || null,
+      monthToDateBalance: balance.month_to_date_balance || null,
+      generatedAt: balance.generated_at || null,
+    },
+    apps: read("apps", "apps").map(mapApp),
+    droplets: read("droplets", "droplets").map(mapDroplet),
+    databases: read("databases", "databases").map(mapDatabase),
+    volumes: read("volumes", "volumes").map(mapVolume),
+    snapshots: read("snapshots", "snapshots").map(mapSnapshot),
+    vpcs: read("vpcs", "vpcs").map(mapVpc),
+    firewalls: read("firewalls", "firewalls").map(mapFirewall),
+    domains: read("domains", "domains").map(mapDomain),
+    loadBalancers: read("loadBalancers", "load_balancers").map(mapLoadBalancer),
+    reservedIps: read("reservedIps", "reserved_ips").map(mapReservedIp),
+    kubernetes: read("kubernetes", "kubernetes").map(mapKubernetesCluster),
+    certificates: read("certificates", "certificates").map(mapCertificate),
+    cdnEndpoints: read("cdnEndpoints", "endpoints").map(mapCdnEndpoint),
+    functions: read("functions", "namespaces").map(mapFunctionNamespace),
+    customImages: read("customImages", "images").map(mapCustomImage),
+    sshKeys: read("sshKeys", "ssh_keys").map(mapSshKey),
+    tags: read("tags", "tags").map(mapTag),
+    uptimeChecks: read("uptimeChecks", "checks").map(mapUptimeCheck),
+    registry:
+      results.registry?.ok && results.registry.data?.registry
+        ? {
+            name: results.registry.data.registry.name || null,
+            region: results.registry.data.registry.region || null,
+            storageUsageBytes:
+              results.registry.data.registry.storage_usage_bytes ?? null,
+            storageUsageUpdatedAt:
+              results.registry.data.registry.storage_usage_bytes_updated_at ||
+              null,
+          }
+        : null,
+    projects: read("projects", "projects").map(mapProject),
+    actions: read("actions", "actions").map(mapAction),
+    unavailable: settled
+      .filter(([, result]) => !result.ok)
+      .map(([resource, result]) => ({
+        resource,
+        status: result.error.status,
+        message: result.error.message,
+      })),
+  };
+  audit.findings = buildFindings(audit);
+  return audit;
+}
+
+export function formatDigitalOceanAudit(audit) {
+  const counts = [
+    `приложения ${audit.apps.length}`,
+    `Droplets ${audit.droplets.length}`,
+    `бази ${audit.databases.length}`,
+    `volumes ${audit.volumes.length}`,
+    `snapshots ${audit.snapshots.length}`,
+    `VPC ${audit.vpcs.length}`,
+    `firewalls ${audit.firewalls.length}`,
+    `домейни ${audit.domains.length}`,
+    `load balancers ${audit.loadBalancers.length}`,
+    `Kubernetes ${audit.kubernetes.length}`,
+    `сертификати ${audit.certificates.length}`,
+    `CDN ${audit.cdnEndpoints.length}`,
+    `Functions ${audit.functions.length}`,
+    `custom images ${audit.customImages.length}`,
+    `uptime проверки ${audit.uptimeChecks.length}`,
+  ].join(", ");
+  const billing =
+    audit.billing.monthToDateUsage || audit.billing.accountBalance
+      ? `Разход този месец: ${audit.billing.monthToDateUsage || "няма данни"} ${audit.billing.currency || ""}; баланс: ${audit.billing.accountBalance || "няма данни"} ${audit.billing.currency || ""}.`
+      : "Разходи: няма достъпни данни.";
+  return [
+    "DigitalOcean — пълен одит само за четене.",
+    `Акаунт: ${audit.account.status || "неизвестен статус"}.`,
+    `Ресурси: ${counts}.`,
+    billing,
+    "Находки:",
+    ...audit.findings.map((finding) => `• ${finding.message}`),
+    audit.unavailable.length
+      ? `Непроверени секции: ${audit.unavailable.map(({ resource }) => resource).join(", ")}.`
+      : "Всички заявени секции са проверени.",
+  ].join("\n");
+}
+
 export function formatDigitalOceanStatus(status) {
   const active = status.activeDeployment;
   return [
@@ -84,5 +575,7 @@ export function formatDigitalOceanStatus(status) {
       : "Няма текущ деплой.",
     status.liveUrl ? `Адрес: ${status.liveUrl}` : null,
     `Последни деплои: ${status.deployments.length}.`,
-  ].filter(Boolean).join("\n");
+  ]
+    .filter(Boolean)
+    .join("\n");
 }

--- a/src/services/mcpReadService.js
+++ b/src/services/mcpReadService.js
@@ -15,7 +15,9 @@ import {
   executeMergedBranchCleanup,
 } from "./githubBranchCleanupService.js";
 import {
+  formatDigitalOceanAudit,
   formatDigitalOceanStatus,
+  getDigitalOceanAccountAudit,
   getDigitalOceanAppStatus,
 } from "./digitalOceanService.js";
 import {
@@ -44,7 +46,11 @@ export const MCP_TOOLS = Object.freeze([
     title: "Прочети личния контекст",
     description:
       "Прочита проверените лични факти за Радко от постоянната памет на SYNCHRON-X. Използвай само когато са нужни за текущия въпрос.",
-    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
     annotations: READ_ONLY_ANNOTATIONS,
   },
   {
@@ -52,7 +58,11 @@ export const MCP_TOOLS = Object.freeze([
     title: "Прочети контекста на проекта",
     description:
       "Прочита проверените факти за NOVARIUM / SYNCHRON-X. Не ги смесвай с личните факти за Радко.",
-    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
     annotations: READ_ONLY_ANNOTATIONS,
   },
   {
@@ -89,7 +99,23 @@ export const MCP_TOOLS = Object.freeze([
     title: "Провери DigitalOcean приложението",
     description:
       "Показва статуса на SYNCHRON-X в DigitalOcean App Platform и последните деплои. Не променя нищо.",
-    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    annotations: READ_ONLY_ANNOTATIONS,
+  },
+  {
+    name: "get_digitalocean_account_audit",
+    title: "Направи пълен DigitalOcean одит",
+    description:
+      "Проверява само за четене приложения, Droplets, бази, storage, мрежи, firewalls, домейни, разходи и последни действия. Не връща тайни и не променя нищо.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
     annotations: READ_ONLY_ANNOTATIONS,
   },
   {
@@ -97,7 +123,11 @@ export const MCP_TOOLS = Object.freeze([
     title: "Провери Cloudflare и DNS",
     description:
       "Показва статуса на Cloudflare зоната и DNS записите. Не променя нищо.",
-    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
     annotations: READ_ONLY_ANNOTATIONS,
   },
   {
@@ -105,7 +135,11 @@ export const MCP_TOOLS = Object.freeze([
     title: "Подготви почистване на слети GitHub клонове",
     description:
       "Проверява кои клонове са от слети PR-и, без отворен PR и без защита. Не изтрива нищо; връща точен списък и еднократно потвърждение.",
-    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
     annotations: READ_ONLY_ANNOTATIONS,
   },
   {
@@ -134,15 +168,20 @@ function textResult(data, summary) {
 
 function safeLimit(value, fallback = 20) {
   const parsed = Number(value);
-  return Number.isInteger(parsed) ? Math.min(Math.max(parsed, 1), 50) : fallback;
+  return Number.isInteger(parsed)
+    ? Math.min(Math.max(parsed, 1), 50)
+    : fallback;
 }
 
 export function isValidMcpToken(header, expectedToken) {
-  if (typeof expectedToken !== "string" || expectedToken.length < 32) return false;
+  if (typeof expectedToken !== "string" || expectedToken.length < 32)
+    return false;
   if (typeof header !== "string" || !header.startsWith("Bearer ")) return false;
   const supplied = Buffer.from(header.slice(7), "utf8");
   const expected = Buffer.from(expectedToken, "utf8");
-  return supplied.length === expected.length && timingSafeEqual(supplied, expected);
+  return (
+    supplied.length === expected.length && timingSafeEqual(supplied, expected)
+  );
 }
 
 export function createMcpRequestHandler({
@@ -156,6 +195,7 @@ export function createMcpRequestHandler({
   validateConfirmation = validateDurableConfirmation,
   consumeConfirmation = markDurableConfirmationUsed,
   getDigitalOceanStatus = getDigitalOceanAppStatus,
+  getDigitalOceanAudit = getDigitalOceanAccountAudit,
   getCloudflareStatus = getCloudflareZoneStatus,
 } = {}) {
   async function callTool(name, args, ownerId) {
@@ -182,7 +222,9 @@ export function createMcpRequestHandler({
       const sessionId =
         typeof args?.sessionId === "string" ? args.sessionId.trim() : "";
       if (!sessionId || sessionId.length > 160) {
-        throw Object.assign(new Error("Невалиден sessionId."), { code: -32602 });
+        throw Object.assign(new Error("Невалиден sessionId."), {
+          code: -32602,
+        });
       }
       const items = await listMessages(sessionId, undefined, ownerId);
       result = textResult(
@@ -192,6 +234,9 @@ export function createMcpRequestHandler({
     } else if (name === "get_digitalocean_app_status") {
       const status = await getDigitalOceanStatus();
       result = textResult(status, formatDigitalOceanStatus(status));
+    } else if (name === "get_digitalocean_account_audit") {
+      const auditReport = await getDigitalOceanAudit();
+      result = textResult(auditReport, formatDigitalOceanAudit(auditReport));
     } else if (name === "get_cloudflare_zone_status") {
       const status = await getCloudflareStatus();
       result = textResult(status, formatCloudflareStatus(status));

--- a/src/tools/capabilityEngine.js
+++ b/src/tools/capabilityEngine.js
@@ -27,7 +27,9 @@ import {
 } from "../services/githubBranchCleanupService.js";
 import { checkSupabaseStatus } from "../services/supabaseService.js";
 import {
+  formatDigitalOceanAudit,
   formatDigitalOceanStatus,
+  getDigitalOceanAccountAudit,
   getDigitalOceanAppStatus,
 } from "../services/digitalOceanService.js";
 import {
@@ -164,8 +166,15 @@ const executors = Object.freeze({
       "OpenSearch остава постоянната AI памет.",
     ].join("\n");
   },
-  "digitalocean-read": async () =>
-    formatDigitalOceanStatus(await getDigitalOceanAppStatus()),
+  "digitalocean-read": async ({ input }) => {
+    const wantsFullAudit =
+      /(?:пълен|цял|одит|акаунт|ресурс|droplet|сървър|баз|мреж|firewall|защит|разход|billing|storage|volume|snapshot|kubernetes)/iu.test(
+        input.message || "",
+      );
+    return wantsFullAudit
+      ? formatDigitalOceanAudit(await getDigitalOceanAccountAudit())
+      : formatDigitalOceanStatus(await getDigitalOceanAppStatus());
+  },
   "cloudflare-read": async () =>
     formatCloudflareStatus(await getCloudflareZoneStatus()),
   "opensearch-memory": async ({ capability, input }) => {

--- a/tests/infrastructureBridges.test.js
+++ b/tests/infrastructureBridges.test.js
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  getDigitalOceanAccountAudit,
   getDigitalOceanAppStatus,
+  formatDigitalOceanAudit,
   formatDigitalOceanStatus,
 } from "../src/services/digitalOceanService.js";
 import {
@@ -36,8 +38,133 @@ test("DigitalOcean bridge reads app and deployment status without writes", async
   assert.equal(status.activeDeployment.phase, "ACTIVE");
   assert.match(formatDigitalOceanStatus(status), /sunchron-backend/u);
   assert.equal(calls.length, 2);
-  assert.ok(calls.every((call) => !call.options.method || call.options.method === "GET"));
+  assert.ok(
+    calls.every(
+      (call) => !call.options.method || call.options.method === "GET",
+    ),
+  );
   assert.doesNotMatch(JSON.stringify(status), /secret/u);
+});
+
+test("DigitalOcean full audit reads account resources without writes or secrets", async () => {
+  const calls = [];
+  const fetchImpl = async (url, options) => {
+    const path = new URL(String(url)).pathname;
+    calls.push({ path, options });
+    if (path === "/v2/account") {
+      return Response.json({
+        account: {
+          status: "active",
+          email_verified: true,
+          droplet_limit: 10,
+          volume_limit: 10,
+        },
+      });
+    }
+    if (path === "/v2/apps") {
+      return Response.json({
+        apps: [
+          {
+            id: "app-1",
+            spec: { name: "sunchron-backend" },
+            active_deployment: { phase: "ACTIVE" },
+          },
+        ],
+      });
+    }
+    if (path === "/v2/droplets") {
+      return Response.json({
+        droplets: [
+          {
+            id: 1,
+            name: "api",
+            status: "active",
+            features: [],
+            size_slug: "s-1vcpu-1gb",
+            region: { slug: "fra1" },
+          },
+        ],
+      });
+    }
+    if (path === "/v2/databases") {
+      return Response.json({
+        databases: [
+          {
+            id: "db-1",
+            name: "memory",
+            status: "online",
+            engine: "opensearch",
+            region: "fra1",
+          },
+        ],
+      });
+    }
+    if (path === "/v2/volumes") {
+      return Response.json({
+        volumes: [
+          {
+            id: "vol-1",
+            name: "data",
+            size_gigabytes: 10,
+            droplet_ids: [],
+            region: { slug: "fra1" },
+          },
+        ],
+      });
+    }
+    if (path === "/v2/firewalls") {
+      return Response.json({ firewalls: [] });
+    }
+    if (path === "/v2/actions") {
+      return Response.json({
+        actions: [{ id: 1, status: "errored", type: "deploy" }],
+      });
+    }
+    if (path === "/v2/customers/my/balance") {
+      return Response.json({
+        month_to_date_usage: "12.34",
+        account_balance: "0.00",
+        currency: "EUR",
+      });
+    }
+    if (path === "/v2/registry") {
+      return Response.json({ registry: null });
+    }
+    const keyByPath = {
+      "/v2/snapshots": "snapshots",
+      "/v2/vpcs": "vpcs",
+      "/v2/domains": "domains",
+      "/v2/load_balancers": "load_balancers",
+      "/v2/reserved_ips": "reserved_ips",
+      "/v2/kubernetes/clusters": "kubernetes",
+      "/v2/certificates": "certificates",
+      "/v2/cdn/endpoints": "endpoints",
+      "/v2/functions/namespaces": "namespaces",
+      "/v2/images": "images",
+      "/v2/account/keys": "ssh_keys",
+      "/v2/tags": "tags",
+      "/v2/uptime/checks": "checks",
+      "/v2/projects": "projects",
+    };
+    return Response.json({ [keyByPath[path]]: [] });
+  };
+  const audit = await getDigitalOceanAccountAudit({
+    env: { DIGITALOCEAN_API_TOKEN: "secret" },
+    fetchImpl,
+  });
+  assert.equal(audit.account.status, "active");
+  assert.equal(audit.apps.length, 1);
+  assert.equal(audit.droplets.length, 1);
+  assert.equal(audit.databases[0].engine, "opensearch");
+  assert.match(formatDigitalOceanAudit(audit), /пълен одит/u);
+  assert.match(
+    formatDigitalOceanAudit(audit),
+    /без включени автоматични backups/u,
+  );
+  assert.equal(audit.unavailable.length, 0);
+  assert.equal(calls.length, 23);
+  assert.ok(calls.every((call) => call.options.method === "GET"));
+  assert.doesNotMatch(JSON.stringify(audit), /secret/u);
 });
 
 test("Cloudflare bridge reads zone and DNS without writes", async () => {
@@ -71,7 +198,11 @@ test("Cloudflare bridge reads zone and DNS without writes", async () => {
   assert.equal(status.status, "active");
   assert.match(formatCloudflareStatus(status), /CNAME/u);
   assert.equal(calls.length, 2);
-  assert.ok(calls.every((call) => !call.options.method || call.options.method === "GET"));
+  assert.ok(
+    calls.every(
+      (call) => !call.options.method || call.options.method === "GET",
+    ),
+  );
   assert.doesNotMatch(JSON.stringify(status), /secret/u);
 });
 
@@ -80,9 +211,12 @@ test("chat routes infrastructure status requests to the bridges", () => {
     detectCapabilityRequests(
       "Провери статуса на DigitalOcean и покажи DNS записите в Cloudflare.",
     ).map(({ capability }) => capability),
-    [
-      "infrastructure.digitalocean.read",
-      "infrastructure.cloudflare.read",
-    ],
+    ["infrastructure.digitalocean.read", "infrastructure.cloudflare.read"],
+  );
+  assert.deepEqual(
+    detectCapabilityRequests(
+      "Направи пълен одит на целия DigitalOcean акаунт, ресурсите, разходите и сигурността.",
+    ).map(({ capability }) => capability),
+    ["infrastructure.digitalocean.read"],
   );
 });

--- a/tests/mcpReadService.test.js
+++ b/tests/mcpReadService.test.js
@@ -23,6 +23,7 @@ test("MCP exposes read tools and a two-step cleanup flow", () => {
       "list_synchron_conversations",
       "get_synchron_conversation",
       "get_digitalocean_app_status",
+      "get_digitalocean_account_audit",
       "get_cloudflare_zone_status",
       "prepare_github_merged_branch_cleanup",
       "confirm_github_merged_branch_cleanup",
@@ -33,6 +34,11 @@ test("MCP exposes read tools and a two-step cleanup flow", () => {
   );
   assert.equal(confirm.annotations.readOnlyHint, false);
   assert.equal(confirm.annotations.destructiveHint, true);
+  const digitalOceanAudit = MCP_TOOLS.find(
+    (tool) => tool.name === "get_digitalocean_account_audit",
+  );
+  assert.equal(digitalOceanAudit.annotations.readOnlyHint, true);
+  assert.equal(digitalOceanAudit.annotations.destructiveHint, false);
 });
 
 test("MCP reads owner-scoped personal memory and audits the call", async () => {
@@ -53,7 +59,10 @@ test("MCP reads owner-scoped personal memory and audits the call", async () => {
     },
     "primary-user",
   );
-  assert.equal(response.result.structuredContent.items[0].fact, "Живея във Варна");
+  assert.equal(
+    response.result.structuredContent.items[0].fact,
+    "Живея във Варна",
+  );
   assert.deepEqual(calls[0][1], {
     scope: "personal",
     ownerId: "primary-user",
@@ -130,7 +139,10 @@ test("MCP cleanup requires the exact one-time confirmation", async () => {
     },
     "primary-user",
   );
-  assert.equal(prepared.result.structuredContent.confirmationId, "confirmation-1");
+  assert.equal(
+    prepared.result.structuredContent.confirmationId,
+    "confirmation-1",
+  );
 
   const confirmed = await handle(
     {


### PR DESCRIPTION
## Какво се променя

- разширява DigitalOcean моста от статус на едно приложение до одит на акаунта;
- проверява приложения, Droplets, бази, storage, мрежи, firewalls, домейни, load balancers, Kubernetes, сертификати, CDN, Functions, custom images, SSH ключове, tags, uptime, проекти, последни действия и разходи;
- използва само GET заявки и не връща токена, IP адреси, database credentials или други тайни;
- маршрутизира заявки за „пълен одит“ от чата и добавя отделен read-only MCP инструмент.

## Проверки

- `node --test tests/infrastructureBridges.test.js tests/mcpReadService.test.js` — 9/9 успешни;
- синтактичните проверки са успешни;
- `git diff --check` е чист;
- пълният локален пакет е частично блокиран от липсващи стари тестови зависимости (`jsdom`, `express-rate-limit`, `dompurify`), затова GitHub Actions трябва да потвърди чистия пълен пакет.

Production не се променя от този PR, докато не бъде слят.