### PR TITLE
Зареди мобилната поправка без стар Cloudflare кеш

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,10 +18,7 @@
     <link rel="stylesheet" href="/modules.css?v=20260726-modules" />
     <link rel="stylesheet" href="/accessibility.css?v=20260728-font-stepper" />
     <link rel="stylesheet" href="/task-journal.css?v=20260728-task-journal" />
-    <link
-      rel="stylesheet"
-      href="/synchron-vision.css?v=20260730-mobile-layout-v2"
-    />
+    <link rel="stylesheet" href="/assets/20260730-v2/synchron-vision.css" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
@@ -294,6 +291,6 @@
     <script src="/google-apps.js?v=20260727-connection-actions"></script>
     <script src="/search.js?v=20260726-search"></script>
     <script src="/modules.js?v=20260726-modules"></script>
-    <script src="/synchron-vision.js?v=20260730-mobile-layout-v2"></script>
+    <script src="/assets/20260730-v2/synchron-vision.js"></script>
   </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -54,7 +54,10 @@ app.use((_req, res, next) => {
       "manifest-src 'self'",
     ].join("; "),
   );
-  res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+  res.setHeader(
+    "Strict-Transport-Security",
+    "max-age=31536000; includeSubDomains",
+  );
   res.setHeader("X-Content-Type-Options", "nosniff");
   res.setHeader("X-Frame-Options", "DENY");
   res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
@@ -67,6 +70,23 @@ app.use((_req, res, next) => {
   next();
 });
 app.use(express.json({ limit: "8mb" }));
+
+const mobileLayoutAssetVersion = "20260730-v2";
+app.get(
+  `/assets/${mobileLayoutAssetVersion}/synchron-vision.css`,
+  (_req, res) => {
+    res.setHeader("Cache-Control", "no-store, max-age=0");
+    res.sendFile(`${process.cwd()}/public/synchron-vision.css`);
+  },
+);
+app.get(
+  `/assets/${mobileLayoutAssetVersion}/synchron-vision.js`,
+  (_req, res) => {
+    res.setHeader("Cache-Control", "no-store, max-age=0");
+    res.sendFile(`${process.cwd()}/public/synchron-vision.js`);
+  },
+);
+
 app.use(
   express.static("public", {
     maxAge: 0,

--- a/tests/synchronVisionUi.test.js
+++ b/tests/synchronVisionUi.test.js
@@ -3,12 +3,16 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 test("the personal AI interface keeps chat primary and exposes four mobile commands", async () => {
-  const [html, css, script] = await Promise.all([
+  const [html, css, script, server] = await Promise.all([
     readFile(new URL("../public/index.html", import.meta.url), "utf8"),
     readFile(new URL("../public/synchron-vision.css", import.meta.url), "utf8"),
     readFile(new URL("../public/synchron-vision.js", import.meta.url), "utf8"),
+    readFile(new URL("../server.js", import.meta.url), "utf8"),
   ]);
 
+  assert.match(html, /\/assets\/20260730-v2\/synchron-vision\.css/u);
+  assert.match(html, /\/assets\/20260730-v2\/synchron-vision\.js/u);
+  assert.match(server, /mobileLayoutAssetVersion = "20260730-v2"/u);
   assert.match(html, /class="mobile-command-bar"/u);
   assert.match(html, /data-command="chat"/u);
   assert.match(html, /data-command="memory"/u);


### PR DESCRIPTION
## Какво променя

- добавя нови уникални пътища за актуалните мобилни CSS и JavaScript файлове;
- насочва началната страница към тях;
- пази `no-store` на отговорите;
- добавя проверка, че HTML и сървърът използват една и съща версия.

## Причина

Production е на commit `84286de`, но Cloudflare продължава да връща старото съдържание на съществуващия CSS път, въпреки новата `?v=` стойност. Новият реален път няма стара кеширана версия.

## Проверки

- 8/8 целеви теста успешни;
- `node --check server.js` успешен;
- Prettier успешен.

Не се променят данни, AI Core, памет или DigitalOcean ресурси.