### PR TITLE
Покажи безопасна диагностика на тестовия вход

### DIFF
--- a/src/routes/userAuthRouter.js
+++ b/src/routes/userAuthRouter.js
@@ -1,6 +1,7 @@
 import express from "express";
 import {
   clearUserSessionCookie,
+  getUserAuthConfigurationStatus,
   isTesterRegistrationEnabled,
   isUserAuthConfigured,
   registerTester,
@@ -32,6 +33,7 @@ router.get("/session", async (req, res) => {
     const identity = await resolveRequestIdentity(req, res);
     return res.json({
       configured: isUserAuthConfigured(),
+      configuration: getUserAuthConfigurationStatus(),
       registrationEnabled: isTesterRegistrationEnabled(),
       authenticated: Boolean(identity),
       user: identity

--- a/src/services/userAuthService.js
+++ b/src/services/userAuthService.js
@@ -80,13 +80,17 @@ function authConfig(env = process.env) {
   };
 }
 
-export function isUserAuthConfigured(env = process.env) {
+export function getUserAuthConfigurationStatus(env = process.env) {
   const config = authConfig(env);
-  return Boolean(
-    config.projectUrl &&
-    config.publishableKey &&
-    config.encryptionSecret.length >= 16,
-  );
+  return {
+    projectConnection: Boolean(config.projectUrl && config.publishableKey),
+    sessionProtection: config.encryptionSecret.length >= 16,
+  };
+}
+
+export function isUserAuthConfigured(env = process.env) {
+  const status = getUserAuthConfigurationStatus(env);
+  return status.projectConnection && status.sessionProtection;
 }
 
 export function isTesterRegistrationEnabled(env = process.env) {

--- a/tests/userAuthService.test.js
+++ b/tests/userAuthService.test.js
@@ -5,6 +5,7 @@ import {
   decryptUserSession,
   encryptUserSession,
   getTesterInviteCode,
+  getUserAuthConfigurationStatus,
   isTesterRegistrationEnabled,
   isUserAuthConfigured,
   registerTester,
@@ -106,6 +107,10 @@ test("uses the operational MCP secret when the invite code is short", () => {
   };
   assert.equal(isUserAuthConfigured(productionLikeEnv), true);
   assert.equal(isTesterRegistrationEnabled(productionLikeEnv), true);
+  assert.deepEqual(getUserAuthConfigurationStatus(productionLikeEnv), {
+    projectConnection: true,
+    sessionProtection: true,
+  });
 });
 
 test("encrypts the Supabase session and never leaves tokens in the cookie", () => {


### PR DESCRIPTION
Живият runtime отчита MCP bridge configured, но tester auth остава false. Добавя се само безопасна диагностика с два булеви флага: Supabase project connection и session protection. Не се връщат имена или стойности на secrets.

Проверка: 323 успешни, 0 неуспешни, 1 пропуснат реален OpenSearch тест.