### PR TITLE
Поправи фалшивия OpenSearch статус

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2,6 +2,8 @@ const state = {
   sessionId: getOrCreateSessionId(),
   serverOnline: false,
   opensearchStatus: "unknown",
+  opensearchFailures: 0,
+  lastMemorySuccessAt: 0,
   lastActions: [],
   chatBusy: false,
   speakingButton: null,
@@ -141,6 +143,7 @@ async function restoreConversation() {
     );
     if (!response.ok) throw new Error("Историята не е достъпна.");
     const data = await response.json();
+    markMemoryOperational();
     const items = Array.isArray(data.items) ? data.items : [];
     if (items.length === 0) {
       await showWelcomeMessage();
@@ -582,6 +585,7 @@ async function openMemoryDrawer() {
     const response = await fetch("/memory/profile", { cache: "no-store" });
     if (!response.ok) throw new Error("Паметта временно не е достъпна.");
     const data = await response.json();
+    markMemoryOperational();
     state.memoryItems = Array.isArray(data.items) ? data.items : [];
     renderMemoryItems();
   } catch (error) {
@@ -1205,16 +1209,38 @@ async function checkHealth() {
 
 async function checkOpenSearch() {
   try {
-    const response = await fetch("/opensearch-status", { cache: "no-store" });
-    if (response.ok) {
-      const data = await response.json();
-      updateOpenSearchUI(data.status);
-    } else {
-      updateOpenSearchUI("error");
+    const response = await fetch("/health/ready", { cache: "no-store" });
+    const data = await response.json();
+    const memory = data?.checks?.memory;
+
+    if (memory?.ready) {
+      state.opensearchFailures = 0;
+      updateOpenSearchUI(memory.status || "operational");
+      return;
     }
+
+    handleOpenSearchProbeFailure(memory?.status || "unavailable");
   } catch {
-    updateOpenSearchUI("unreachable");
+    handleOpenSearchProbeFailure("unreachable");
   }
+}
+
+function markMemoryOperational() {
+  state.lastMemorySuccessAt = Date.now();
+  state.opensearchFailures = 0;
+  updateOpenSearchUI("operational");
+}
+
+function handleOpenSearchProbeFailure(status) {
+  const memoryWorkedRecently = Date.now() - state.lastMemorySuccessAt < 60_000;
+
+  if (memoryWorkedRecently) {
+    updateOpenSearchUI("operational");
+    return;
+  }
+
+  state.opensearchFailures += 1;
+  updateOpenSearchUI(state.opensearchFailures >= 3 ? status : "checking");
 }
 
 function setServerStatus(isOnline) {
@@ -1229,18 +1255,28 @@ function setServerStatus(isOnline) {
 
 function updateOpenSearchUI(status) {
   state.opensearchStatus = status;
-  elements.opensearchStatusDisplay.textContent = status;
   elements.opensearchStatusDisplay.className = "context-value";
 
-  if (status === "green") {
+  if (status === "green" || status === "operational") {
+    elements.opensearchStatusDisplay.textContent = "Свързан · работи";
     elements.opensearchStatusDisplay.classList.add("status-green");
+  } else if (status === "yellow") {
+    elements.opensearchStatusDisplay.textContent = "Работи · ограничен резерв";
+    elements.opensearchStatusDisplay.classList.add("status-yellow");
   } else if (
     status === "red" ||
     status === "error" ||
-    status === "unreachable"
+    status === "unreachable" ||
+    status === "unavailable"
   ) {
+    elements.opensearchStatusDisplay.textContent =
+      status === "red" ? "Проблем в паметта" : "Временно недостъпен";
+    elements.opensearchStatusDisplay.classList.add("status-red");
+  } else if (status === "not-configured") {
+    elements.opensearchStatusDisplay.textContent = "Не е настроен";
     elements.opensearchStatusDisplay.classList.add("status-red");
   } else {
+    elements.opensearchStatusDisplay.textContent = "Проверка…";
     elements.opensearchStatusDisplay.classList.add("status-yellow");
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -283,7 +283,7 @@
     </main>
 
     <script src="/markdown-renderer.js?v=20260728-xss"></script>
-    <script src="/app.js?v=20260730-mobile-copy"></script>
+    <script src="/assets/20260730-opensearch-status-v1/app.js"></script>
     <script src="/accessibility.js?v=20260728-font-stepper"></script>
     <script src="/work-center.js?v=20260728-task-journal"></script>
     <script src="/task-journal.js?v=20260728-task-journal"></script>

--- a/server.js
+++ b/server.js
@@ -72,6 +72,11 @@ app.use((_req, res, next) => {
 app.use(express.json({ limit: "8mb" }));
 
 const mobileLayoutAssetVersion = "20260730-v2";
+const openSearchStatusAssetVersion = "20260730-opensearch-status-v1";
+app.get(`/assets/${openSearchStatusAssetVersion}/app.js`, (_req, res) => {
+  res.setHeader("Cache-Control", "no-store, max-age=0");
+  res.sendFile(`${process.cwd()}/public/app.js`);
+});
 app.get(
   `/assets/${mobileLayoutAssetVersion}/synchron-vision.css`,
   (_req, res) => {

--- a/tests/dataControlsUi.test.js
+++ b/tests/dataControlsUi.test.js
@@ -30,4 +30,10 @@ test("application exposes working memory and permission controls", async () => {
   assert.match(script, /fetch\(["']\/health\/integrations["']/u);
   assert.match(script, /Твоята лична AI операционна система/u);
   assert.match(script, /item\.readOnly/u);
+  assert.match(script, /fetch\(["']\/health\/ready["']/u);
+  assert.match(script, /markMemoryOperational\(\)/u);
+  assert.match(script, /state\.opensearchFailures >= 3/u);
+  assert.match(script, /Свързан · работи/u);
+  assert.doesNotMatch(script, /fetch\(["']\/opensearch-status["']/u);
+  assert.match(html, /\/assets\/20260730-opensearch-status-v1\/app\.js/u);
 });


### PR DESCRIPTION
## Какво се променя

- Статусът на OpenSearch вече използва общата production health проверка.
- Успешното зареждане на разговор или памет се приема като пряко доказателство, че паметта работи.
- Единична временна грешка не показва погрешно „разкачен“; реален проблем се показва след три последователни неуспешни проверки.
- Статусите са изписани ясно на български.
- Новият JavaScript се зарежда от отделен некеширан път, за да не остане старият Cloudflare файл.

## Причина

Панелът „Памет“ успешно зарежда 29 факта, но отделният защитен `/opensearch-status` маршрут може да върне временна грешка или отказ на сесията. Интерфейсът приемаше всяка единична грешка за прекъсната OpenSearch връзка.

## Проверки

- 37/37 целеви теста успешни.
- Пълен пакет: 268 успешни, 0 неуспешни, 1 пропуснат production OpenSearch интеграционен тест.
- Без промени или изтриване на памет, индекси, пароли и DigitalOcean ресурси.