### PR TITLE
Премахни стария Agent и показвай реалните връзки

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -50,12 +50,6 @@ services:
       - key: OPENSEARCH_TLS_REJECT_UNAUTHORIZED
         value: "true"
         scope: RUN_TIME
-      - key: AGENT_KEY
-        scope: RUN_TIME
-        type: SECRET
-      - key: AGENT_URL
-        scope: RUN_TIME
-        type: SECRET
       - key: OPENAI_API_KEY
         scope: RUN_TIME
         type: SECRET

--- a/public/index.html
+++ b/public/index.html
@@ -285,7 +285,7 @@
     <script src="/markdown-renderer.js?v=20260728-xss"></script>
     <script src="/assets/20260730-opensearch-status-v1/app.js"></script>
     <script src="/accessibility.js?v=20260728-font-stepper"></script>
-    <script src="/work-center.js?v=20260728-task-journal"></script>
+    <script src="/assets/20260730-connections-v1/work-center.js"></script>
     <script src="/task-journal.js?v=20260728-task-journal"></script>
     <script src="/google-drive.js?v=20260727-connection-actions"></script>
     <script src="/google-apps.js?v=20260727-connection-actions"></script>

--- a/public/work-center.js
+++ b/public/work-center.js
@@ -123,7 +123,36 @@
     };
   }
 
-  function renderWorkCenter(config, readiness = null) {
+  function resolveToolStatus(
+    integrations,
+    toolId,
+    { connected = true, connectionName = "услугата" } = {},
+  ) {
+    const tool = integrations?.tools?.find((item) => item.id === toolId);
+    if (!tool?.configured || !tool?.enabled || !tool?.executable) {
+      return {
+        label: "Не е конфигуриран",
+        className: "warning",
+      };
+    }
+    if (!connected) {
+      return {
+        label: `Изисква еднократен вход в ${connectionName}`,
+        className: "warning",
+      };
+    }
+    return {
+      label: toolId === "github-read" ? "GitHub Read: работи" : "Работи",
+      className: "internal",
+    };
+  }
+
+  function renderWorkCenter(
+    config,
+    readiness = null,
+    integrations = null,
+    sessions = {},
+  ) {
     const chatgptUrl = safeHttpsUrl(
       config.chatgptWorkUrl,
       FALLBACK_CONFIG.chatgptWorkUrl,
@@ -151,6 +180,32 @@
     grid.className = "work-center-grid";
     grid.setAttribute("aria-label", "Услуги на проекта");
     const coreStatus = resolveCoreStatus(readiness);
+    const githubReadStatus = resolveToolStatus(integrations, "github-read");
+    const digitalOceanStatus = resolveToolStatus(
+      integrations,
+      "digitalocean-read",
+    );
+    const cloudflareStatus = resolveToolStatus(integrations, "cloudflare-read");
+    const googleDriveStatus = resolveToolStatus(
+      integrations,
+      "google-drive-read",
+      {
+        connected: Boolean(sessions.googleConnected),
+        connectionName: "Google",
+      },
+    );
+    const gmailStatus = resolveToolStatus(integrations, "gmail-read", {
+      connected: Boolean(sessions.googleConnected),
+      connectionName: "Google",
+    });
+    const calendarStatus = resolveToolStatus(
+      integrations,
+      "google-calendar-read",
+      {
+        connected: Boolean(sessions.googleConnected),
+        connectionName: "Google",
+      },
+    );
     const cards = [
       createInternalCard({
         title: "SYNCHRON-X — свързан разговор",
@@ -175,11 +230,11 @@
         description: "Кодът и историята на SYNCHRON-X.",
         url: REPOSITORY_URL,
         icon: "fa-brands fa-github",
+        status: githubReadStatus.label,
       }),
       createInternalCard({
         title: "Дневник на задачите",
-        description:
-          "Текущи, чакащи и завършени задачи на едно място.",
+        description: "Текущи, чакащи и завършени задачи на едно място.",
         targetId: "focusBtn",
         icon: "fa-solid fa-list-check",
         status: "Вградено · Запазва се автоматично",
@@ -201,30 +256,38 @@
         description: "Облачната услуга, която публикува сайта.",
         url: digitalOceanUrl,
         icon: "fa-brands fa-digital-ocean",
+        status: `DigitalOcean Read: ${digitalOceanStatus.label.toLocaleLowerCase("bg-BG")}`,
       }),
       createExternalCard({
         title: "Cloudflare",
         description: "Домейн, защита и мрежови настройки.",
         url: cloudflareUrl,
         icon: "fa-brands fa-cloudflare",
+        status: `Cloudflare Read: ${cloudflareStatus.label.toLocaleLowerCase("bg-BG")}`,
       }),
       createInternalCard({
         title: "Google Drive",
         description: "Преглед и анализ на разрешени файлове.",
         targetId: "googleDriveBtn",
         icon: "fa-brands fa-google-drive",
+        status: googleDriveStatus.label,
+        statusClass: googleDriveStatus.className,
       }),
       createInternalCard({
         title: "Gmail",
         description: "Преглед на разрешените имейли само за четене.",
         targetId: "gmailBtn",
         icon: "fa-solid fa-envelope",
+        status: gmailStatus.label,
+        statusClass: gmailStatus.className,
       }),
       createInternalCard({
         title: "Google Calendar",
         description: "Преглед на предстоящите събития.",
         targetId: "googleCalendarBtn",
         icon: "fa-solid fa-calendar-days",
+        status: calendarStatus.label,
+        statusClass: calendarStatus.className,
       }),
     ];
     cards.forEach((card) => grid.appendChild(card));
@@ -246,9 +309,18 @@
     body.innerHTML =
       '<div class="drawer-state"><i class="fa-solid fa-circle-notch fa-spin"></i> Зареждане…</div>';
 
-    const [configResult, readinessResult] = await Promise.allSettled([
+    const [
+      configResult,
+      readinessResult,
+      integrationsResult,
+      googleResult,
+      githubResult,
+    ] = await Promise.allSettled([
       fetch("/api/public-config", { cache: "no-store" }),
       fetch("/health/ready", { cache: "no-store" }),
+      fetch("/health/integrations", { cache: "no-store" }),
+      fetch("/api/google/status", { cache: "no-store" }),
+      fetch("/api/github/status", { cache: "no-store" }),
     ]);
 
     let config = FALLBACK_CONFIG;
@@ -260,7 +332,27 @@
     if (readinessResult.status === "fulfilled" && readinessResult.value.ok) {
       readiness = await readinessResult.value.json();
     }
-    renderWorkCenter(config, readiness);
+    let integrations = null;
+    if (
+      integrationsResult.status === "fulfilled" &&
+      integrationsResult.value.ok
+    ) {
+      integrations = await integrationsResult.value.json();
+    }
+    let googleConnected = false;
+    if (googleResult.status === "fulfilled" && googleResult.value.ok) {
+      const google = await googleResult.value.json();
+      googleConnected = Boolean(google.connected);
+    }
+    let githubConnected = false;
+    if (githubResult.status === "fulfilled" && githubResult.value.ok) {
+      const github = await githubResult.value.json();
+      githubConnected = Boolean(github.connected);
+    }
+    renderWorkCenter(config, readiness, integrations, {
+      googleConnected,
+      githubConnected,
+    });
   }
 
   body.addEventListener("click", (event) => {
@@ -281,6 +373,7 @@
   globalThis.SynchronWorkCenter = Object.freeze({
     openWorkCenter,
     resolveCoreStatus,
+    resolveToolStatus,
     safeHttpsUrl,
   });
 })();

--- a/server.js
+++ b/server.js
@@ -25,9 +25,9 @@ dotenv.config();
 const { oauthRateLimiter, paidAiRateLimiter, privateApiRateLimiter } =
   createRateLimiters();
 
-if (!process.env.AGENT_KEY) {
+if (!process.env.OPENAI_API_KEY) {
   console.warn(
-    "⚠️  AGENT_KEY is not configured. Direct AI conversation is unavailable; independent tools can still run.",
+    "⚠️  OPENAI_API_KEY is not configured. Direct AI conversation is unavailable; independent tools can still run.",
   );
 }
 
@@ -73,10 +73,18 @@ app.use(express.json({ limit: "8mb" }));
 
 const mobileLayoutAssetVersion = "20260730-v2";
 const openSearchStatusAssetVersion = "20260730-opensearch-status-v1";
+const connectionStatusAssetVersion = "20260730-connections-v1";
 app.get(`/assets/${openSearchStatusAssetVersion}/app.js`, (_req, res) => {
   res.setHeader("Cache-Control", "no-store, max-age=0");
   res.sendFile(`${process.cwd()}/public/app.js`);
 });
+app.get(
+  `/assets/${connectionStatusAssetVersion}/work-center.js`,
+  (_req, res) => {
+    res.setHeader("Cache-Control", "no-store, max-age=0");
+    res.sendFile(`${process.cwd()}/public/work-center.js`);
+  },
+);
 app.get(
   `/assets/${mobileLayoutAssetVersion}/synchron-vision.css`,
   (_req, res) => {

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -68,7 +68,7 @@ import {
 
 const router = express.Router();
 const HEARTBEAT_INTERVAL_MS = 15000;
-const DEFAULT_AGENT_TIMEOUT_MS = 120000;
+const DEFAULT_AI_TIMEOUT_MS = 120000;
 const MEMORY_WRITE_CONFIRM_PREFIX = "Потвърждавам запис в постоянната памет:";
 const MEMORY_DELETE_CONFIRM_PREFIX =
   "Потвърждавам изтриването от постоянната памет само на факта:";
@@ -669,37 +669,11 @@ export function shouldReplyWithVerifiedToolOutput(capabilityResults) {
   );
 }
 
-function extractTokenFromAgentEvent(rawEvent) {
-  const dataLines = rawEvent
-    .split(/\r?\n/)
-    .filter((line) => line.startsWith("data:"))
-    .map((line) => line.slice(5).trimStart());
-  if (dataLines.length === 0) return { type: "ignore" };
-
-  const payload = dataLines.join("\n").trim();
-  if (!payload || payload === "[DONE]") return { type: "done" };
-
-  let data;
-  try {
-    data = JSON.parse(payload);
-  } catch {
-    throw new Error("Invalid JSON event received from the AI agent.");
-  }
-  const token = data.choices?.[0]?.delta?.content;
-  return typeof token === "string" && token
-    ? { type: "token", token }
-    : { type: "ignore" };
-}
-
 router.post("/chat", async (req, res) => {
-  const agentUrl =
-    process.env.AGENT_URL ||
-    "https://a4ppevqrxnzlo6t2bgcpaj3a.agents.do-ai.run";
-  const agentKey = process.env.AGENT_KEY;
   const openAiApiKey = process.env.OPENAI_API_KEY;
-  const agentTimeoutMs = parsePositiveInteger(
-    process.env.AGENT_TIMEOUT_MS,
-    DEFAULT_AGENT_TIMEOUT_MS,
+  const aiTimeoutMs = parsePositiveInteger(
+    process.env.OPENAI_TIMEOUT_MS,
+    DEFAULT_AI_TIMEOUT_MS,
   );
   const { sessionId, message, image } = req.body || {};
   const googleSessionId =
@@ -1068,13 +1042,11 @@ router.post("/chat", async (req, res) => {
     message: "Проверявам задачата и избирам нужните инструменти…",
   });
   if (
-    (openAiApiKey || agentKey) &&
+    openAiApiKey &&
     shouldUseAgentPlanner(cleanMessage, fallbackCapabilityRequests)
   ) {
     try {
       const plannedCapabilityRequests = await planCapabilities({
-        agentUrl,
-        agentKey,
         openAiApiKey,
         message: cleanMessage,
       });
@@ -1176,7 +1148,7 @@ router.post("/chat", async (req, res) => {
     return;
   }
 
-  if (!openAiApiKey && !agentKey) {
+  if (!openAiApiKey) {
     if (capabilityReplies.length) {
       const fullReply = [...capabilityReplies, memoryReply]
         .filter(Boolean)
@@ -1249,93 +1221,17 @@ router.post("/chat", async (req, res) => {
   timeoutHandle = setTimeout(() => {
     timedOut = true;
     abortUpstream();
-  }, agentTimeoutMs);
+  }, aiTimeoutMs);
 
   try {
-    let fullReply = "";
-    let aiProvider = "openai";
-
-    if (openAiApiKey) {
-      try {
-        fullReply = await requestOpenAIText({
-          apiKey: openAiApiKey,
-          input: messages,
-          signal: abortController.signal,
-        });
-        sendEvent("token", { token: fullReply });
-      } catch (error) {
-        if (!agentKey || error?.name === "AbortError") throw error;
-        console.warn(
-          "[AI Core] OpenAI failed; using DigitalOcean fallback:",
-          error?.code || error?.message,
-        );
-        aiProvider = "digitalocean";
-      }
-    } else {
-      aiProvider = "digitalocean";
-    }
-
-    if (!fullReply) {
-      const agentRes = await fetch(`${agentUrl}/api/v1/chat/completions`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${agentKey}`,
-        },
-        body: JSON.stringify({ messages, stream: true }),
-        signal: abortController.signal,
-      });
-
-      if (!agentRes.ok) {
-        const body = await agentRes.text();
-        console.error(`[Agent] ${agentRes.status}:`, body || "<empty>");
-        sendEvent("error", {
-          status: agentRes.status,
-          message: `AI агентът върна грешка ${agentRes.status}. Опитай отново.`,
-        });
-        return;
-      }
-      if (!agentRes.body) throw new Error("Empty AI response stream.");
-
-      const reader = agentRes.body.getReader();
-      const decoder = new TextDecoder("utf-8");
-      let buffer = "";
-
-      const processEvents = () => {
-        buffer = buffer.replace(/\r\n/g, "\n");
-        const events = buffer.split("\n\n");
-        buffer = events.pop() || "";
-        for (const rawEvent of events) {
-          if (!rawEvent.trim()) continue;
-          const parsed = extractTokenFromAgentEvent(rawEvent);
-          if (parsed.type === "token") {
-            fullReply += parsed.token;
-            if (!sendEvent("token", { token: parsed.token })) {
-              abortUpstream();
-              return false;
-            }
-          }
-        }
-        return true;
-      };
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        if (!processEvents()) return;
-      }
-      buffer += decoder.decode();
-      if (buffer.trim()) {
-        const parsed = extractTokenFromAgentEvent(buffer);
-        if (parsed.type === "token") {
-          fullReply += parsed.token;
-          sendEvent("token", { token: parsed.token });
-        }
-      }
-    }
+    const fullReply = await requestOpenAIText({
+      apiKey: openAiApiKey,
+      input: messages,
+      signal: abortController.signal,
+    });
+    sendEvent("token", { token: fullReply });
     if (!fullReply.trim()) {
-      throw new Error("AI agent completed without returning text.");
+      throw new Error("AI ядрото приключи без текстов отговор.");
     }
 
     await saveConversationTurnBestEffort(
@@ -1352,20 +1248,20 @@ router.post("/chat", async (req, res) => {
       capabilities: capabilityResults.map(({ request }) => request.capability),
       task: taskResult,
       mode: capabilityResults.length ? "agentic" : "conversation",
-      provider: aiProvider,
+      provider: "openai",
     });
-    console.log(`[AI Core] ${aiProvider} success for ${cleanSessionId}`);
+    console.log(`[AI Core] openai success for ${cleanSessionId}`);
     console.info(
       `[Chat] Response completed (agent stream) for ${cleanSessionId}`,
     );
   } catch (error) {
     if (abortController.signal.aborted && !timedOut) return;
-    console.error(`[Agent] Failure for ${cleanSessionId}:`, error);
+    console.error(`[AI Core] Failure for ${cleanSessionId}:`, error);
     sendEvent("error", {
       status: timedOut ? 504 : 502,
       message: timedOut
-        ? "AI агентът се забави прекалено. Опитай отново."
-        : "Връзката с AI агента беше прекъсната. Опитай отново.",
+        ? "AI ядрото се забави прекалено. Опитай отново."
+        : "Връзката с AI ядрото беше прекъсната. Опитай отново.",
     });
   } finally {
     cleanup();

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -48,13 +48,8 @@ export async function getReadinessStatus({
   loadOpenSearchClient = getOpenSearchClient,
   timeoutMs = DEFAULT_READINESS_TIMEOUT_MS,
 } = {}) {
-  const digitalOceanAgentReady = hasAllEnvironmentVariables(
-    env,
-    "AGENT_URL",
-    "AGENT_KEY",
-  );
   const openAiReady = Boolean(env.OPENAI_API_KEY);
-  const chatAgentReady = openAiReady || digitalOceanAgentReady;
+  const chatAgentReady = openAiReady;
   let memory = { ready: false, status: "unavailable" };
 
   try {
@@ -71,9 +66,7 @@ export async function getReadinessStatus({
     memory = { ready: false, status: "unavailable" };
   }
 
-  const bridge = (
-    await getBridgeDiagnosticsStatus({ env, timeoutMs })
-  ).bridge;
+  const bridge = (await getBridgeDiagnosticsStatus({ env, timeoutMs })).bridge;
   const ready = chatAgentReady && memory.ready;
   return {
     status: ready ? "ready" : "not-ready",
@@ -82,12 +75,8 @@ export async function getReadinessStatus({
       chatAgent: {
         ready: chatAgentReady,
         status: chatAgentReady ? "configured" : "not-configured",
-        primaryProvider: openAiReady
-          ? "openai"
-          : digitalOceanAgentReady
-            ? "digitalocean"
-            : null,
-        fallbackConfigured: openAiReady && digitalOceanAgentReady,
+        primaryProvider: openAiReady ? "openai" : null,
+        removedProvider: "digitalocean-agent",
       },
       memory,
       bridge,
@@ -214,8 +203,7 @@ export function getIntegrationStatus({ githubAuthenticated = false } = {}) {
     "digitalocean-read": {
       configured:
         Boolean(
-          process.env.DIGITALOCEAN_API_TOKEN ||
-            process.env.DIGITALOCEAN_TOKEN,
+          process.env.DIGITALOCEAN_API_TOKEN || process.env.DIGITALOCEAN_TOKEN,
         ) && Boolean(process.env.DIGITALOCEAN_APP_ID),
     },
     "cloudflare-read": {
@@ -238,17 +226,9 @@ export function getIntegrationStatus({ githubAuthenticated = false } = {}) {
     ...getRuntimeVersion(),
     core: {
       chatAgent: {
-        configured:
-          Boolean(process.env.OPENAI_API_KEY) ||
-          hasAllProcessEnvironmentVariables("AGENT_URL", "AGENT_KEY"),
-        primaryProvider: process.env.OPENAI_API_KEY
-          ? "openai"
-          : hasAllProcessEnvironmentVariables("AGENT_URL", "AGENT_KEY")
-            ? "digitalocean"
-            : null,
-        fallbackConfigured:
-          Boolean(process.env.OPENAI_API_KEY) &&
-          hasAllProcessEnvironmentVariables("AGENT_URL", "AGENT_KEY"),
+        configured: Boolean(process.env.OPENAI_API_KEY),
+        primaryProvider: process.env.OPENAI_API_KEY ? "openai" : null,
+        removedProvider: "digitalocean-agent",
       },
       openai: {
         configured: Boolean(process.env.OPENAI_API_KEY),

--- a/src/services/agentPlannerService.js
+++ b/src/services/agentPlannerService.js
@@ -62,23 +62,6 @@ function parsePositiveInteger(value, fallback) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function extractAssistantContent(data) {
-  const content = data?.choices?.[0]?.message?.content;
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    return content
-      .map((item) =>
-        typeof item === "string"
-          ? item
-          : typeof item?.text === "string"
-            ? item.text
-            : "",
-      )
-      .join("");
-  }
-  return "";
-}
-
 function extractJsonObject(content) {
   const cleanContent = String(content || "")
     .replace(/^```(?:json)?\s*/iu, "")
@@ -156,17 +139,14 @@ export function shouldUseAgentPlanner(message, fallbackRequests = []) {
 }
 
 export async function planCapabilities({
-  agentUrl,
-  agentKey,
   openAiApiKey = process.env.OPENAI_API_KEY,
   openAiModel = process.env.OPENAI_PLANNER_MODEL ||
     DEFAULT_OPENAI_PLANNER_MODEL,
   message,
   fetchImpl = fetch,
-  timeoutMs = process.env.AGENT_PLANNER_TIMEOUT_MS,
+  timeoutMs = process.env.OPENAI_PLANNER_TIMEOUT_MS,
 }) {
-  const digitalOceanConfigured = Boolean(agentUrl && agentKey);
-  if (!openAiApiKey && !digitalOceanConfigured) {
+  if (!openAiApiKey) {
     throw new AgentPlannerError(
       "AI планировчикът не е конфигуриран.",
       "AGENT_PLANNER_NOT_CONFIGURED",
@@ -181,57 +161,15 @@ export async function planCapabilities({
 
   try {
     const plannerInput = `${PLANNER_INSTRUCTIONS}\n\n[ЗАЯВКА]\n${message}`;
-    if (openAiApiKey) {
-      try {
-        const content = await requestOpenAIText({
-          apiKey: openAiApiKey,
-          input: [{ role: "user", content: plannerInput }],
-          model: openAiModel,
-          fetchImpl,
-          signal: controller.signal,
-          verbosity: "low",
-        });
-        const plan = extractJsonObject(content);
-        return sanitizeCapabilityPlan(plan, message);
-      } catch (error) {
-        if (!digitalOceanConfigured || error?.name === "AbortError") {
-          throw error;
-        }
-        console.warn(
-          "[AgentPlanner] OpenAI failed; using DigitalOcean fallback:",
-          error?.code || error?.message,
-        );
-      }
-    }
-
-    const response = await fetchImpl(`${agentUrl}/api/v1/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${agentKey}`,
-      },
-      body: JSON.stringify({
-        messages: [
-          {
-            role: "user",
-            content: plannerInput,
-          },
-        ],
-        stream: false,
-        temperature: 0,
-      }),
+    const content = await requestOpenAIText({
+      apiKey: openAiApiKey,
+      input: [{ role: "user", content: plannerInput }],
+      model: openAiModel,
+      fetchImpl,
       signal: controller.signal,
+      verbosity: "low",
     });
-
-    if (!response.ok) {
-      throw new AgentPlannerError(
-        `AI планировчикът върна грешка ${response.status}.`,
-        "AGENT_PLANNER_UPSTREAM_ERROR",
-      );
-    }
-
-    const data = await response.json();
-    const plan = extractJsonObject(extractAssistantContent(data));
+    const plan = extractJsonObject(content);
     return sanitizeCapabilityPlan(plan, message);
   } catch (error) {
     if (error instanceof AgentPlannerError) throw error;

--- a/tests/agentPlannerService.test.js
+++ b/tests/agentPlannerService.test.js
@@ -9,8 +9,7 @@ import {
 
 test("planner keeps temporary calendar text inside a memory request out of tools", async () => {
   const requests = await planCapabilities({
-    agentUrl: "https://agent.test",
-    agentKey: "test-key",
+    openAiApiKey: "openai-key",
     message: [
       "Запомни като постоянна памет следните факти.",
       "Временна информация: утре трябва да проверя календара — не записвай това като постоянен факт.",
@@ -18,11 +17,16 @@ test("planner keeps temporary calendar text inside a memory request out of tools
     ].join(" "),
     fetchImpl: async (_url, options) => {
       const request = JSON.parse(options.body);
-      assert.equal(request.stream, false);
-      assert.match(request.messages[0].content, /Само споменаване/u);
+      assert.equal(request.store, false);
+      assert.match(request.input[0].content, /Само споменаване/u);
       return new Response(
         JSON.stringify({
-          choices: [{ message: { content: '{"calls":[]}' } }],
+          output: [
+            {
+              type: "message",
+              content: [{ type: "output_text", text: '{"calls":[]}' }],
+            },
+          ],
         }),
         {
           status: 200,
@@ -39,25 +43,28 @@ test("planner creates a single GitHub read and write plan for one implementation
   const message =
     "Провери main и промени цвета на бутона Памет в GitHub хранилището.";
   const requests = await planCapabilities({
-    agentUrl: "https://agent.test",
-    agentKey: "test-key",
+    openAiApiKey: "openai-key",
     message,
     fetchImpl: async () =>
       new Response(
         JSON.stringify({
-          choices: [
+          output: [
             {
-              message: {
-                content: [
-                  "```json",
-                  '{"calls":[',
-                  '{"capability":"code.read","request":"Провери актуалния main и бутона Памет."},',
-                  '{"capability":"code.write","request":"Промени цвета на бутона Памет."},',
-                  '{"capability":"code.write","request":"Промени цвета на бутона Памет."}',
-                  "]}",
-                  "```",
-                ].join("\n"),
-              },
+              type: "message",
+              content: [
+                {
+                  type: "output_text",
+                  text: [
+                    "```json",
+                    '{"calls":[',
+                    '{"capability":"code.read","request":"Провери актуалния main и бутона Памет."},',
+                    '{"capability":"code.write","request":"Промени цвета на бутона Памет."},',
+                    '{"capability":"code.write","request":"Промени цвета на бутона Памет."}',
+                    "]}",
+                    "```",
+                  ].join("\n"),
+                },
+              ],
             },
           ],
         }),
@@ -84,17 +91,10 @@ test("planner creates a single GitHub read and write plan for one implementation
 });
 
 test("planner uses OpenAI Responses as the primary provider", async () => {
-  let digitalOceanCalls = 0;
   const requests = await planCapabilities({
-    agentUrl: "https://agent.test",
-    agentKey: "agent-key",
     openAiApiKey: "openai-key",
     message: "Провери Supabase.",
     fetchImpl: async (url, options) => {
-      if (String(url).includes("/api/v1/chat/completions")) {
-        digitalOceanCalls += 1;
-        throw new Error("DigitalOcean should be a fallback only.");
-      }
       assert.equal(url, "https://api.openai.com/v1/responses");
       const body = JSON.parse(options.body);
       assert.equal(body.model, "gpt-5.6-luna");
@@ -117,42 +117,25 @@ test("planner uses OpenAI Responses as the primary provider", async () => {
     },
   });
 
-  assert.equal(digitalOceanCalls, 0);
   assert.equal(requests[0].capability, "database.status");
 });
 
-test("planner falls back to DigitalOcean when OpenAI is unavailable", async () => {
+test("planner does not call the removed DigitalOcean agent when OpenAI is unavailable", async () => {
   const calledUrls = [];
-  const requests = await planCapabilities({
-    agentUrl: "https://agent.test",
-    agentKey: "agent-key",
-    openAiApiKey: "openai-key",
-    message: "Провери Supabase.",
-    fetchImpl: async (url) => {
-      calledUrls.push(String(url));
-      if (String(url).includes("api.openai.com")) {
+  await assert.rejects(
+    planCapabilities({
+      openAiApiKey: "openai-key",
+      message: "Провери Supabase.",
+      fetchImpl: async (url) => {
+        calledUrls.push(String(url));
         return new Response("temporary failure", { status: 503 });
-      }
-      return new Response(
-        JSON.stringify({
-          choices: [
-            {
-              message: {
-                content:
-                  '{"calls":[{"capability":"database.status","request":"Провери Supabase."}]}',
-              },
-            },
-          ],
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-    },
-  });
+      },
+    }),
+    (error) => error?.code === "AGENT_PLANNER_UNAVAILABLE",
+  );
 
-  assert.equal(calledUrls.length, 2);
+  assert.equal(calledUrls.length, 1);
   assert.match(calledUrls[0], /api\.openai\.com\/v1\/responses/u);
-  assert.match(calledUrls[1], /agent\.test\/api\/v1\/chat\/completions/u);
-  assert.equal(requests[0].capability, "database.status");
 });
 
 test("sanitizer rejects unknown capabilities and keeps valid scopes", () => {

--- a/tests/chatResilience.test.js
+++ b/tests/chatResilience.test.js
@@ -3,7 +3,7 @@ import test from "node:test";
 import request from "supertest";
 
 process.env.NODE_ENV = "test";
-process.env.AGENT_KEY = "test-agent-key";
+process.env.OPENAI_API_KEY = "test-openai-key";
 process.env.GITHUB_REPOSITORY = "radostinvgeorgiev-commits/sunchron-backend";
 delete process.env.OPENSEARCH_HOST;
 delete process.env.OPENSEARCH_USERNAME;
@@ -25,11 +25,17 @@ test("normal AI chat continues when persistent memory is unavailable", async () 
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () =>
     new Response(
-      'data: {"choices":[{"delta":{"content":"Работя нормално."}}]}\n\n' +
-        "data: [DONE]\n\n",
+      JSON.stringify({
+        output: [
+          {
+            type: "message",
+            content: [{ type: "output_text", text: "Работя нормално." }],
+          },
+        ],
+      }),
       {
         status: 200,
-        headers: { "content-type": "text/event-stream" },
+        headers: { "content-type": "application/json" },
       },
     );
 
@@ -48,17 +54,12 @@ test("normal AI chat continues when persistent memory is unavailable", async () 
   }
 });
 
-test("normal chat uses OpenAI Responses before the DigitalOcean fallback", async () => {
+test("normal chat uses OpenAI Responses without the removed DigitalOcean agent", async () => {
   const originalFetch = globalThis.fetch;
   const originalOpenAiKey = process.env.OPENAI_API_KEY;
   process.env.OPENAI_API_KEY = "test-openai-key";
-  let digitalOceanCalls = 0;
 
   globalThis.fetch = async (url, options = {}) => {
-    if (String(url).includes("/api/v1/chat/completions")) {
-      digitalOceanCalls += 1;
-      throw new Error("DigitalOcean should be a fallback only.");
-    }
     assert.equal(String(url), "https://api.openai.com/v1/responses");
     const body = JSON.parse(options.body);
     assert.equal(body.store, false);
@@ -82,7 +83,6 @@ test("normal chat uses OpenAI Responses before the DigitalOcean fallback", async
       .send({ sessionId: "openai-primary-test", message: "Здравей" })
       .expect(200);
 
-    assert.equal(digitalOceanCalls, 0);
     assert.match(response.text, /Отговор от OpenAI\./u);
     assert.match(response.text, /"provider":"openai"/u);
   } finally {
@@ -92,7 +92,7 @@ test("normal chat uses OpenAI Responses before the DigitalOcean fallback", async
   }
 });
 
-test("normal chat falls back to DigitalOcean when OpenAI is unavailable", async () => {
+test("normal chat does not call the removed DigitalOcean agent when OpenAI is unavailable", async () => {
   const originalFetch = globalThis.fetch;
   const originalOpenAiKey = process.env.OPENAI_API_KEY;
   process.env.OPENAI_API_KEY = "test-openai-key";
@@ -100,20 +100,7 @@ test("normal chat falls back to DigitalOcean when OpenAI is unavailable", async 
 
   globalThis.fetch = async (url) => {
     calledUrls.push(String(url));
-    if (String(url).includes("api.openai.com")) {
-      return new Response("temporary failure", { status: 503 });
-    }
-    if (String(url).includes("/api/v1/chat/completions")) {
-      return new Response(
-        'data: {"choices":[{"delta":{"content":"Резервният агент работи."}}]}\n\n' +
-          "data: [DONE]\n\n",
-        {
-          status: 200,
-          headers: { "content-type": "text/event-stream" },
-        },
-      );
-    }
-    throw new Error(`Unexpected request: ${url}`);
+    return new Response("temporary failure", { status: 503 });
   };
 
   try {
@@ -123,9 +110,10 @@ test("normal chat falls back to DigitalOcean when OpenAI is unavailable", async 
       .send({ sessionId: "digitalocean-fallback-test", message: "Здравей" })
       .expect(200);
 
-    assert.equal(calledUrls.length, 2);
-    assert.match(response.text, /Резервният агент работи\./u);
-    assert.match(response.text, /"provider":"digitalocean"/u);
+    assert.equal(calledUrls.length, 1);
+    assert.match(calledUrls[0], /api\.openai\.com\/v1\/responses/u);
+    assert.match(response.text, /Връзката с AI ядрото/u);
+    assert.doesNotMatch(response.text, /"provider":"digitalocean"/u);
   } finally {
     globalThis.fetch = originalFetch;
     if (originalOpenAiKey === undefined) delete process.env.OPENAI_API_KEY;
@@ -135,22 +123,25 @@ test("normal chat falls back to DigitalOcean when OpenAI is unavailable", async 
 
 test("tool results return to the AI core for one synthesized answer", async () => {
   const originalFetch = globalThis.fetch;
-  let agentCalls = 0;
+  let openAiCalls = 0;
   let githubCalls = 0;
 
   globalThis.fetch = async (url, options = {}) => {
-    if (String(url).includes("/api/v1/chat/completions")) {
-      agentCalls += 1;
+    if (String(url).includes("api.openai.com/v1/responses")) {
+      openAiCalls += 1;
       const body = JSON.parse(options.body);
-      if (body.stream === false) {
+      if (body.model === "gpt-5.6-luna") {
         return new Response(
           JSON.stringify({
-            choices: [
+            output: [
               {
-                message: {
-                  content:
-                    '{"calls":[{"capability":"code.read","request":"Покажи последния commit в GitHub."}]}',
-                },
+                type: "message",
+                content: [
+                  {
+                    type: "output_text",
+                    text: '{"calls":[{"capability":"code.read","request":"Покажи последния commit в GitHub."}]}',
+                  },
+                ],
               },
             ],
           }),
@@ -161,14 +152,25 @@ test("tool results return to the AI core for one synthesized answer", async () =
         );
       }
 
-      assert.match(body.messages[0].content, /РЕЗУЛТАТИ ОТ ИНСТРУМЕНТИ/u);
-      assert.match(body.messages[0].content, /abc1234/u);
+      assert.match(body.input[0].content, /РЕЗУЛТАТИ ОТ ИНСТРУМЕНТИ/u);
+      assert.match(body.input[0].content, /abc1234/u);
       return new Response(
-        'data: {"choices":[{"delta":{"content":"Проверих GitHub. Последният commit е abc1234."}}]}\n\n' +
-          "data: [DONE]\n\n",
+        JSON.stringify({
+          output: [
+            {
+              type: "message",
+              content: [
+                {
+                  type: "output_text",
+                  text: "Проверих GitHub. Последният commit е abc1234.",
+                },
+              ],
+            },
+          ],
+        }),
         {
           status: 200,
-          headers: { "content-type": "text/event-stream" },
+          headers: { "content-type": "application/json" },
         },
       );
     }
@@ -206,7 +208,7 @@ test("tool results return to the AI core for one synthesized answer", async () =
       })
       .expect(200);
 
-    assert.equal(agentCalls, 2);
+    assert.equal(openAiCalls, 2);
     assert.equal(githubCalls, 1);
     assert.match(
       response.text,
@@ -224,13 +226,18 @@ test("explicit GitHub request still runs when the AI planner returns no tools", 
   let githubCalls = 0;
 
   globalThis.fetch = async (url, options = {}) => {
-    if (String(url).includes("/api/v1/chat/completions")) {
+    if (String(url).includes("api.openai.com/v1/responses")) {
       const body = JSON.parse(options.body);
-      if (body.stream === false) {
+      if (body.model === "gpt-5.6-luna") {
         plannerCalls += 1;
         return new Response(
           JSON.stringify({
-            choices: [{ message: { content: '{"calls":[]}' } }],
+            output: [
+              {
+                type: "message",
+                content: [{ type: "output_text", text: '{"calls":[]}' }],
+              },
+            ],
           }),
           {
             status: 200,
@@ -239,14 +246,22 @@ test("explicit GitHub request still runs when the AI planner returns no tools", 
         );
       }
 
-      assert.match(body.messages[0].content, /РЕЗУЛТАТИ ОТ ИНСТРУМЕНТИ/u);
-      assert.match(body.messages[0].content, /Planner cannot suppress tools/u);
+      assert.match(body.input[0].content, /РЕЗУЛТАТИ ОТ ИНСТРУМЕНТИ/u);
+      assert.match(body.input[0].content, /Planner cannot suppress tools/u);
       return new Response(
-        'data: {"choices":[{"delta":{"content":"Проверих GitHub успешно."}}]}\n\n' +
-          "data: [DONE]\n\n",
+        JSON.stringify({
+          output: [
+            {
+              type: "message",
+              content: [
+                { type: "output_text", text: "Проверих GitHub успешно." },
+              ],
+            },
+          ],
+        }),
         {
           status: 200,
-          headers: { "content-type": "text/event-stream" },
+          headers: { "content-type": "application/json" },
         },
       );
     }
@@ -306,10 +321,10 @@ test("explicit memory writes fail safely when memory is unavailable", async () =
   assert.match(response.body.error, /Нищо не беше записано или изтрито/u);
 });
 
-test("independent tools still run when the AI agent key is unavailable", async () => {
+test("independent tools still run when the OpenAI key is unavailable", async () => {
   const originalFetch = globalThis.fetch;
-  const originalAgentKey = process.env.AGENT_KEY;
-  delete process.env.AGENT_KEY;
+  const originalOpenAiKey = process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_API_KEY;
   globalThis.fetch = async (url) => {
     assert.match(String(url), /api\.github\.com\/repos\//u);
     return new Response(
@@ -346,14 +361,14 @@ test("independent tools still run when the AI agent key is unavailable", async (
     assert.doesNotMatch(response.text, /AI разговорът временно/u);
   } finally {
     globalThis.fetch = originalFetch;
-    if (originalAgentKey === undefined) delete process.env.AGENT_KEY;
-    else process.env.AGENT_KEY = originalAgentKey;
+    if (originalOpenAiKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = originalOpenAiKey;
   }
 });
 
 test("normal chat reports only the missing AI connection", async () => {
-  const originalAgentKey = process.env.AGENT_KEY;
-  delete process.env.AGENT_KEY;
+  const originalOpenAiKey = process.env.OPENAI_API_KEY;
+  delete process.env.OPENAI_API_KEY;
 
   try {
     const response = await request(app)
@@ -366,7 +381,7 @@ test("normal chat reports only the missing AI connection", async () => {
     assert.match(response.text, /AI разговорът временно не е конфигуриран/u);
     assert.match(response.text, /Независимите инструменти остават достъпни/u);
   } finally {
-    if (originalAgentKey === undefined) delete process.env.AGENT_KEY;
-    else process.env.AGENT_KEY = originalAgentKey;
+    if (originalOpenAiKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = originalOpenAiKey;
   }
 });

--- a/tests/coreProfileDelivery.test.js
+++ b/tests/coreProfileDelivery.test.js
@@ -3,10 +3,8 @@ import test from "node:test";
 import request from "supertest";
 
 process.env.NODE_ENV = "test";
-process.env.AGENT_KEY = "test-agent-key";
 process.env.OPENAI_API_KEY = "test-openai-key";
-process.env.GITHUB_REPOSITORY =
-  "radostinvgeorgiev-commits/sunchron-backend";
+process.env.GITHUB_REPOSITORY = "radostinvgeorgiev-commits/sunchron-backend";
 delete process.env.OPENSEARCH_HOST;
 delete process.env.OPENSEARCH_USERNAME;
 delete process.env.OPENSEARCH_PASSWORD;
@@ -88,10 +86,9 @@ function createProfileClient() {
 const ownerSession = await createGitHubSession(
   { access_token: "test-owner-token" },
   async () =>
-    new Response(
-      JSON.stringify({ login: "radostinvgeorgiev-commits" }),
-      { status: 200 },
-    ),
+    new Response(JSON.stringify({ login: "radostinvgeorgiev-commits" }), {
+      status: 200,
+    }),
 );
 const OWNER_COOKIE = `synchron_github_session=${ownerSession.id}`;
 

--- a/tests/healthRoutes.test.js
+++ b/tests/healthRoutes.test.js
@@ -21,11 +21,10 @@ test("liveness version exposes the deployed commit without exposing secrets", ()
   );
 });
 
-test("readiness requires the chat agent and a healthy OpenSearch cluster", async () => {
+test("readiness requires OpenAI and a healthy OpenSearch cluster", async () => {
   const result = await getReadinessStatus({
     env: {
-      AGENT_URL: "https://agent.example",
-      AGENT_KEY: "secret",
+      OPENAI_API_KEY: "secret",
       MCP_ACCESS_TOKEN: "m".repeat(48),
       APP_COMMIT_SHA: "abc123",
     },
@@ -39,6 +38,8 @@ test("readiness requires the chat agent and a healthy OpenSearch cluster", async
   assert.equal(result.status, "ready");
   assert.equal(result.commit, "abc123");
   assert.equal(result.checks.memory.status, "green");
+  assert.equal(result.checks.chatAgent.primaryProvider, "openai");
+  assert.equal(result.checks.chatAgent.removedProvider, "digitalocean-agent");
   assert.equal(result.checks.bridge.configured, true);
   assert.equal(result.checks.bridge.responding, true);
 });
@@ -58,7 +59,7 @@ test("readiness accepts OpenAI as the primary chat provider", async () => {
 
   assert.equal(result.status, "ready");
   assert.equal(result.checks.chatAgent.primaryProvider, "openai");
-  assert.equal(result.checks.chatAgent.fallbackConfigured, false);
+  assert.equal(result.checks.chatAgent.removedProvider, "digitalocean-agent");
 });
 
 test("readiness returns 503 when a required dependency is unavailable", async () => {
@@ -66,7 +67,7 @@ test("readiness returns 503 when a required dependency is unavailable", async ()
   app.get(
     "/health/ready",
     createReadinessHandler({
-      env: { AGENT_URL: "https://agent.example", AGENT_KEY: "secret" },
+      env: { OPENAI_API_KEY: "secret" },
       loadOpenSearchClient: () => null,
     }),
   );
@@ -78,7 +79,7 @@ test("readiness returns 503 when a required dependency is unavailable", async ()
 
 test("readiness rejects a red OpenSearch cluster", async () => {
   const result = await getReadinessStatus({
-    env: { AGENT_URL: "https://agent.example", AGENT_KEY: "secret" },
+    env: { OPENAI_API_KEY: "secret" },
     loadOpenSearchClient: () => ({
       cluster: {
         health: async () => ({ body: { status: "red" } }),

--- a/tests/integrationHealth.test.js
+++ b/tests/integrationHealth.test.js
@@ -1,12 +1,11 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import { getIntegrationStatus } from "../src/routes/health.js";
 import { resetToolRegistryForTests } from "../src/tools/toolRegistry.js";
 
 const ENV_NAMES = [
-  "AGENT_URL",
-  "AGENT_KEY",
   "OPENAI_API_KEY",
   "OPENSEARCH_HOST",
   "OPENSEARCH_PORT",
@@ -36,6 +35,8 @@ test("integration status reports configuration without exposing secret values", 
   try {
     const status = getIntegrationStatus();
     assert.equal(status.core.chatAgent.configured, true);
+    assert.equal(status.core.chatAgent.primaryProvider, "openai");
+    assert.equal(status.core.chatAgent.removedProvider, "digitalocean-agent");
     assert.equal(status.core.openai.configured, true);
     assert.equal(status.tools.length, 10);
     assert.equal(
@@ -105,4 +106,15 @@ test("GitHub Write is configured with client id and secret only", () => {
     }
     resetToolRegistryForTests();
   }
+});
+
+test("removed DigitalOcean AI Agent is not required by production configuration", async () => {
+  const [appSpec, server] = await Promise.all([
+    readFile(new URL("../.do/app.yaml", import.meta.url), "utf8"),
+    readFile(new URL("../server.js", import.meta.url), "utf8"),
+  ]);
+
+  assert.doesNotMatch(appSpec, /key:\s*AGENT_(?:URL|KEY)/u);
+  assert.doesNotMatch(server, /if\s*\(!process\.env\.AGENT_KEY\)/u);
+  assert.match(server, /if\s*\(!process\.env\.OPENAI_API_KEY\)/u);
 });

--- a/tests/workCenterUi.test.js
+++ b/tests/workCenterUi.test.js
@@ -23,6 +23,48 @@ function createHarness({
       memory: { ready: true, status: "green" },
     },
   },
+  integrations = {
+    tools: [
+      {
+        id: "github-read",
+        enabled: true,
+        executable: true,
+        configured: true,
+      },
+      {
+        id: "digitalocean-read",
+        enabled: true,
+        executable: true,
+        configured: true,
+      },
+      {
+        id: "cloudflare-read",
+        enabled: true,
+        executable: true,
+        configured: false,
+      },
+      {
+        id: "google-drive-read",
+        enabled: true,
+        executable: true,
+        configured: true,
+      },
+      {
+        id: "gmail-read",
+        enabled: true,
+        executable: true,
+        configured: true,
+      },
+      {
+        id: "google-calendar-read",
+        enabled: true,
+        executable: true,
+        configured: true,
+      },
+    ],
+  },
+  googleConnected = false,
+  githubConnected = false,
   fetchFails = false,
 } = {}) {
   const dom = new JSDOM(`<!doctype html><body>
@@ -45,9 +87,16 @@ function createHarness({
     Event: dom.window.Event,
     fetch: async (url) => {
       if (fetchFails) throw new Error("offline");
-      const result = String(url).includes("/health/ready")
+      const path = String(url);
+      const result = path.includes("/health/ready")
         ? readiness
-        : config || {};
+        : path.includes("/health/integrations")
+          ? integrations
+          : path.includes("/api/google/status")
+            ? { connected: googleConnected }
+            : path.includes("/api/github/status")
+              ? { connected: githubConnected }
+              : config || {};
       return {
         ok: true,
         json: async () => result,
@@ -107,7 +156,10 @@ test("work center uses safe GitHub links without duplicating the task journal", 
   const journalButton = harness.dom.window.document.querySelector(
     '[data-work-center-target="focusBtn"]',
   );
-  assert.equal(journalButton?.textContent.includes("Дневник на задачите"), true);
+  assert.equal(
+    journalButton?.textContent.includes("Дневник на задачите"),
+    true,
+  );
   assert.ok(
     hrefs.includes(
       "https://github.com/radostinvgeorgiev-commits/sunchron-backend/pulls",
@@ -190,6 +242,35 @@ test("Google cards reuse the existing hidden integration actions", async () => {
     .click();
 
   assert.deepEqual(clicks, ["googleDriveBtn", "gmailBtn", "googleCalendarBtn"]);
+});
+
+test("work center shows real connection state instead of claiming everything works", async () => {
+  const harness = createHarness();
+  await openCenter(harness);
+  const text = harness.dom.window.document
+    .getElementById("dataDrawerBody")
+    .textContent.replace(/\s+/gu, " ");
+
+  assert.match(text, /GitHub Read: работи/u);
+  assert.match(text, /DigitalOcean Read: работи/u);
+  assert.match(text, /Cloudflare Read: не е конфигуриран/u);
+  assert.match(text, /Изисква еднократен вход в Google/u);
+});
+
+test("one Google login marks Drive, Gmail, and Calendar as connected", async () => {
+  const harness = createHarness({ googleConnected: true });
+  await openCenter(harness);
+  const googleCards = ["googleDriveBtn", "gmailBtn", "googleCalendarBtn"].map(
+    (target) =>
+      harness.dom.window.document.querySelector(
+        `[data-work-center-target="${target}"]`,
+      ),
+  );
+
+  googleCards.forEach((card) => {
+    assert.match(card.textContent, /Работи/u);
+    assert.doesNotMatch(card.textContent, /Изисква еднократен вход/u);
+  });
 });
 
 test("mobile drawer cards use full width without horizontal overflow", () => {


### PR DESCRIPTION
Премахва напълно стария DigitalOcean AI Agent като AI fallback, запазва отделния DigitalOcean Read одит и използва OpenAI като единствено AI ядро. Панелът „Инструменти“ вече показва реалното състояние на GitHub, Google, DigitalOcean и Cloudflare. Премахнати са AGENT_URL/AGENT_KEY от App Platform спецификацията.

Проверки: 271 успешни, 0 неуспешни, 1 пропуснат реален OpenSearch интеграционен тест поради липса на локални production ключове.