### PR TITLE
Покажи безопасно имената на DigitalOcean променливите през моста

### DIFF
--- a/src/services/digitalOceanService.js
+++ b/src/services/digitalOceanService.js
@@ -53,6 +53,44 @@ async function request(path, { env = process.env, fetchImpl = fetch } = {}) {
   return response.json();
 }
 
+export function listDigitalOceanEnvironmentVariables(spec = {}) {
+  const components = [
+    ["app", spec.name || "app", spec.envs],
+    ...[
+      ["service", spec.services],
+      ["worker", spec.workers],
+      ["job", spec.jobs],
+      ["function", spec.functions],
+      ["static-site", spec.static_sites],
+    ].flatMap(([kind, items]) =>
+      (Array.isArray(items) ? items : []).map((item) => [
+        kind,
+        item?.name || kind,
+        item?.envs,
+      ]),
+    ),
+  ];
+
+  return components
+    .flatMap(([sourceKind, sourceName, envs]) =>
+      (Array.isArray(envs) ? envs : [])
+        .filter((item) => typeof item?.key === "string" && item.key.trim())
+        .map((item) => ({
+          key: item.key.trim(),
+          scope: item.scope || null,
+          type: item.type || "GENERAL",
+          sourceKind,
+          sourceName,
+        })),
+    )
+    .sort(
+      (left, right) =>
+        left.key.localeCompare(right.key) ||
+        left.sourceKind.localeCompare(right.sourceKind) ||
+        left.sourceName.localeCompare(right.sourceName),
+    );
+}
+
 export async function getDigitalOceanAppStatus(options = {}) {
   const { appId } = requiredAppConfig(options.env);
   const [appData, deploymentsData] = await Promise.all([
@@ -82,6 +120,7 @@ export async function getDigitalOceanAppStatus(options = {}) {
           phase: app.in_progress_deployment.phase,
         }
       : null,
+    environmentVariables: listDigitalOceanEnvironmentVariables(app.spec),
     deployments: deployments.map((deployment) => ({
       id: deployment.id,
       phase: deployment.phase,
@@ -606,6 +645,7 @@ export function formatDigitalOceanStatus(status) {
       ? `Текущ деплой: ${status.inProgressDeployment.phase} (${status.inProgressDeployment.id}).`
       : "Няма текущ деплой.",
     status.liveUrl ? `Адрес: ${status.liveUrl}` : null,
+    `Environment variables: ${status.environmentVariables?.length || 0} имена; стойностите не се връщат.`,
     `Последни деплои: ${status.deployments.length}.`,
   ]
     .filter(Boolean)

--- a/tests/digitalOceanEnvironmentVariables.test.js
+++ b/tests/digitalOceanEnvironmentVariables.test.js
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getDigitalOceanAppStatus,
+  listDigitalOceanEnvironmentVariables,
+} from "../src/services/digitalOceanService.js";
+
+test("DigitalOcean environment inventory returns metadata without values", () => {
+  const inventory = listDigitalOceanEnvironmentVariables({
+    name: "sunchron-backend",
+    envs: [
+      {
+        key: "APP_LEVEL",
+        scope: "RUN_TIME",
+        type: "GENERAL",
+        value: "visible-value",
+      },
+    ],
+    services: [
+      {
+        name: "web",
+        envs: [
+          {
+            key: "OPENAI_API_KEY",
+            scope: "RUN_TIME",
+            type: "SECRET",
+            value: "super-secret",
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.deepEqual(inventory, [
+    {
+      key: "APP_LEVEL",
+      scope: "RUN_TIME",
+      type: "GENERAL",
+      sourceKind: "app",
+      sourceName: "sunchron-backend",
+    },
+    {
+      key: "OPENAI_API_KEY",
+      scope: "RUN_TIME",
+      type: "SECRET",
+      sourceKind: "service",
+      sourceName: "web",
+    },
+  ]);
+  assert.equal(JSON.stringify(inventory).includes("visible-value"), false);
+  assert.equal(JSON.stringify(inventory).includes("super-secret"), false);
+});
+
+test("DigitalOcean app status exposes only safe environment metadata", async () => {
+  const responses = new Map([
+    [
+      "/apps/app-1",
+      {
+        app: {
+          id: "app-1",
+          spec: {
+            name: "sunchron-backend",
+            services: [
+              {
+                name: "web",
+                envs: [
+                  {
+                    key: "MCP_ACCESS_TOKEN",
+                    scope: "RUN_TIME",
+                    type: "SECRET",
+                    value: "must-not-leak",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    ],
+    ["/apps/app-1/deployments?page=1&per_page=5", { deployments: [] }],
+  ]);
+  const fetchImpl = async (url) => {
+    const parsed = new URL(url);
+    const path = parsed.pathname.replace(/^\/v2/, "") + parsed.search;
+    return {
+      ok: true,
+      json: async () => responses.get(path),
+    };
+  };
+
+  const status = await getDigitalOceanAppStatus({
+    env: {
+      DIGITALOCEAN_API_TOKEN: "token",
+      DIGITALOCEAN_APP_ID: "app-1",
+    },
+    fetchImpl,
+  });
+
+  assert.equal(status.environmentVariables[0].key, "MCP_ACCESS_TOKEN");
+  assert.equal(status.environmentVariables[0].type, "SECRET");
+  assert.equal(JSON.stringify(status).includes("must-not-leak"), false);
+});


### PR DESCRIPTION
## Какво променя

- разширява съществуващия read-only DigitalOcean MCP инструмент;
- връща само име, scope, type и компонент на environment variable;
- никога не връща стойността, включително при GENERAL и SECRET;
- добавя два целеви теста срещу изтичане на стойности.

## Защо

Текущият мост показва приложението и деплоите, но не може да довърши одита на реалните environment variables. Тази промяна позволява списъкът да се извлече безопасно през съществуващия мост без снимки от таблото.

## Проверка

- `node --check src/services/digitalOceanService.js`
- `node --test tests/digitalOceanEnvironmentVariables.test.js` — 2 успешни, 0 неуспешни
- `git diff --check`

Пълният локален пакет не можа да се изпълни чисто поради непълни зависимости в работното копие; GitHub Actions трябва да направи окончателната проверка в чиста среда.