### PR TITLE
Поправи активирането на тестови профили

### DIFF
--- a/public/appshell.css
+++ b/public/appshell.css
@@ -63,11 +63,12 @@
 .work-center-icon{width:44px;height:44px;display:grid;place-items:center;border-radius:13px;color:#111;background:#eef2f6;font-size:20px}
 .featured .work-center-icon{color:#111;background:#fff}
 .work-center-card-content{min-width:0;display:block}
-.work-center-card strong,.work-center-description,.work-center-status{display:block;overflow-wrap:anywhere}
+.work-center-card strong,.work-center-description,.work-center-status,.work-center-action-label{display:block;overflow-wrap:anywhere}
 .work-center-card strong{font-size:15px;line-height:1.3}
 .work-center-description{margin-top:4px;color:#64748b;font-size:12px;line-height:1.45}
 .featured .work-center-description{color:#d6d9de}
 .work-center-status{width:fit-content;max-width:100%;margin-top:8px;padding:4px 8px;border-radius:999px;font-size:10px;font-weight:750;line-height:1.25}
+.work-center-action-label{margin-top:9px;color:#1d4ed8;font-size:12px;font-weight:800;line-height:1.3}
 .work-center-status.external{color:#7c4a03;background:#fff4d7}.work-center-status.internal{color:#137333;background:#e6f4ea}
 .work-center-arrow{color:#94a3b8}.featured .work-center-arrow{color:#fff}
 .work-center-close{width:100%;min-height:48px;margin-top:8px;border:1px solid #cbd5e1;border-radius:14px;color:#17212b;background:#fff;font:inherit;font-weight:750;cursor:pointer}

--- a/public/work-center.js
+++ b/public/work-center.js
@@ -101,6 +101,7 @@
     icon,
     status,
     statusClass = "warning",
+    actionLabel = "Натисни за активиране",
   }) {
     const card = document.createElement("button");
     card.type = "button";
@@ -117,7 +118,13 @@
     addText(content, "strong", cardTitle);
     addText(content, "span", description, "work-center-description");
     addText(content, "span", status, `work-center-status ${statusClass}`);
+    addText(content, "span", actionLabel, "work-center-action-label");
     card.appendChild(content);
+
+    const arrow = document.createElement("i");
+    arrow.className = "fa-solid fa-chevron-right work-center-arrow";
+    arrow.setAttribute("aria-hidden", "true");
+    card.appendChild(arrow);
     return card;
   }
 
@@ -308,6 +315,10 @@
           testerAuth?.configured && testerAuth?.registrationEnabled
             ? "internal"
             : "warning",
+        actionLabel:
+          testerAuth?.configured && testerAuth?.registrationEnabled
+            ? "Натисни, за да покажеш кода"
+            : "Натисни за активиране",
       }),
       createExternalCard({
         title: "Cloudflare",
@@ -352,9 +363,15 @@
     body.appendChild(closeButton);
   }
 
-  function showTesterAuthResult({ title: resultTitle, message, inviteCode }) {
+  function showTesterAuthResult({
+    title: resultTitle,
+    message,
+    inviteCode,
+    anchor,
+  }) {
     const panel = document.createElement("section");
     panel.className = "work-center-intro";
+    panel.dataset.testerAuthResult = "";
     addText(panel, "strong", resultTitle);
     addText(panel, "p", message);
     if (inviteCode) {
@@ -364,13 +381,22 @@
       copyButton.type = "button";
       copyButton.dataset.copyTesterInvite = "";
     }
-    body.prepend(panel);
+    body.querySelector("[data-tester-auth-result]")?.remove();
+    if (anchor?.parentNode) {
+      anchor.insertAdjacentElement("afterend", panel);
+    } else {
+      body.prepend(panel);
+    }
+    panel.scrollIntoView?.({ behavior: "smooth", block: "nearest" });
   }
 
   async function readJson(response) {
     const payload = await response.json().catch(() => ({}));
     if (!response.ok) {
-      throw new Error(payload.error || "Действието не успя.");
+      const error = new Error(payload.error || "Действието не успя.");
+      error.code = payload.code;
+      error.status = response.status;
+      throw error;
     }
     return payload;
   }
@@ -419,11 +445,23 @@
         message:
           "DigitalOcean започва нов deployment. След публикуването бутонът „Създай тестов профил“ ще се появи.",
         inviteCode: result.inviteCode,
+        anchor: card,
       });
     } catch (error) {
+      if (error.code === "AUTH_REQUIRED" || error.status === 401) {
+        showTesterAuthResult({
+          title: "Необходим е вход на собственика",
+          message:
+            "Отварям защитения GitHub вход. След връщането натисни картата отново.",
+          anchor: card,
+        });
+        globalThis.location?.assign?.("/api/github/connect");
+        return;
+      }
       showTesterAuthResult({
         title: "Активирането не успя",
         message: error.message,
+        anchor: card,
       });
     } finally {
       card.disabled = false;

--- a/tests/workCenterUi.test.js
+++ b/tests/workCenterUi.test.js
@@ -67,6 +67,7 @@ function createHarness({
   githubConnected = false,
   testerAuth = { configured: false, registrationEnabled: false },
   fetchFails = false,
+  testerPrepareResponse = null,
 } = {}) {
   const dom = new JSDOM(`<!doctype html><body>
     <aside id="sidebar"></aside>
@@ -86,9 +87,17 @@ function createHarness({
     console,
     document: dom.window.document,
     Event: dom.window.Event,
+    location: {
+      assign: (url) => {
+        dom.window.document.body.dataset.redirectedTo = url;
+      },
+    },
     fetch: async (url) => {
       if (fetchFails) throw new Error("offline");
       const path = String(url);
+      if (path.includes("/api/tester-auth/prepare") && testerPrepareResponse) {
+        return testerPrepareResponse;
+      }
       const result = path.includes("/health/ready")
         ? readiness
         : path.includes("/health/integrations")
@@ -273,6 +282,72 @@ test("work center shows the invite action only after tester auth is active", asy
 
   assert.match(card.textContent, /Тестови профили/u);
   assert.match(card.textContent, /Работи · Само за собственика/u);
+});
+
+test("tester auth action is visibly actionable on mobile", async () => {
+  const harness = createHarness();
+  await openCenter(harness);
+  const card = harness.dom.window.document.querySelector(
+    '[data-work-center-action="activate-tester-auth"]',
+  );
+
+  assert.match(card.textContent, /Натисни за активиране/u);
+  assert.ok(card.querySelector(".fa-chevron-right"));
+});
+
+test("tester auth error is shown next to the action card", async () => {
+  const harness = createHarness({
+    testerPrepareResponse: {
+      ok: false,
+      status: 503,
+      json: async () => ({
+        error: "DigitalOcean мостът не е достъпен.",
+        code: "DIGITALOCEAN_UNAVAILABLE",
+      }),
+    },
+  });
+  await openCenter(harness);
+  const { document } = harness.dom.window;
+  const card = document.querySelector(
+    '[data-work-center-action="activate-tester-auth"]',
+  );
+
+  card.click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const result = card.nextElementSibling;
+  assert.equal(result?.dataset.testerAuthResult, "");
+  assert.match(result.textContent, /DigitalOcean мостът не е достъпен/u);
+});
+
+test("missing owner session opens the protected GitHub login", async () => {
+  const harness = createHarness({
+    testerPrepareResponse: {
+      ok: false,
+      status: 401,
+      json: async () => ({
+        error: "Трябва да влезеш.",
+        code: "AUTH_REQUIRED",
+      }),
+    },
+  });
+  await openCenter(harness);
+  const { document } = harness.dom.window;
+  const card = document.querySelector(
+    '[data-work-center-action="activate-tester-auth"]',
+  );
+
+  card.click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(
+    document.body.dataset.redirectedTo,
+    "/api/github/connect",
+  );
+  assert.match(
+    card.nextElementSibling.textContent,
+    /Необходим е вход на собственика/u,
+  );
 });
 
 test("one Google login marks Drive, Gmail, and Calendar as connected", async () => {


### PR DESCRIPTION
## Какво е поправено

- картата „Активирай тестови профили“ вече изглежда и се държи като ясно действие;
- резултатът или грешката се показват непосредствено под натиснатата карта;
- при липсваща собственическа сесия автоматично се отваря защитеният GitHub вход;
- след активация текстът се сменя коректно към показване на кода за покана.

## Причина

Плюсът беше само икона, а грешките се добавяха най-горе в Работния център, извън видимата част на мобилния екран. При липсваща сесия потребителят не получаваше видим път към входа.

## Проверки

- 313 успешни теста;
- 0 неуспешни;
- 1 пропуснат реален OpenSearch тест поради липса на локални production credentials;
- добавени тестове за видимо действие, локално съобщение за грешка и автоматичен GitHub вход.