### PR TITLE
Покажи точната DigitalOcean грешка при активация

### DIFF
--- a/public/work-center.js
+++ b/public/work-center.js
@@ -448,7 +448,7 @@
         anchor: card,
       });
     } catch (error) {
-      if (error.code === "AUTH_REQUIRED" || error.status === 401) {
+      if (error.code === "AUTH_REQUIRED") {
         showTesterAuthResult({
           title: "Необходим е вход на собственика",
           message:

--- a/src/routes/testerAuthAdminRouter.js
+++ b/src/routes/testerAuthAdminRouter.js
@@ -2,8 +2,7 @@ import express from "express";
 import { TESTER_AUTH_BOOTSTRAP } from "../config/testerAuthBootstrap.js";
 import {
   activateTesterAuthConfiguration,
-  getDigitalOceanAppStatus,
-  TESTER_AUTH_ENV_KEYS,
+  inspectTesterAuthActivation,
 } from "../services/digitalOceanService.js";
 import {
   createDurableConfirmation,
@@ -43,7 +42,8 @@ function safeError(error) {
     status: resolvedStatus,
     body: {
       error:
-        resolvedStatus >= 400 && resolvedStatus < 500
+        error?.name === "DigitalOceanError" ||
+        (resolvedStatus >= 400 && resolvedStatus < 500)
           ? error.message
           : "Активирането на тестовите профили не успя.",
       code: error?.code || "TESTER_AUTH_ACTIVATION_FAILED",
@@ -52,7 +52,7 @@ function safeError(error) {
 }
 
 export function createTesterAuthAdminRouter({
-  getDigitalOceanStatus = getDigitalOceanAppStatus,
+  inspectDigitalOcean = inspectTesterAuthActivation,
   activate = activateTesterAuthConfiguration,
   createConfirmation = createDurableConfirmation,
   validateConfirmation = validateDurableConfirmation,
@@ -88,18 +88,19 @@ export function createTesterAuthAdminRouter({
 
   router.post("/prepare", async (req, res) => {
     try {
-      const status = await getDigitalOceanStatus();
-      const existing = new Set(
-        (status.environmentVariables || []).map(({ key }) => key),
-      );
-      const missingKeys = TESTER_AUTH_ENV_KEYS.filter(
-        (key) => !existing.has(key),
-      );
+      const status = await inspectDigitalOcean({
+        projectUrl: bootstrap.projectUrl,
+        publishableKey: bootstrap.publishableKey,
+      });
+      const missingKeys = status.missingKeys;
       if (!missingKeys.length) {
         return res.json({
           configured: true,
           registrationEnabled: isTesterRegistrationEnabled(env),
           missingKeys: [],
+          readAccessVerified: status.readAccessVerified,
+          requiredWriteScope: status.requiredWriteScope,
+          writeAccess: status.writeAccess,
         });
       }
       const confirmation = await createConfirmation({
@@ -126,8 +127,11 @@ export function createTesterAuthAdminRouter({
         confirmationId: confirmation.id,
         expiresAt: new Date(confirmation.expiresAt).toISOString(),
         missingKeys,
+        readAccessVerified: status.readAccessVerified,
+        requiredWriteScope: status.requiredWriteScope,
+        writeAccess: status.writeAccess,
         message:
-          "Ще добавя само настройките за Supabase тестови профили и ще започне нов DigitalOcean deployment.",
+          "Предварителната проверка на токена, приложението и app spec-а е успешна. За записа DigitalOcean изисква app:update. Ще добавя само настройките за Supabase тестови профили и ще започне нов deployment.",
       });
     } catch (error) {
       const response = safeError(error);

--- a/src/services/digitalOceanService.js
+++ b/src/services/digitalOceanService.js
@@ -17,6 +17,68 @@ export class DigitalOceanError extends Error {
   }
 }
 
+function safeUpstreamMessage(payload) {
+  const message =
+    typeof payload?.message === "string" ? payload.message.trim() : "";
+  if (!message) return "";
+  return message
+    .replace(/\b(?:dop|doo|dor)_v1_[A-Za-z0-9_-]+\b/gu, "[скрит токен]")
+    .replace(/\bBearer\s+[A-Za-z0-9._-]+\b/giu, "Bearer [скрит токен]")
+    .slice(0, 300);
+}
+
+async function readErrorPayload(response) {
+  try {
+    const payload = await response.json();
+    return payload && typeof payload === "object" ? payload : {};
+  } catch {
+    return {};
+  }
+}
+
+function digitalOceanRequestError(response, payload, { method, path }) {
+  const upstreamMessage = safeUpstreamMessage(payload);
+  const suffix = upstreamMessage ? ` DigitalOcean: ${upstreamMessage}` : "";
+
+  if (response.status === 401) {
+    return new DigitalOceanError(
+      `DigitalOcean токенът е невалиден, изтекъл или е отнет.${suffix}`,
+      401,
+      "DIGITALOCEAN_TOKEN_INVALID",
+    );
+  }
+  if (
+    response.status === 403 &&
+    method === "PUT" &&
+    /^\/apps\/[^/]+$/u.test(path)
+  ) {
+    return new DigitalOceanError(
+      `DigitalOcean токенът няма право да променя App Platform. Нужно е разрешение app:update заедно с app:read.${suffix}`,
+      403,
+      "DIGITALOCEAN_APP_UPDATE_FORBIDDEN",
+    );
+  }
+  if (response.status === 403) {
+    return new DigitalOceanError(
+      `DigitalOcean токенът няма право за това действие.${suffix}`,
+      403,
+      "DIGITALOCEAN_FORBIDDEN",
+    );
+  }
+  if (response.status === 422) {
+    return new DigitalOceanError(
+      `DigitalOcean отхвърли настройките на приложението.${suffix}`,
+      422,
+      "DIGITALOCEAN_APP_SPEC_REJECTED",
+    );
+  }
+  return new DigitalOceanError(
+    `DigitalOcean API върна грешка ${response.status}.${suffix}`,
+    response.status >= 400 && response.status < 500 ? response.status : 502,
+    "DIGITALOCEAN_UPSTREAM_ERROR",
+  );
+}
+
 function requiredToken(env = process.env) {
   const token = env.DIGITALOCEAN_API_TOKEN || env.DIGITALOCEAN_TOKEN;
   if (!token) {
@@ -65,11 +127,8 @@ async function request(
     },
   );
   if (!response.ok) {
-    throw new DigitalOceanError(
-      `DigitalOcean API върна грешка ${response.status}.`,
-      response.status === 401 || response.status === 403 ? 401 : 502,
-      "DIGITALOCEAN_UPSTREAM_ERROR",
-    );
+    const payload = await readErrorPayload(response);
+    throw digitalOceanRequestError(response, payload, { method, path });
   }
   return response.json();
 }
@@ -185,13 +244,12 @@ export function addTesterAuthEnvironmentVariables(
   return { spec: nextSpec, missingKeys };
 }
 
-export async function activateTesterAuthConfiguration({
+async function loadTesterAuthActivation({
   projectUrl,
   publishableKey,
   expectedAppId = "",
   env = process.env,
   fetchImpl = fetch,
-  randomBytesImpl = randomBytes,
 } = {}) {
   const { token, appId } = requiredAppConfig(env);
   if (expectedAppId && expectedAppId !== appId) {
@@ -207,7 +265,50 @@ export async function activateTesterAuthConfiguration({
   const app = appData.app || {};
   const currentSpec = app.spec;
   assertSafeSecretRoundTrip(currentSpec);
-  const existingMissing = missingTesterAuthEnvironmentKeys(currentSpec);
+  return {
+    app,
+    appId,
+    config,
+    currentSpec,
+    missingKeys: missingTesterAuthEnvironmentKeys(currentSpec),
+    options,
+  };
+}
+
+export async function inspectTesterAuthActivation(options = {}) {
+  const inspection = await loadTesterAuthActivation(options);
+  return {
+    appId: inspection.appId,
+    missingKeys: inspection.missingKeys,
+    readAccessVerified: true,
+    requiredWriteScope: "app:update",
+    writeAccess:
+      inspection.missingKeys.length === 0 ? "not-needed" : "verified-on-update",
+  };
+}
+
+export async function activateTesterAuthConfiguration({
+  projectUrl,
+  publishableKey,
+  expectedAppId = "",
+  env = process.env,
+  fetchImpl = fetch,
+  randomBytesImpl = randomBytes,
+} = {}) {
+  const {
+    app,
+    appId,
+    config,
+    currentSpec,
+    missingKeys: existingMissing,
+    options,
+  } = await loadTesterAuthActivation({
+    projectUrl,
+    publishableKey,
+    expectedAppId,
+    env,
+    fetchImpl,
+  });
   if (!existingMissing.length) {
     return {
       updated: false,

--- a/tests/digitalOceanTesterAuth.test.js
+++ b/tests/digitalOceanTesterAuth.test.js
@@ -5,12 +5,23 @@ import {
   activateTesterAuthConfiguration,
   addTesterAuthEnvironmentVariables,
   DigitalOceanError,
+  inspectTesterAuthActivation,
   missingTesterAuthEnvironmentKeys,
   TESTER_AUTH_ENV_KEYS,
 } from "../src/services/digitalOceanService.js";
 
 const PROJECT_URL = "https://projectref.supabase.co";
 const PUBLISHABLE_KEY = "sb_publishable_abcdefghijklmnopqrstuvwxyz";
+
+function jsonResponse(status, payload) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async json() {
+      return payload;
+    },
+  };
+}
 
 test("adds only the missing tester-auth variables at app level", () => {
   const current = {
@@ -160,4 +171,64 @@ test("refuses to round-trip a redacted existing DigitalOcean secret", async () =
       error.code === "DIGITALOCEAN_SECRET_ROUND_TRIP_UNSAFE",
   );
   assert.equal(putCalled, false);
+});
+
+test("inspects tester auth safely before any write", async () => {
+  const methods = [];
+  const result = await inspectTesterAuthActivation({
+    projectUrl: PROJECT_URL,
+    publishableKey: PUBLISHABLE_KEY,
+    env: {
+      DIGITALOCEAN_API_TOKEN: "do-token",
+      DIGITALOCEAN_APP_ID: "app-1",
+    },
+    fetchImpl: async (_url, options) => {
+      methods.push(options.method);
+      return jsonResponse(200, {
+        app: { id: "app-1", spec: { name: "synchron", envs: [] } },
+      });
+    },
+  });
+
+  assert.deepEqual(methods, ["GET"]);
+  assert.equal(result.readAccessVerified, true);
+  assert.equal(result.requiredWriteScope, "app:update");
+  assert.equal(result.writeAccess, "verified-on-update");
+  assert.deepEqual(result.missingKeys, TESTER_AUTH_ENV_KEYS);
+});
+
+test("reports an actionable app:update error without leaking tokens", async () => {
+  let call = 0;
+  await assert.rejects(
+    activateTesterAuthConfiguration({
+      projectUrl: PROJECT_URL,
+      publishableKey: PUBLISHABLE_KEY,
+      env: {
+        DIGITALOCEAN_API_TOKEN: "do-token",
+        DIGITALOCEAN_APP_ID: "app-1",
+      },
+      fetchImpl: async (_url, options) => {
+        call += 1;
+        if (options.method === "GET") {
+          return jsonResponse(200, {
+            app: { id: "app-1", spec: { name: "synchron", envs: [] } },
+          });
+        }
+        return jsonResponse(403, {
+          id: "forbidden",
+          message:
+            "Token dop_v1_secretvalue has no access for the attempted action.",
+        });
+      },
+    }),
+    (error) => {
+      assert.equal(error.code, "DIGITALOCEAN_APP_UPDATE_FORBIDDEN");
+      assert.equal(error.status, 403);
+      assert.match(error.message, /app:update/u);
+      assert.doesNotMatch(error.message, /dop_v1_secretvalue/u);
+      assert.match(error.message, /\[скрит токен\]/u);
+      return true;
+    },
+  );
+  assert.equal(call, 2);
 });

--- a/tests/testerAuthAdminRouter.test.js
+++ b/tests/testerAuthAdminRouter.test.js
@@ -26,9 +26,17 @@ test("prepares an exact owner confirmation without returning the publishable key
   let created;
   const app = testApp({
     bootstrap: BOOTSTRAP,
-    getDigitalOceanStatus: async () => ({
-      id: "app-1",
-      environmentVariables: [],
+    inspectDigitalOcean: async () => ({
+      appId: "app-1",
+      missingKeys: [
+        "SUPABASE_URL",
+        "SUPABASE_PUBLISHABLE_KEY",
+        "SUPABASE_SESSION_ENCRYPTION_KEY",
+        "SYNCHRON_TEST_INVITE_CODE",
+      ],
+      readAccessVerified: true,
+      requiredWriteScope: "app:update",
+      writeAccess: "verified-on-update",
     }),
     createConfirmation: async (input) => {
       created = input;
@@ -51,6 +59,40 @@ test("prepares an exact owner confirmation without returning the publishable key
   assert.equal(created.action, ACTION);
   assert.equal(created.sessionId, "owner");
   assert.equal(created.params.publishableKey, BOOTSTRAP.publishableKey);
+  assert.equal(response.body.readAccessVerified, true);
+  assert.equal(response.body.requiredWriteScope, "app:update");
+  assert.equal(response.body.writeAccess, "verified-on-update");
+  assert.match(response.body.message, /Предварителната проверка/u);
+});
+
+test("returns the exact safe DigitalOcean permission error", async () => {
+  const error = new Error(
+    "DigitalOcean токенът няма право да променя App Platform. Нужно е разрешение app:update заедно с app:read.",
+  );
+  error.name = "DigitalOceanError";
+  error.status = 403;
+  error.code = "DIGITALOCEAN_APP_UPDATE_FORBIDDEN";
+  const app = testApp({
+    validateConfirmation: async () => ({
+      action: ACTION,
+      resource: { appId: "app-1" },
+      params: BOOTSTRAP,
+    }),
+    consumeConfirmation: async () => {},
+    activate: async () => {
+      throw error;
+    },
+    audit: async () => {},
+  });
+
+  const response = await request(app)
+    .post("/api/tester-auth/confirm")
+    .send({ confirmationId: "confirmation-1" })
+    .expect(403);
+
+  assert.equal(response.body.code, "DIGITALOCEAN_APP_UPDATE_FORBIDDEN");
+  assert.match(response.body.error, /app:update/u);
+  assert.doesNotMatch(response.body.error, /не успя$/u);
 });
 
 test("consumes the exact confirmation before activating DigitalOcean", async () => {

--- a/tests/workCenterUi.test.js
+++ b/tests/workCenterUi.test.js
@@ -340,13 +340,37 @@ test("missing owner session opens the protected GitHub login", async () => {
   card.click();
   await new Promise((resolve) => setTimeout(resolve, 0));
 
-  assert.equal(
-    document.body.dataset.redirectedTo,
-    "/api/github/connect",
-  );
+  assert.equal(document.body.dataset.redirectedTo, "/api/github/connect");
   assert.match(
     card.nextElementSibling.textContent,
     /Необходим е вход на собственика/u,
+  );
+});
+
+test("DigitalOcean token rejection stays visible and does not open GitHub", async () => {
+  const harness = createHarness({
+    testerPrepareResponse: {
+      ok: false,
+      status: 401,
+      json: async () => ({
+        error: "DigitalOcean токенът е невалиден, изтекъл или е отнет.",
+        code: "DIGITALOCEAN_TOKEN_INVALID",
+      }),
+    },
+  });
+  await openCenter(harness);
+  const { document } = harness.dom.window;
+  const card = document.querySelector(
+    '[data-work-center-action="activate-tester-auth"]',
+  );
+
+  card.click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(document.body.dataset.redirectedTo, undefined);
+  assert.match(
+    card.nextElementSibling.textContent,
+    /DigitalOcean токенът е невалиден/u,
   );
 });
 


### PR DESCRIPTION
## Какво се променя

- прави безопасна предварителна проверка само с GET на токена, приложението и app spec-а;
- показва точна и безопасна DigitalOcean грешка при невалиден токен, липсващ `app:update` или отхвърлен app spec;
- скрива токени от upstream съобщенията;
- не бърка DigitalOcean 401/403 със загубен GitHub собственически вход.

## Причина

Production заменяше реалния отказ на DigitalOcean с общото „Действието не успя“, а клиентът можеше погрешно да отвори GitHub вход при DigitalOcean 401.

## Проверки

- 317 успешни теста, 0 неуспешни, 1 пропуснат реален OpenSearch тест;
- 24/24 целеви теста;
- Prettier проверка на шестте файла;
- remote blob SHA на всеки файл съвпада с локално тествания файл.

`main` и production не се променят от този Draft PR.