### PR TITLE
Документирай инфраструктурните environment променливи

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -35,6 +35,12 @@ services:
       - key: APP_COMMIT_SHA
         value: ${_self.COMMIT_HASH}
         scope: RUN_TIME
+      - key: MCP_ACCESS_TOKEN
+        scope: RUN_TIME
+        type: SECRET
+      - key: MEMORY_OWNER_ID
+        scope: RUN_TIME
+        type: SECRET
       - key: OPENSEARCH_HOST
         scope: RUN_TIME
         type: SECRET

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ OPENSEARCH_PORT=your-port
 # TLS certificate verification is enabled by default and always enforced in production.
 OPENSEARCH_TLS_REJECT_UNAUTHORIZED=true
 
+# Required stable owner identifier used to isolate the primary user's memory.
+MEMORY_OWNER_ID=your-stable-memory-owner-id
+# Required bearer token for the protected MCP bridge. Use a long random secret.
+MCP_ACCESS_TOKEN=your-long-random-mcp-access-token
+
 SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_PUBLISHABLE_KEY=your-supabase-publishable-key
 # Required dedicated key. Supabase sessions never reuse another integration's
@@ -40,6 +45,16 @@ GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 GOOGLE_REDIRECT_URI=https://synchron.foundation/api/google/callback
 GOOGLE_SESSION_ENCRYPTION_KEY=your-long-random-session-encryption-key
+
+# Optional: protected infrastructure diagnostics
+DIGITALOCEAN_API_TOKEN=
+# Legacy alias accepted by the runtime; prefer DIGITALOCEAN_API_TOKEN.
+DIGITALOCEAN_TOKEN=
+DIGITALOCEAN_APP_ID=
+DIGITALOCEAN_API_URL=https://api.digitalocean.com/v2
+CLOUDFLARE_API_TOKEN=
+CLOUDFLARE_ZONE_ID=
+CLOUDFLARE_API_URL=https://api.cloudflare.com/client/v4
 
 # Optional: Logic Core Service
 LOGIC_CORE_URL=http://127.0.0.1:8000

--- a/tests/environmentContract.test.js
+++ b/tests/environmentContract.test.js
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const appSpec = readFileSync(new URL("../.do/app.yaml", import.meta.url), "utf8");
+const envExample = readFileSync(
+  new URL("../.env.example", import.meta.url),
+  "utf8",
+);
+
+function appSpecEnvironmentKeys(source) {
+  return new Set(
+    [...source.matchAll(/^\s+- key:\s*([A-Z0-9_]+)\s*$/gmu)].map(
+      (match) => match[1],
+    ),
+  );
+}
+
+function exampleEnvironmentKeys(source) {
+  return new Set(
+    [...source.matchAll(/^([A-Z0-9_]+)=/gmu)].map((match) => match[1]),
+  );
+}
+
+function appSpecKeyBlock(source, key) {
+  const lines = source.split("\n");
+  const start = lines.findIndex(
+    (line) => line.trim() === `- key: ${key}`,
+  );
+  assert.notEqual(start, -1, `${key} must exist in .do/app.yaml`);
+
+  const end = lines.findIndex(
+    (line, index) => index > start && /^\s+- key:/u.test(line),
+  );
+  return lines.slice(start, end === -1 ? lines.length : end).join("\n");
+}
+
+test("required MCP and memory variables stay declared in DigitalOcean", () => {
+  const keys = appSpecEnvironmentKeys(appSpec);
+
+  for (const key of ["MCP_ACCESS_TOKEN", "MEMORY_OWNER_ID"]) {
+    assert.equal(keys.has(key), true, `${key} is missing from .do/app.yaml`);
+
+    const block = appSpecKeyBlock(appSpec, key);
+    assert.match(block, /^\s*type:\s*SECRET\s*$/mu);
+    assert.doesNotMatch(block, /^\s*value:/mu);
+  }
+});
+
+test("bridge variables stay documented without real secret values", () => {
+  const keys = exampleEnvironmentKeys(envExample);
+  const documentedKeys = [
+    "MCP_ACCESS_TOKEN",
+    "MEMORY_OWNER_ID",
+    "DIGITALOCEAN_API_TOKEN",
+    "DIGITALOCEAN_TOKEN",
+    "DIGITALOCEAN_APP_ID",
+    "DIGITALOCEAN_API_URL",
+    "CLOUDFLARE_API_TOKEN",
+    "CLOUDFLARE_ZONE_ID",
+    "CLOUDFLARE_API_URL",
+  ];
+
+  for (const key of documentedKeys) {
+    assert.equal(keys.has(key), true, `${key} is missing from .env.example`);
+  }
+
+  for (const key of [
+    "DIGITALOCEAN_API_TOKEN",
+    "DIGITALOCEAN_TOKEN",
+    "CLOUDFLARE_API_TOKEN",
+  ]) {
+    assert.match(envExample, new RegExp(`^${key}=$`, "mu"));
+  }
+});


### PR DESCRIPTION
## Какво се променя

- добавя `MCP_ACCESS_TOKEN` и `MEMORY_OWNER_ID` в DigitalOcean app spec като `SECRET`, без стойности;
- описва MCP, memory, DigitalOcean и Cloudflare променливите в `.env.example`;
- добавя автоматичен тест за environment договора и за липса на реални токени в примерната конфигурация.

## Защо

Кодът използва тези имена, но част от тях не бяха описани в deployment spec-а и примерната среда. Това създава риск бъдещ deployment или локална настройка да пропусне необходима променлива.

## Влияние

Няма промяна в приложната логика, AI разговора, OpenSearch данните или текущите тайни. PR-ът не съдържа стойности на тайни.

## Проверки

- `node --test tests/environmentContract.test.js` — 2 успешни теста;
- `node --check tests/environmentContract.test.js` — успешно;
- `.do/app.yaml` — успешно парсиран като YAML;
- качените три файла съвпадат с локално проверените.