### PR TITLE
Поправи профила и реалната проверка на инструментите

### DIFF
--- a/public/auth.css
+++ b/public/auth.css
@@ -180,6 +180,17 @@
   font-weight: 800;
 }
 
+.profile-button-visible {
+  flex: 0 0 auto;
+  border: 1px solid rgba(18, 32, 29, 0.1) !important;
+  background: rgba(255, 255, 255, 0.72) !important;
+}
+
+.profile-button-visible #profileRole {
+  color: #1b6f57;
+  font-weight: 800;
+}
+
 @media (max-width: 520px) {
   .auth-card {
     padding: 24px 20px;

--- a/public/index.html
+++ b/public/index.html
@@ -131,6 +131,18 @@
             <small>Лична AI операционна система</small>
           </span>
         </div>
+        <button
+          id="toggleStatusBtn"
+          class="profile-button profile-button-visible"
+          type="button"
+        >
+          <span class="profile-avatar" id="profileAvatar">Р</span>
+          <span
+            ><strong id="profileName">Радко</strong
+            ><small id="profileRole">Проверка на профила…</small></span
+          >
+          <i class="fa-solid fa-ellipsis"></i>
+        </button>
         <button id="newChatBtn" class="new-chat" type="button">
           <i class="fa-regular fa-pen-to-square"></i>
           <span>Нов разговор</span>
@@ -207,14 +219,6 @@
           />
           <div id="conversationList" class="conversation-list"></div>
         </div>
-        <button id="toggleStatusBtn" class="profile-button" type="button">
-          <span class="profile-avatar" id="profileAvatar">Р</span>
-          <span
-            ><strong id="profileName">Радко</strong
-            ><small id="profileRole">Настройки и статус</small></span
-          >
-          <i class="fa-solid fa-ellipsis"></i>
-        </button>
       </aside>
 
       <section class="chatPanel" id="chat-container">

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -75,6 +75,7 @@ const MEMORY_DELETE_CONFIRM_PREFIX =
 const DIGITALOCEAN_NAME_PATTERN =
   /(?:digital\s*ocean|ди[гж]итал\s*о(?:кеа|ка|ке)н|ди[гж]итъл\s*о(?:кеа|ка|ке)н)/iu;
 const DIRECT_CAPABILITY_REPLIES = new Set([
+  "system.integrations.status",
   "infrastructure.digitalocean.read",
   "infrastructure.cloudflare.read",
 ]);
@@ -301,6 +302,18 @@ export function detectCapabilityRequests(message) {
     ) {
       continue;
     }
+    if (
+      /(?:(?:инструмент(?:ите)?|връзк(?:и|ите)|интеграци(?:и|ите)).{0,40}(?:работят|работи|достъпни|активни|статус)|(?:работят|достъпни|активни|статус).{0,40}(?:инструмент(?:ите)?|връзк(?:и|ите)|интеграци(?:и|ите)))/iu.test(
+        subtask,
+      ) &&
+      !/(?:регистрирани|tool\s+registry|capability\s+engine)/iu.test(subtask)
+    ) {
+      requests.push({
+        capability: "system.integrations.status",
+        action: "infrastructure.read",
+        message: subtask,
+      });
+    }
     if (isCalendarReadRequest(subtask)) {
       requests.push({
         capability: "calendar.read",
@@ -525,6 +538,8 @@ export async function executeDetectedCapabilities(
 }
 
 function capabilityLabel(capability) {
+  if (capability === "system.integrations.status")
+    return "статус на инструментите";
   if (capability === "calendar.read") return "календар";
   if (capability === "code.read") return "GitHub";
   if (capability === "code.write") return "GitHub запис";
@@ -1280,6 +1295,8 @@ router.post("/chat", async (req, res) => {
       apiKey: openAiApiKey,
       input: messages,
       signal: abortController.signal,
+      reasoningEffort: "low",
+      verbosity: "medium",
     });
     sendEvent("token", { token: fullReply });
     if (!fullReply.trim()) {

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -159,6 +159,10 @@ function resolveToolHealthStatus(tool, configuration = {}) {
 export function getIntegrationStatus({ githubAuthenticated = false } = {}) {
   registerCoreTools();
   const configuration = {
+    "synchron-integrations-status": {
+      configured: true,
+      authenticated: true,
+    },
     "github-read": {
       configured: true,
       authenticated: true,

--- a/src/services/agentPlannerService.js
+++ b/src/services/agentPlannerService.js
@@ -7,6 +7,7 @@ const DEFAULT_PLANNER_TIMEOUT_MS = 30000;
 const MAX_PLANNED_CALLS = 8;
 
 const CAPABILITY_ACTIONS = Object.freeze({
+  "system.integrations.status": "infrastructure.read",
   "calendar.read": "calendar.read",
   "code.read": "github.read",
   "code.write": "github.write",
@@ -27,6 +28,7 @@ const PLANNER_INSTRUCTIONS = [
   "Върни само валиден JSON във формат:",
   '{"calls":[{"capability":"code.read","request":"точната подзадача","scope":"project"}]}',
   "Разрешени способности:",
+  "- system.integrations.status: обща реална проверка кои инструменти работят и кои връзки липсват",
   "- code.read: четене и проверка на разрешеното GitHub хранилище",
   "- code.write: промяна в GitHub; може да е недостъпна и винаги изисква потвърждение",
   "- database.status: проверка дали Supabase е свързан и отговаря",

--- a/src/services/aiCoreService.js
+++ b/src/services/aiCoreService.js
@@ -34,6 +34,7 @@ export async function requestOpenAIText({
   fetchImpl = fetch,
   signal,
   verbosity = "low",
+  reasoningEffort = "none",
 }) {
   if (!apiKey) {
     throw new AiCoreError(
@@ -52,7 +53,7 @@ export async function requestOpenAIText({
     body: JSON.stringify({
       model,
       input,
-      reasoning: { effort: "none" },
+      reasoning: { effort: reasoningEffort },
       text: { verbosity },
       store: false,
     }),

--- a/src/tools/capabilityEngine.js
+++ b/src/tools/capabilityEngine.js
@@ -51,6 +51,80 @@ function resolvePermission(tool, capability) {
   return tool.capabilityPermissions?.[capability] || null;
 }
 
+async function checkedStatus(check) {
+  try {
+    await check();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function buildIntegrationStatusReport(
+  input = {},
+  {
+    checkGitHub = () =>
+      answerGitHubReadRequest("Покажи последния commit в GitHub."),
+    checkMemory = () =>
+      listProfileMemories({ ownerId: input.ownerId, limit: 1 }),
+    checkSupabase = checkSupabaseStatus,
+    checkDigitalOcean = getDigitalOceanAppStatus,
+    checkGoogleSession = hasSession,
+    env = process.env,
+  } = {},
+) {
+  const [githubRead, memory, supabase, digitalOcean, googleConnected] =
+    await Promise.all([
+      checkedStatus(checkGitHub),
+      checkedStatus(checkMemory),
+      checkedStatus(checkSupabase),
+      checkedStatus(checkDigitalOcean),
+      input.googleSessionId
+        ? checkedStatus(() => checkGoogleSession(input.googleSessionId))
+        : false,
+    ]);
+
+  const working = [
+    ["GitHub Read", githubRead],
+    ["Synchron Memory", memory],
+    ["Supabase Status", supabase],
+    ["DigitalOcean Read", digitalOcean],
+    ["OpenAI разговор", Boolean(env.OPENAI_API_KEY)],
+    ["OpenAI Web Search", Boolean(env.OPENAI_API_KEY)],
+  ];
+  const sessionTools = [
+    ["GitHub Write", Boolean(input.githubSessionId), "изисква потвърждение"],
+    ["Google Drive", googleConnected, "изисква Google вход"],
+    ["Google Calendar", googleConnected, "изисква Google вход"],
+    ["Gmail", googleConnected, "изисква Google вход"],
+    [
+      "Cloudflare Read",
+      Boolean(env.CLOUDFLARE_API_TOKEN && env.CLOUDFLARE_ZONE_ID),
+      "липсват Cloudflare настройки",
+    ],
+  ];
+
+  return [
+    "Проверих инструментите реално сега.",
+    "",
+    "Работят:",
+    ...working
+      .filter(([, available]) => available)
+      .map(([name]) => `• ${name}`),
+    "",
+    "Състояние на останалите връзки:",
+    ...sessionTools
+      .filter(([, available]) => !available)
+      .map(([name, , reason]) => `• ${name} — ${reason}`),
+    ...working
+      .filter(([, available]) => !available)
+      .map(([name]) => `• ${name} — реалната проверка е неуспешна`),
+    ...sessionTools
+      .filter(([, available]) => available)
+      .map(([name, , note]) => `• ${name} — свързан; ${note}`),
+  ].join("\n");
+}
+
 export function resolveCapability(capability, options = {}) {
   if (typeof capability !== "string" || !capability.trim()) {
     throw new CapabilityError(
@@ -104,6 +178,8 @@ export function resolveCapability(capability, options = {}) {
 }
 
 const executors = Object.freeze({
+  "synchron-integrations-status": async ({ input }) =>
+    buildIntegrationStatusReport(input),
   "github-read": async ({ input }) => {
     if (isMergedBranchCleanupPlanRequest(input.message)) {
       return prepareMergedBranchCleanup({ ownerId: input.ownerId });

--- a/src/tools/toolRegistry.js
+++ b/src/tools/toolRegistry.js
@@ -97,6 +97,21 @@ export function resetToolRegistryForTests() {
 export function registerCoreTools() {
   [
     {
+      id: "synchron-integrations-status",
+      provider: "synchron",
+      name: "SYNCHRON-X Status",
+      version: "1.0.0",
+      category: "system",
+      capabilities: ["system.integrations.status"],
+      permissions: ["infrastructure.read"],
+      capabilityPermissions: {
+        "system.integrations.status": "infrastructure.read",
+      },
+      enabled: true,
+      requiresConfirmation: false,
+      healthStatus: "healthy",
+    },
+    {
       id: "github-read",
       provider: "github",
       name: "GitHub Read",

--- a/tests/aiCoreService.test.js
+++ b/tests/aiCoreService.test.js
@@ -53,3 +53,21 @@ test("OpenAI Responses request preserves local state and uses the balanced chat 
 
   assert.equal(result, "Работи.");
 });
+
+test("allows the final conversation to request stronger reasoning and detail", async () => {
+  await requestOpenAIText({
+    apiKey: "test-openai-key",
+    input: [{ role: "user", content: "Провери внимателно" }],
+    reasoningEffort: "low",
+    verbosity: "medium",
+    fetchImpl: async (_url, options) => {
+      const body = JSON.parse(options.body);
+      assert.deepEqual(body.reasoning, { effort: "low" });
+      assert.deepEqual(body.text, { verbosity: "medium" });
+      return new Response(JSON.stringify({ output_text: "Проверено." }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+});

--- a/tests/authUi.test.js
+++ b/tests/authUi.test.js
@@ -36,3 +36,14 @@ test("hides owner tools for tester profiles and exposes logout", () => {
   assert.match(app, /user\?\.role === "owner"/u);
   assert.match(app, /\/api\/auth\/logout/u);
 });
+
+test("shows the authenticated profile before the long navigation list", () => {
+  const profilePosition = html.indexOf('id="toggleStatusBtn"');
+  const navigationPosition = html.indexOf('class="sidebar-nav"');
+  const conversationPosition = html.indexOf('id="conversationList"');
+
+  assert.ok(profilePosition > 0);
+  assert.ok(profilePosition < navigationPosition);
+  assert.ok(profilePosition < conversationPosition);
+  assert.match(html, /id="profileRole">Проверка на профила/u);
+});

--- a/tests/capabilityEngine.test.js
+++ b/tests/capabilityEngine.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  buildIntegrationStatusReport,
   CapabilityError,
   executeCapability,
   isToolExecutable,
@@ -121,6 +122,31 @@ test("изпълнява GitHub четене чрез избрания инст�
   }
 });
 
+test("връща общ статус само след реални проверки", async () => {
+  const report = await buildIntegrationStatusReport(
+    {
+      ownerId: "primary-user",
+      githubSessionId: "github-session",
+      googleSessionId: "",
+    },
+    {
+      checkGitHub: async () => true,
+      checkMemory: async () => [],
+      checkSupabase: async () => ({ status: "healthy" }),
+      checkDigitalOcean: async () => ({ app: { id: "app-1" } }),
+      env: { OPENAI_API_KEY: "configured" },
+    },
+  );
+
+  assert.match(report, /Проверих инструментите реално сега/u);
+  assert.match(report, /GitHub Read/u);
+  assert.match(report, /Synchron Memory/u);
+  assert.match(report, /Supabase Status/u);
+  assert.match(report, /DigitalOcean Read/u);
+  assert.match(report, /Google Drive — изисква Google вход/u);
+  assert.match(report, /GitHub Write — свързан; изисква потвърждение/u);
+});
+
 test("не изпълнява способност за потвърждение без разрешение", async () => {
   await assert.rejects(
     () => executeCapability("memory.delete"),
@@ -134,6 +160,7 @@ test("всеки регистриран основен инструмент им
   registerCoreTools();
   for (const id of [
     "github-read",
+    "synchron-integrations-status",
     "github-write",
     "google-drive-read",
     "google-calendar-read",

--- a/tests/chatCapabilityExecution.test.js
+++ b/tests/chatCapabilityExecution.test.js
@@ -75,6 +75,28 @@ test("recognizes common Bulgarian GitHub spellings as a real tool request", () =
   }
 });
 
+test("общ въпрос за инструментите задейства реална системна проверка", () => {
+  for (const message of [
+    "А инструментите работят ли?",
+    "Кои връзки са активни?",
+    "Покажи статус на интеграциите.",
+  ]) {
+    assert.deepEqual(
+      detectCapabilityRequests(message).map(({ capability }) => capability),
+      ["system.integrations.status"],
+    );
+  }
+});
+
+test("въпрос за Tool Registry остава GitHub проверка, а не системен статус", () => {
+  assert.deepEqual(
+    detectCapabilityRequests(
+      "Провери в GitHub кои инструменти са регистрирани в Tool Registry.",
+    ).map(({ capability }) => capability),
+    ["code.read"],
+  );
+});
+
 test("routes safe merged-branch cleanup planning from chat to GitHub Read", () => {
   const message =
     "Подготви безопасен списък за изтриване само на GitHub клоновете от вече слети PR-и. Не изтривай нищо.";
@@ -399,7 +421,13 @@ test("detects a combined personal-OS tool check without duplicate GitHub tasks",
   const requests = detectCapabilityRequests(message);
   assert.deepEqual(
     requests.map(({ capability }) => capability),
-    ["code.read", "calendar.read", "memory.read", "web.search"],
+    [
+      "code.read",
+      "calendar.read",
+      "memory.read",
+      "web.search",
+      "system.integrations.status",
+    ],
   );
   assert.equal(
     requests.filter(({ capability }) => capability === "code.read").length,
@@ -428,7 +456,7 @@ test("a GitHub implementation task creates one read check and one honest write a
   const requests = detectCapabilityRequests(message);
   assert.deepEqual(
     requests.map(({ capability }) => capability),
-    ["code.read", "code.write"],
+    ["code.read", "system.integrations.status", "code.write"],
   );
   assert.equal(
     requests.filter(({ capability }) => capability === "code.read").length,

--- a/tests/integrationHealth.test.js
+++ b/tests/integrationHealth.test.js
@@ -38,7 +38,7 @@ test("integration status reports configuration without exposing secret values", 
     assert.equal(status.core.chatAgent.primaryProvider, "openai");
     assert.equal(status.core.chatAgent.removedProvider, "digitalocean-agent");
     assert.equal(status.core.openai.configured, true);
-    assert.equal(status.tools.length, 10);
+    assert.equal(status.tools.length, 11);
     assert.equal(
       status.tools
         .filter((tool) => tool.id !== "github-write")

--- a/tests/toolRegistry.test.js
+++ b/tests/toolRegistry.test.js
@@ -13,7 +13,10 @@ test.beforeEach(() => resetToolRegistryForTests());
 
 test("регистрира съществуващите интеграции с пълни метаданни", () => {
   registerCoreTools();
-  assert.equal(listTools().length, 10);
+  assert.equal(listTools().length, 11);
+  assert.deepEqual(getTool("synchron-integrations-status").capabilities, [
+    "system.integrations.status",
+  ]);
   assert.deepEqual(getTool("github-read").capabilities, [
     "code.read",
     "code.search",


### PR DESCRIPTION
## Какво поправя

- показва профила и ролята веднага под логото, преди дългото меню;
- разпознава въпроси като „Инструментите работят ли?“ и изпълнява реални read-only проверки;
- проверява GitHub Read, OpenSearch паметта, Supabase, DigitalOcean и състоянието на останалите връзки;
- подобрява нормалните OpenAI отговори от `reasoning: none / verbosity: low` на `reasoning: low / verbosity: medium`;
- DigitalOcean Agent остава премахнат и не се връща.

## Проверки

- 291 успешни теста
- 0 неуспешни
- 1 пропуснат реален OpenSearch тест, защото локално няма production OpenSearch
- formatting и diff проверките са чисти

Не променя production и не се слива без изрично потвърждение.