### PR TITLE
Поправи мобилния край и изясни DigitalOcean одита

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="/task-journal.css?v=20260728-task-journal" />
     <link
       rel="stylesheet"
-      href="/synchron-vision.css?v=20260730-mobile-layout"
+      href="/synchron-vision.css?v=20260730-mobile-layout-v2"
     />
     <link
       rel="stylesheet"
@@ -294,6 +294,6 @@
     <script src="/google-apps.js?v=20260727-connection-actions"></script>
     <script src="/search.js?v=20260726-search"></script>
     <script src="/modules.js?v=20260726-modules"></script>
-    <script src="/synchron-vision.js?v=20260730-mobile-layout"></script>
+    <script src="/synchron-vision.js?v=20260730-mobile-layout-v2"></script>
   </body>
 </html>

--- a/public/synchron-vision.css
+++ b/public/synchron-vision.css
@@ -390,8 +390,16 @@ input:focus-visible {
   }
 
   #chatMessages {
-    padding: 24px 16px calc(var(--sx-mobile-occupied-height, 230px) + 24px) !important;
+    padding: 24px 16px !important;
     scroll-padding-bottom: calc(var(--sx-mobile-occupied-height, 230px) + 24px);
+  }
+
+  #chatMessages::after {
+    content: "";
+    width: 100%;
+    min-height: calc(var(--sx-mobile-occupied-height, 230px) + 24px);
+    flex: 0 0 calc(var(--sx-mobile-occupied-height, 230px) + 24px);
+    pointer-events: none;
   }
 
   .composer-wrap {

--- a/public/synchron-vision.js
+++ b/public/synchron-vision.js
@@ -1,5 +1,6 @@
 const commandBar = document.querySelector(".mobile-command-bar");
 const composer = document.querySelector(".composer-wrap");
+const chatMessages = document.getElementById("chatMessages");
 const root = document.documentElement;
 const mobileLayout = globalThis.matchMedia?.("(max-width: 900px)");
 
@@ -9,13 +10,35 @@ function updateMobileOccupiedHeight() {
     return;
   }
 
-  const occupiedHeight =
-    composer.getBoundingClientRect().height +
-    commandBar.getBoundingClientRect().height;
+  const distanceFromBottom = chatMessages
+    ? chatMessages.scrollHeight -
+      chatMessages.clientHeight -
+      chatMessages.scrollTop
+    : Number.POSITIVE_INFINITY;
+  const composerRect = composer.getBoundingClientRect();
+  const commandBarRect = commandBar.getBoundingClientRect();
+  const viewportBottom =
+    globalThis.visualViewport?.offsetTop + globalThis.visualViewport?.height ||
+    globalThis.innerHeight;
+  const occupiedHeight = Math.max(
+    composerRect.height + commandBarRect.height,
+    viewportBottom - Math.min(composerRect.top, commandBarRect.top),
+  );
   root.style.setProperty(
     "--sx-mobile-occupied-height",
-    `${Math.ceil(occupiedHeight)}px`,
+    `${Math.ceil(occupiedHeight + 20)}px`,
   );
+
+  if (chatMessages && distanceFromBottom <= 80) {
+    const keepLastAnswerVisible = () => {
+      chatMessages.scrollTop = chatMessages.scrollHeight;
+    };
+    if (typeof globalThis.requestAnimationFrame === "function") {
+      globalThis.requestAnimationFrame(keepLastAnswerVisible);
+    } else {
+      keepLastAnswerVisible();
+    }
+  }
 }
 
 function scheduleMobileLayoutUpdate() {

--- a/src/services/digitalOceanService.js
+++ b/src/services/digitalOceanService.js
@@ -341,6 +341,13 @@ function mapAction(action) {
 
 function buildFindings(audit) {
   const findings = [];
+  if (audit.account.emailVerified === false) {
+    findings.push({
+      severity: "warning",
+      code: "ACCOUNT_EMAIL_NOT_VERIFIED",
+      message: "Имейлът на DigitalOcean акаунта не е потвърден.",
+    });
+  }
   const dropletsWithoutBackups = audit.droplets.filter(
     (droplet) => !droplet.backupsEnabled,
   );
@@ -390,6 +397,26 @@ function buildFindings(audit) {
       message: `${inactiveApps.length} приложение(я) нямат активен успешен deployment.`,
     });
   }
+  const unhealthyDatabases = audit.databases.filter(
+    (database) => database.status && database.status !== "online",
+  );
+  if (unhealthyDatabases.length) {
+    findings.push({
+      severity: "warning",
+      code: "DATABASES_NOT_ONLINE",
+      message: `${unhealthyDatabases.length} управлявана база не е със статус online.`,
+    });
+  }
+  const unassignedReservedIps = audit.reservedIps.filter(
+    (reservedIp) => !reservedIp.assigned,
+  );
+  if (unassignedReservedIps.length) {
+    findings.push({
+      severity: "info",
+      code: "UNASSIGNED_RESERVED_IPS",
+      message: `${unassignedReservedIps.length} Reserved IP адрес(а) не са свързани към Droplet.`,
+    });
+  }
   const failedActions = audit.actions.filter(
     (action) => action.status === "errored",
   );
@@ -425,7 +452,8 @@ function buildFindings(audit) {
     findings.push({
       severity: "ok",
       code: "NO_OBVIOUS_RISKS",
-      message: "Не са открити очевидни проблеми в наличните данни.",
+      message:
+        "Автоматичната проверка не откри предупреждения в достъпните полета. Това не доказва, че няма други проблеми.",
     });
   }
   return findings;
@@ -531,6 +559,7 @@ export async function getDigitalOceanAccountAudit(options = {}) {
 }
 
 export function formatDigitalOceanAudit(audit) {
+  const checkedSections = AUDIT_RESOURCES.length - audit.unavailable.length;
   const counts = [
     `приложения ${audit.apps.length}`,
     `Droplets ${audit.droplets.length}`,
@@ -553,8 +582,9 @@ export function formatDigitalOceanAudit(audit) {
       ? `Разход този месец: ${audit.billing.monthToDateUsage || "няма данни"} ${audit.billing.currency || ""}; баланс: ${audit.billing.accountBalance || "няма данни"} ${audit.billing.currency || ""}.`
       : "Разходи: няма достъпни данни.";
   return [
-    "DigitalOcean — пълен одит само за четене.",
+    "DigitalOcean — преглед на ресурсите само за четене.",
     `Акаунт: ${audit.account.status || "неизвестен статус"}.`,
+    `Покритие: проверени ${checkedSections} от ${AUDIT_RESOURCES.length} заявени секции.`,
     `Ресурси: ${counts}.`,
     billing,
     "Находки:",
@@ -562,6 +592,8 @@ export function formatDigitalOceanAudit(audit) {
     audit.unavailable.length
       ? `Непроверени секции: ${audit.unavailable.map(({ resource }) => resource).join(", ")}.`
       : "Всички заявени секции са проверени.",
+    "Ограничение: това е автоматичен преглед на данните от DigitalOcean API, а не доказателство, че приложението, архивите, тайните и всички настройки за сигурност са правилни.",
+    "Не са направени промени.",
   ].join("\n");
 }
 

--- a/tests/infrastructureBridges.test.js
+++ b/tests/infrastructureBridges.test.js
@@ -156,11 +156,13 @@ test("DigitalOcean full audit reads account resources without writes or secrets"
   assert.equal(audit.apps.length, 1);
   assert.equal(audit.droplets.length, 1);
   assert.equal(audit.databases[0].engine, "opensearch");
-  assert.match(formatDigitalOceanAudit(audit), /пълен одит/u);
+  assert.match(formatDigitalOceanAudit(audit), /преглед на ресурсите/u);
+  assert.match(formatDigitalOceanAudit(audit), /проверени 23 от 23/u);
   assert.match(
     formatDigitalOceanAudit(audit),
     /без включени автоматични backups/u,
   );
+  assert.match(formatDigitalOceanAudit(audit), /Не са направени промени/u);
   assert.equal(audit.unavailable.length, 0);
   assert.equal(calls.length, 23);
   assert.ok(calls.every((call) => call.options.method === "GET"));

--- a/tests/synchronVisionUi.test.js
+++ b/tests/synchronVisionUi.test.js
@@ -42,9 +42,11 @@ test("mobile chat content clears the measured composer and command bar", async (
 
   assert.match(css, /--sx-mobile-occupied-height/u);
   assert.match(css, /scroll-padding-bottom/u);
+  assert.match(css, /#chatMessages::after/u);
   assert.match(script, /ResizeObserver/u);
-  assert.match(script, /composer\.getBoundingClientRect\(\)\.height/u);
-  assert.match(script, /commandBar\.getBoundingClientRect\(\)\.height/u);
+  assert.match(script, /composerRect\.height/u);
+  assert.match(script, /commandBarRect\.height/u);
+  assert.match(script, /chatMessages\.scrollTop = chatMessages\.scrollHeight/u);
   assert.match(css, /user-select:\s*text/u);
   assert.match(app, /class="action-label">Копирай<\/span>/u);
 });


### PR DESCRIPTION
## Какво променя

- добавя реален долен ограничител, за да не се скриват последният текст и бутонът „Копирай“ под фиксираните мобилни ленти;
- запазва последния отговор видим при промяна на височината и iPhone viewport;
- обновява версиите на мобилните CSS/JS файлове;
- представя DigitalOcean резултата като автоматичен преглед на ресурсите, с ясно покритие и ограничения;
- добавя проверки за непотвърден акаунт, база извън `online` и несвързани Reserved IP адреси.

## Защо

На iPhone долните ленти продължаваха да закриват края на дълъг отговор. Одитът също можеше да звучи по-категорично от данните, които DigitalOcean API реално доказва.

## Проверки

- 8/8 целеви теста успешни;
- `node --check` успешен;
- Prettier успешен;
- пълният локален пакет е ограничен от липсващи зависимости в работната среда; GitHub Actions трябва да направи чистата окончателна проверка.

Не се променят AI Core, памет, бази, тайни или DigitalOcean ресурси.