### PR TITLE
Възстанови историята на разговорите в мобилното меню

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -9,6 +9,7 @@ const state = {
   speakingButton: null,
   pendingImage: null,
   conversations: [],
+  conversationLoadError: "",
   memoryItems: [],
   recognition: null,
   listening: false,
@@ -192,10 +193,13 @@ async function loadConversations() {
     if (!response.ok) throw new Error("Списъкът не е достъпен.");
     const data = await response.json();
     state.conversations = Array.isArray(data.items) ? data.items : [];
+    state.conversationLoadError = "";
     renderConversationList();
   } catch (error) {
     console.error(error);
     state.conversations = [];
+    state.conversationLoadError =
+      "Историята временно не е достъпна. Опитай отново.";
     renderConversationList();
   }
 }
@@ -208,6 +212,24 @@ function renderConversationList() {
     (item) => !query || item.title.toLocaleLowerCase("bg-BG").includes(query),
   );
   elements.conversationList.replaceChildren();
+
+  if (state.conversationLoadError) {
+    const error = document.createElement("p");
+    error.className = "conversation-state conversation-state-error";
+    error.textContent = state.conversationLoadError;
+    elements.conversationList.appendChild(error);
+    return;
+  }
+
+  if (conversations.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "conversation-state";
+    empty.textContent = query
+      ? "Няма намерени разговори."
+      : "Все още няма запазени разговори.";
+    elements.conversationList.appendChild(empty);
+    return;
+  }
 
   for (const item of conversations) {
     const button = document.createElement("button");
@@ -258,8 +280,11 @@ function handleGlobalKeydown(event) {
 }
 
 function toggleConversationSearch() {
-  elements.conversationSearch.hidden = !elements.conversationSearch.hidden;
-  if (!elements.conversationSearch.hidden) elements.conversationSearch.focus();
+  elements.conversationSearch.hidden = false;
+  elements.conversationList
+    .closest(".sidebar-section")
+    ?.scrollIntoView({ block: "start", behavior: "smooth" });
+  elements.conversationSearch.focus({ preventScroll: true });
 }
 
 function handleImageSelection(event) {

--- a/public/index.html
+++ b/public/index.html
@@ -42,7 +42,7 @@
         </button>
         <nav class="sidebar-nav" aria-label="Основно меню">
           <button id="searchChatsBtn" type="button">
-            <i class="fa-solid fa-magnifying-glass"></i><span>Търси</span>
+            <i class="fa-solid fa-clock-rotate-left"></i><span>Разговори</span>
           </button>
           <button id="focusBtn" type="button">
             <i class="fa-solid fa-bullseye"></i><span>Дневник на задачите</span>

--- a/public/synchron-vision.css
+++ b/public/synchron-vision.css
@@ -134,6 +134,22 @@ input:focus-visible {
   color: var(--sx-accent);
 }
 
+.conversation-state {
+  margin: 6px 8px;
+  padding: 12px;
+  border: 1px dashed var(--sx-line);
+  border-radius: 14px;
+  color: var(--sx-muted);
+  background: rgba(255, 255, 255, 0.5);
+  line-height: 1.4;
+}
+
+.conversation-state-error {
+  color: #9f2f1c;
+  border-color: rgba(159, 47, 28, 0.25);
+  background: rgba(255, 238, 233, 0.72);
+}
+
 .font-size-control {
   margin: 8px 0;
   padding: 12px !important;
@@ -366,6 +382,21 @@ input:focus-visible {
     border: 0 !important;
     border-radius: 0 28px 28px 0 !important;
     background: rgba(250, 248, 242, 0.98) !important;
+    overflow-y: auto !important;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .sidebar-nav,
+  .sidebar-section,
+  .profile-button {
+    flex: 0 0 auto;
+  }
+
+  .sidebar-section {
+    min-height: 180px;
+    overflow: visible;
+    scroll-margin-top: 12px;
   }
 
   .chat-toolbar {

--- a/tests/synchronVisionUi.test.js
+++ b/tests/synchronVisionUi.test.js
@@ -37,6 +37,24 @@ test("the visual layer preserves the readable text controls and safe drawers", a
   assert.match(css, /prefers-reduced-motion/u);
 });
 
+test("mobile conversation history stays reachable with very large text", async () => {
+  const [html, css, app] = await Promise.all([
+    readFile(new URL("../public/index.html", import.meta.url), "utf8"),
+    readFile(new URL("../public/synchron-vision.css", import.meta.url), "utf8"),
+    readFile(new URL("../public/app.js", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(html, /id="searchChatsBtn"[\s\S]*?<span>Разговори<\/span>/u);
+  assert.match(css, /\.sidebar\s*\{[\s\S]*?overflow-y:\s*auto\s*!important/u);
+  assert.match(css, /\.sidebar-section\s*\{[\s\S]*?min-height:\s*180px/u);
+  assert.match(
+    app,
+    /scrollIntoView\(\{ block: "start", behavior: "smooth" \}\)/u,
+  );
+  assert.match(app, /Историята временно не е достъпна/u);
+  assert.match(app, /Все още няма запазени разговори/u);
+});
+
 test("mobile chat content clears the measured composer and command bar", async () => {
   const [css, script, app] = await Promise.all([
     readFile(new URL("../public/synchron-vision.css", import.meta.url), "utf8"),


### PR DESCRIPTION
## Какво е поправено

- преименува подвеждащото „Търси“ на ясно „Разговори“;
- прави мобилното меню превъртаемо при много едър текст;
- отвежда директно до списъка с разговори;
- показва ясно празно състояние или грешка вместо празен блок.

## Причина

Историята и API маршрутите съществуват, но при много едър текст навигацията заемаше целия екран и свиваше секцията „Разговори“ до невидима височина.

## Проверка

- целеви UI и history тестове: 8 успешни;
- пълен пакет: 272 успешни, 0 неуспешни, 1 пропуснат реален OpenSearch тест без production ключове;
- форматиране и синтактични проверки: успешни.

Не се променят памет, разговори или production данни.