### PR TITLE
Довърши runtime настройката на тестовия вход

### DIFF
--- a/src/services/userAuthService.js
+++ b/src/services/userAuthService.js
@@ -7,6 +7,7 @@ import {
   scryptSync,
   timingSafeEqual,
 } from "node:crypto";
+import { TESTER_AUTH_BOOTSTRAP } from "../config/testerAuthBootstrap.js";
 
 export const USER_SESSION_COOKIE = "synchron_user_session";
 const SESSION_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
@@ -65,11 +66,14 @@ export function getTesterInviteCode(env = process.env) {
 
 function authConfig(env = process.env) {
   return {
-    projectUrl: normalizeProjectUrl(env.SUPABASE_URL),
+    projectUrl: normalizeProjectUrl(
+      env.SUPABASE_URL || TESTER_AUTH_BOOTSTRAP.projectUrl,
+    ),
     publishableKey:
-      typeof env.SUPABASE_PUBLISHABLE_KEY === "string"
+      typeof env.SUPABASE_PUBLISHABLE_KEY === "string" &&
+      env.SUPABASE_PUBLISHABLE_KEY.trim()
         ? env.SUPABASE_PUBLISHABLE_KEY.trim()
-        : "",
+        : TESTER_AUTH_BOOTSTRAP.publishableKey,
     encryptionSecret: sessionSecret(env),
   };
 }

--- a/tests/userAuthService.test.js
+++ b/tests/userAuthService.test.js
@@ -50,6 +50,7 @@ test("derives isolated tester secrets from the existing owner session secret", (
     SUPABASE_PUBLISHABLE_KEY: ENV.SUPABASE_PUBLISHABLE_KEY,
     GITHUB_SESSION_ENCRYPTION_KEY: "github-only-key-with-enough-entropy",
   };
+  const expectedSession = session("derived");
   assert.equal(isUserAuthConfigured(fallbackEnv), true);
   assert.equal(isTesterRegistrationEnabled(fallbackEnv), true);
   assert.equal(getTesterInviteCode(fallbackEnv).length, 16);
@@ -59,10 +60,10 @@ test("derives isolated tester secrets from the existing owner session secret", (
   );
   assert.deepEqual(
     decryptUserSession(
-      encryptUserSession(session("derived"), fallbackEnv),
+      encryptUserSession(expectedSession, fallbackEnv),
       fallbackEnv,
     ),
-    session("derived"),
+    expectedSession,
   );
 });
 
@@ -80,6 +81,14 @@ test("the configured GitHub client secret is a safe final fallback", () => {
   assert.equal(isUserAuthConfigured(fallbackEnv), true);
   assert.equal(isTesterRegistrationEnabled(fallbackEnv), true);
   assert.equal(getTesterInviteCode(fallbackEnv).length, 16);
+});
+
+test("uses the public production Supabase connection when App Platform omits it", () => {
+  const fallbackEnv = {
+    GITHUB_SESSION_ENCRYPTION_KEY: "github-only-key-with-enough-entropy",
+  };
+  assert.equal(isUserAuthConfigured(fallbackEnv), true);
+  assert.equal(isTesterRegistrationEnabled(fallbackEnv), true);
 });
 
 test("encrypts the Supabase session and never leaves tokens in the cookie", () => {


### PR DESCRIPTION
Production е на merge commit `5dc03ab`, но `/api/auth/session` връща `configured:false`, защото DigitalOcean не прилага стойностите от `.do/app.yaml` към вече съществуващия App spec.

Промяната:
- използва вече съществуващия публичен Supabase bootstrap, когато runtime variables липсват;
- запазва отделните runtime variables като override;
- не променя OpenSearch, паметта или AI разговора;
- стабилизира auth тест, зависещ от граница на секундата.

Проверка: 321 успешни, 0 неуспешни, 1 пропуснат реален OpenSearch тест.