### PR TITLE
Отхвърли DigitalOcean placeholders за Supabase

### DIFF
--- a/src/services/userAuthService.js
+++ b/src/services/userAuthService.js
@@ -34,6 +34,13 @@ function normalizeProjectUrl(value) {
   }
 }
 
+function normalizePublishableKey(value) {
+  const key = typeof value === "string" ? value.trim() : "";
+  return key.startsWith("sb_publishable_") || key.split(".").length === 3
+    ? key
+    : "";
+}
+
 function sessionSecret(env = process.env) {
   const dedicated = (env.SUPABASE_SESSION_ENCRYPTION_KEY || "").trim();
   if (dedicated) return dedicated;
@@ -67,15 +74,15 @@ export function getTesterInviteCode(env = process.env) {
 }
 
 function authConfig(env = process.env) {
+  const projectUrl =
+    normalizeProjectUrl(env.SUPABASE_URL) ||
+    normalizeProjectUrl(TESTER_AUTH_BOOTSTRAP.projectUrl);
+  const publishableKey =
+    normalizePublishableKey(env.SUPABASE_PUBLISHABLE_KEY) ||
+    normalizePublishableKey(TESTER_AUTH_BOOTSTRAP.publishableKey);
   return {
-    projectUrl: normalizeProjectUrl(
-      env.SUPABASE_URL || TESTER_AUTH_BOOTSTRAP.projectUrl,
-    ),
-    publishableKey:
-      typeof env.SUPABASE_PUBLISHABLE_KEY === "string" &&
-      env.SUPABASE_PUBLISHABLE_KEY.trim()
-        ? env.SUPABASE_PUBLISHABLE_KEY.trim()
-        : TESTER_AUTH_BOOTSTRAP.publishableKey,
+    projectUrl,
+    publishableKey,
     encryptionSecret: sessionSecret(env),
   };
 }

--- a/tests/userAuthService.test.js
+++ b/tests/userAuthService.test.js
@@ -113,6 +113,20 @@ test("uses the operational MCP secret when the invite code is short", () => {
   });
 });
 
+test("rejects encrypted App Platform placeholders before using public bootstrap", () => {
+  const productionLikeEnv = {
+    SUPABASE_URL: "EV[1:encrypted-placeholder]",
+    SUPABASE_PUBLISHABLE_KEY: "EV[1:encrypted-placeholder]",
+    MCP_ACCESS_TOKEN: "mcp-access-token-with-at-least-32-characters",
+    SYNCHRON_TEST_INVITE_CODE: "short-code",
+  };
+  assert.deepEqual(getUserAuthConfigurationStatus(productionLikeEnv), {
+    projectConnection: true,
+    sessionProtection: true,
+  });
+  assert.equal(isUserAuthConfigured(productionLikeEnv), true);
+});
+
 test("encrypts the Supabase session and never leaves tokens in the cookie", () => {
   const original = session("secret");
   const encrypted = encryptUserSession(original, ENV);


### PR DESCRIPTION
Production диагностиката показа `projectConnection:false` при активна session protection. Непразни DigitalOcean placeholders блокират fallback-а. Промяната валидира URL и publishable key преди употреба; невалидните placeholders се заменят с вече проверения публичен Supabase bootstrap.

Проверка: 324 успешни, 0 неуспешни, 1 пропуснат реален OpenSearch тест.