### PR TITLE
Осигури защитен fallback за тестовите сесии

### DIFF
--- a/src/services/userAuthService.js
+++ b/src/services/userAuthService.js
@@ -37,15 +37,16 @@ function normalizeProjectUrl(value) {
 function sessionSecret(env = process.env) {
   const dedicated = (env.SUPABASE_SESSION_ENCRYPTION_KEY || "").trim();
   if (dedicated) return dedicated;
-  const ownerSessionSecret = (
+  const fallbackSecret = (
     env.GITHUB_SESSION_ENCRYPTION_KEY ||
     env.GITHUB_CLIENT_SECRET ||
+    env.SYNCHRON_TEST_INVITE_CODE ||
     ""
   ).trim();
-  if (ownerSessionSecret.length < 16) return "";
+  if (fallbackSecret.length < 16) return "";
   return createHash("sha256")
     .update("synchron-supabase-session-v1\0")
-    .update(ownerSessionSecret)
+    .update(fallbackSecret)
     .digest("base64url");
 }
 

--- a/tests/userAuthService.test.js
+++ b/tests/userAuthService.test.js
@@ -91,6 +91,14 @@ test("uses the public production Supabase connection when App Platform omits it"
   assert.equal(isTesterRegistrationEnabled(fallbackEnv), true);
 });
 
+test("derives session protection from the private production invite code", () => {
+  const productionLikeEnv = {
+    SYNCHRON_TEST_INVITE_CODE: "private-invite-code-with-enough-entropy",
+  };
+  assert.equal(isUserAuthConfigured(productionLikeEnv), true);
+  assert.equal(isTesterRegistrationEnabled(productionLikeEnv), true);
+});
+
 test("encrypts the Supabase session and never leaves tokens in the cookie", () => {
   const original = session("secret");
   const encrypted = encryptUserSession(original, ENV);


### PR DESCRIPTION
Production на `ff026455` потвърди `registrationEnabled:true`, но `configured:false`: кодът за покана е наличен, а отделният session encryption key липсва.

Промяната извежда domain-separated SHA-256 сесиен ключ от наличния частен invite secret само когато dedicated session key и GitHub secrets липсват. Invite кодът не се записва в cookie и не се разкрива. OpenSearch, паметта и AI разговорът не се променят.

Проверка: 322 успешни, 0 неуспешни, 1 пропуснат реален OpenSearch тест.