### PR TITLE
Поправи мобилния чат и копирането

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -879,6 +879,7 @@ function createAssistantTurn(text = "", showActions = true) {
   actions.innerHTML = `
         <button type="button" data-action="copy" title="Копирай" aria-label="Копирай">
             <i class="fa-regular fa-copy"></i>
+            <span class="action-label">Копирай</span>
         </button>
         <button type="button" data-action="speak" title="Прочети на глас" aria-label="Прочети на глас">
             <i class="fa-solid fa-volume-high"></i>
@@ -1179,6 +1180,7 @@ function appendMessage(role, text, image = null) {
   actions.innerHTML = `
         <button type="button" data-action="copy" title="Копирай" aria-label="Копирай">
             <i class="fa-regular fa-copy"></i>
+            <span class="action-label">Копирай</span>
         </button>
     `;
 

--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,10 @@
     <link rel="stylesheet" href="/modules.css?v=20260726-modules" />
     <link rel="stylesheet" href="/accessibility.css?v=20260728-font-stepper" />
     <link rel="stylesheet" href="/task-journal.css?v=20260728-task-journal" />
-    <link rel="stylesheet" href="/synchron-vision.css?v=20260729-vision" />
+    <link
+      rel="stylesheet"
+      href="/synchron-vision.css?v=20260730-mobile-layout"
+    />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
@@ -283,7 +286,7 @@
     </main>
 
     <script src="/markdown-renderer.js?v=20260728-xss"></script>
-    <script src="/app.js?v=20260728-xss"></script>
+    <script src="/app.js?v=20260730-mobile-copy"></script>
     <script src="/accessibility.js?v=20260728-font-stepper"></script>
     <script src="/work-center.js?v=20260728-task-journal"></script>
     <script src="/task-journal.js?v=20260728-task-journal"></script>
@@ -291,6 +294,6 @@
     <script src="/google-apps.js?v=20260727-connection-actions"></script>
     <script src="/search.js?v=20260726-search"></script>
     <script src="/modules.js?v=20260726-modules"></script>
-    <script src="/synchron-vision.js?v=20260729-vision"></script>
+    <script src="/synchron-vision.js?v=20260730-mobile-layout"></script>
   </body>
 </html>

--- a/public/synchron-vision.css
+++ b/public/synchron-vision.css
@@ -193,6 +193,8 @@ input:focus-visible {
 .message {
   color: var(--sx-ink) !important;
   letter-spacing: -0.012em;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .message.user {
@@ -220,6 +222,10 @@ input:focus-visible {
 .message-actions button {
   border-radius: 12px !important;
   color: var(--sx-muted) !important;
+}
+
+.message-actions .action-label {
+  display: none;
 }
 
 .typing-indicator {
@@ -384,7 +390,8 @@ input:focus-visible {
   }
 
   #chatMessages {
-    padding: 24px 16px 160px !important;
+    padding: 24px 16px calc(var(--sx-mobile-occupied-height, 230px) + 24px) !important;
+    scroll-padding-bottom: calc(var(--sx-mobile-occupied-height, 230px) + 24px);
   }
 
   .composer-wrap {
@@ -397,9 +404,43 @@ input:focus-visible {
     background: linear-gradient(to top, #fbfaf6 72%, transparent) !important;
   }
 
+  .search-mode-bar {
+    width: 100%;
+    margin-bottom: 7px;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .search-mode-bar::-webkit-scrollbar {
+    display: none;
+  }
+
+  .search-mode {
+    flex: 0 0 auto;
+    min-height: 42px;
+  }
+
   .chat-input-area {
     min-height: 62px !important;
     border-radius: 22px !important;
+  }
+
+  .message-actions button[data-action="copy"] {
+    width: auto !important;
+    min-width: 112px;
+    height: 46px !important;
+    padding: 0 14px;
+    gap: 8px;
+    border: 1px solid var(--sx-line);
+    background: rgba(255, 255, 255, 0.72);
+    font-size: 16px;
+    font-weight: 800;
+  }
+
+  .message-actions button[data-action="copy"] .action-label {
+    display: inline;
   }
 
   .composer-note {

--- a/public/synchron-vision.js
+++ b/public/synchron-vision.js
@@ -1,4 +1,46 @@
 const commandBar = document.querySelector(".mobile-command-bar");
+const composer = document.querySelector(".composer-wrap");
+const root = document.documentElement;
+const mobileLayout = globalThis.matchMedia?.("(max-width: 900px)");
+
+function updateMobileOccupiedHeight() {
+  if (!mobileLayout?.matches || !composer || !commandBar) {
+    root.style.removeProperty("--sx-mobile-occupied-height");
+    return;
+  }
+
+  const occupiedHeight =
+    composer.getBoundingClientRect().height +
+    commandBar.getBoundingClientRect().height;
+  root.style.setProperty(
+    "--sx-mobile-occupied-height",
+    `${Math.ceil(occupiedHeight)}px`,
+  );
+}
+
+function scheduleMobileLayoutUpdate() {
+  if (typeof globalThis.requestAnimationFrame === "function") {
+    globalThis.requestAnimationFrame(updateMobileOccupiedHeight);
+    return;
+  }
+  updateMobileOccupiedHeight();
+}
+
+if (typeof globalThis.ResizeObserver === "function") {
+  const mobileChromeObserver = new globalThis.ResizeObserver(
+    scheduleMobileLayoutUpdate,
+  );
+  if (composer) mobileChromeObserver.observe(composer);
+  if (commandBar) mobileChromeObserver.observe(commandBar);
+}
+
+mobileLayout?.addEventListener?.("change", scheduleMobileLayoutUpdate);
+globalThis.visualViewport?.addEventListener?.(
+  "resize",
+  scheduleMobileLayoutUpdate,
+);
+globalThis.addEventListener?.("orientationchange", scheduleMobileLayoutUpdate);
+scheduleMobileLayoutUpdate();
 
 function activateCommand(command) {
   if (!commandBar) return;

--- a/tests/synchronVisionUi.test.js
+++ b/tests/synchronVisionUi.test.js
@@ -33,6 +33,22 @@ test("the visual layer preserves the readable text controls and safe drawers", a
   assert.match(css, /prefers-reduced-motion/u);
 });
 
+test("mobile chat content clears the measured composer and command bar", async () => {
+  const [css, script, app] = await Promise.all([
+    readFile(new URL("../public/synchron-vision.css", import.meta.url), "utf8"),
+    readFile(new URL("../public/synchron-vision.js", import.meta.url), "utf8"),
+    readFile(new URL("../public/app.js", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(css, /--sx-mobile-occupied-height/u);
+  assert.match(css, /scroll-padding-bottom/u);
+  assert.match(script, /ResizeObserver/u);
+  assert.match(script, /composer\.getBoundingClientRect\(\)\.height/u);
+  assert.match(script, /commandBar\.getBoundingClientRect\(\)\.height/u);
+  assert.match(css, /user-select:\s*text/u);
+  assert.match(app, /class="action-label">Копирай<\/span>/u);
+});
+
 test("the chat shows live autonomous task progress", async () => {
   const [script, css] = await Promise.all([
     readFile(new URL("../public/app.js", import.meta.url), "utf8"),


### PR DESCRIPTION
## Какво се променя

- долното отстояние на чата вече следва реалната височина на полето и мобилната навигация;
- последният отговор и действията му не остават под бутоните;
- текстът може да се маркира директно на телефон;
- бутонът за копиране има ясен надпис;
- режимите над полето се побират чрез хоризонтално превъртане при тесен екран.

## Проверка

- 4/4 целеви UI теста минават;
- JavaScript syntax check минава;
- Prettier и `git diff --check` минават;
- пълният локален пакет не стартира поради повреден временен npm кеш, затова сливането изчаква чистия GitHub Actions резултат.