### PR TITLE
Използвай operational MCP secret за тестови сесии

### DIFF
--- a/src/services/userAuthService.js
+++ b/src/services/userAuthService.js
@@ -40,6 +40,7 @@ function sessionSecret(env = process.env) {
   const fallbackSecret = (
     env.GITHUB_SESSION_ENCRYPTION_KEY ||
     env.GITHUB_CLIENT_SECRET ||
+    env.MCP_ACCESS_TOKEN ||
     env.SYNCHRON_TEST_INVITE_CODE ||
     ""
   ).trim();

--- a/tests/userAuthService.test.js
+++ b/tests/userAuthService.test.js
@@ -99,6 +99,15 @@ test("derives session protection from the private production invite code", () =>
   assert.equal(isTesterRegistrationEnabled(productionLikeEnv), true);
 });
 
+test("uses the operational MCP secret when the invite code is short", () => {
+  const productionLikeEnv = {
+    MCP_ACCESS_TOKEN: "mcp-access-token-with-at-least-32-characters",
+    SYNCHRON_TEST_INVITE_CODE: "short-code",
+  };
+  assert.equal(isUserAuthConfigured(productionLikeEnv), true);
+  assert.equal(isTesterRegistrationEnabled(productionLikeEnv), true);
+});
+
 test("encrypts the Supabase session and never leaves tokens in the cookie", () => {
   const original = session("secret");
   const encrypted = encryptUserSession(original, ENV);


### PR DESCRIPTION
Живата проверка потвърди, че MCP bridge е operational и `MCP_ACCESS_TOKEN` е минимум 32 знака, докато invite кодът е по-къс от 16. Добавя се MCP secret като domain-separated SHA-256 fallback за потребителските сесии. Стойността не се разкрива и не се записва в cookie.

OpenSearch, паметта и AI разговорът не се променят.

Проверка: 323 успешни, 0 неуспешни, 1 пропуснат реален OpenSearch тест.