### PR TITLE
Поправи разпознаването на собственика при две сесии

### DIFF
--- a/src/middleware/ownerAuth.js
+++ b/src/middleware/ownerAuth.js
@@ -31,6 +31,24 @@ export async function resolveRequestIdentity(
   res,
   { getUserSession = resolveUserSession, getSession = getGitHubSession } = {},
 ) {
+  const cookies = parseGitHubCookies(req.headers.cookie);
+  if (cookies.synchron_github_session) {
+    const githubSession = await getSession(cookies.synchron_github_session);
+    if (githubSession && isAuthorizedGitHubLogin(githubSession.login)) {
+      if (cookies.synchron_user_session) {
+        res.append("Set-Cookie", clearUserSessionCookie());
+      }
+      return {
+        id: githubSession.login.toLocaleLowerCase("en-US"),
+        login: githubSession.login,
+        displayName: "Радко",
+        role: "owner",
+        authProvider: "github",
+        memoryOwnerId: resolveMemoryOwnerId(githubSession.login),
+      };
+    }
+  }
+
   const userSession = await getUserSession(req.headers.cookie);
   if (userSession?.user) {
     if (userSession.refreshed && userSession.session) {
@@ -46,24 +64,11 @@ export async function resolveRequestIdentity(
     };
   }
 
-  if (parseGitHubCookies(req.headers.cookie).synchron_user_session) {
+  if (cookies.synchron_user_session) {
     res.append("Set-Cookie", clearUserSessionCookie());
   }
 
-  const cookies = parseGitHubCookies(req.headers.cookie);
-  const githubSession = await getSession(cookies.synchron_github_session);
-  if (!githubSession || !isAuthorizedGitHubLogin(githubSession.login)) {
-    return null;
-  }
-
-  return {
-    id: githubSession.login.toLocaleLowerCase("en-US"),
-    login: githubSession.login,
-    displayName: "Радко",
-    role: "owner",
-    authProvider: "github",
-    memoryOwnerId: resolveMemoryOwnerId(githubSession.login),
-  };
+  return null;
 }
 
 export function createRequireOwnerSession({

--- a/tests/ownerAuth.test.js
+++ b/tests/ownerAuth.test.js
@@ -13,6 +13,12 @@ function responseRecorder() {
   return {
     statusCode: 200,
     payload: null,
+    headers: {},
+    append(name, value) {
+      this.headers[name] ||= [];
+      this.headers[name].push(value);
+      return this;
+    },
     status(value) {
       this.statusCode = value;
       return this;
@@ -92,6 +98,42 @@ test("allows only the configured owner and attaches verified identity", async ()
     memoryOwnerId: "primary-user",
   });
   assert.equal(response.payload, null);
+});
+
+test("verified GitHub owner takes priority over a stale tester session", async () => {
+  const middleware = createRequireOwnerSession({
+    getSession: async (id) => {
+      assert.equal(id, "owner-session");
+      return {
+        login: "radostinvgeorgiev-commits",
+        accessToken: "protected-token",
+      };
+    },
+    getUserSession: async () =>
+      assert.fail("A verified owner session must bypass the tester session"),
+  });
+  const request = {
+    headers: {
+      cookie:
+        "synchron_user_session=stale-tester; synchron_github_session=owner-session",
+    },
+  };
+  const response = responseRecorder();
+  let continued = false;
+
+  await middleware(request, response, () => {
+    continued = true;
+  });
+
+  assert.equal(continued, true);
+  assert.equal(request.owner.role, "owner");
+  assert.equal(request.owner.authProvider, "github");
+  assert.equal(request.owner.memoryOwnerId, "primary-user");
+  assert.equal(response.headers["Set-Cookie"].length, 1);
+  assert.match(
+    response.headers["Set-Cookie"][0],
+    /^synchron_user_session=;/u,
+  );
 });
 
 test("allows a Supabase tester with a separate memory namespace", async () => {


### PR DESCRIPTION
## Какво се променя

- Валидната GitHub сесия на собственика се проверява преди Supabase тестова сесия.
- При успешен собственически вход старата тестова cookie се изчиства.
- Паметта на собственика остава в `primary-user`; тестовите профили запазват отделни пространства.

## Причина

При едновременно налични Supabase и GitHub cookies backend-ът избираше първо Supabase. Така Радко можеше да бъде разпознат като тестов профил и чатът правилно за този профил изключваше GitHub, DigitalOcean и другите инструменти.

## Проверка

Добавен е регресионен тест за едновременно налична стара тестова сесия и валидна GitHub owner сесия. Очакваният резултат е роля `owner`, GitHub като доставчик и изчистване на тестовата cookie.

PR-ът е чернова и не трябва да се слива преди успешни GitHub Actions.