### PR TITLE
Блокирай неодобрени Supabase тестови профили

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,8 @@ OPENSEARCH_HOST=your-host
 OPENSEARCH_PORT=your-port
 # TLS certificate verification is enabled by default and always enforced in production.
 OPENSEARCH_TLS_REJECT_UNAUTHORIZED=true
+# Optional index for server-approved tester accounts. The default is safe.
+TESTER_ACCESS_INDEX=synchron-tester-access-v1
 
 # Required stable owner identifier used to isolate the primary user's memory.
 MEMORY_OWNER_ID=your-stable-memory-owner-id

--- a/src/services/testerAccessService.js
+++ b/src/services/testerAccessService.js
@@ -1,0 +1,113 @@
+import { getOpenSearchClient } from "../config/opensearch.js";
+
+const DEFAULT_INDEX = "synchron-tester-access-v1";
+
+export class TesterAccessError extends Error {
+  constructor(message, status, code) {
+    super(message);
+    this.name = "TesterAccessError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function cleanUserId(user) {
+  const userId = typeof user?.id === "string" ? user.id.trim() : "";
+  if (!userId) {
+    throw new TesterAccessError(
+      "Supabase не върна валиден потребител.",
+      502,
+      "AUTH_INVALID_USER",
+    );
+  }
+  return userId;
+}
+
+function accessIndex(env = process.env) {
+  const configured =
+    typeof env.TESTER_ACCESS_INDEX === "string"
+      ? env.TESTER_ACCESS_INDEX.trim()
+      : "";
+  return configured || DEFAULT_INDEX;
+}
+
+function requireClient(client = getOpenSearchClient()) {
+  if (!client) {
+    throw new TesterAccessError(
+      "Проверката на одобрените тестови профили временно не е достъпна.",
+      503,
+      "TESTER_ACCESS_UNAVAILABLE",
+    );
+  }
+  return client;
+}
+
+function statusCode(error) {
+  return error?.statusCode || error?.meta?.statusCode || error?.status;
+}
+
+export async function approveTesterAccess(
+  user,
+  { client, env = process.env } = {},
+) {
+  const userId = cleanUserId(user);
+  const approvedAt = new Date().toISOString();
+  try {
+    await requireClient(client).index({
+      index: accessIndex(env),
+      id: userId,
+      body: {
+        userId,
+        status: "approved",
+        approvedAt,
+      },
+      refresh: true,
+    });
+  } catch (error) {
+    if (error instanceof TesterAccessError) throw error;
+    throw new TesterAccessError(
+      "Одобрението на тестовия профил не можа да бъде запазено.",
+      503,
+      "TESTER_ACCESS_PERSISTENCE_FAILED",
+    );
+  }
+  return { userId, approvedAt };
+}
+
+export async function assertTesterAccess(
+  user,
+  { client, env = process.env } = {},
+) {
+  const userId = cleanUserId(user);
+  const primaryUserId =
+    typeof env.SYNCHRON_PRIMARY_SUPABASE_USER_ID === "string"
+      ? env.SYNCHRON_PRIMARY_SUPABASE_USER_ID.trim()
+      : "";
+  if (primaryUserId && userId === primaryUserId) return true;
+
+  try {
+    const response = await requireClient(client).get({
+      index: accessIndex(env),
+      id: userId,
+    });
+    const source = response.body?._source ?? response._source;
+    if (source?.userId === userId && source?.status === "approved") {
+      return true;
+    }
+  } catch (error) {
+    if (error instanceof TesterAccessError) throw error;
+    if (Number(statusCode(error)) !== 404) {
+      throw new TesterAccessError(
+        "Проверката на одобрения тестов профил временно не е достъпна.",
+        503,
+        "TESTER_ACCESS_UNAVAILABLE",
+      );
+    }
+  }
+
+  throw new TesterAccessError(
+    "Този профил няма одобрен тестов достъп.",
+    403,
+    "TESTER_ACCESS_NOT_APPROVED",
+  );
+}

--- a/src/services/userAuthService.js
+++ b/src/services/userAuthService.js
@@ -8,6 +8,11 @@ import {
   timingSafeEqual,
 } from "node:crypto";
 import { TESTER_AUTH_BOOTSTRAP } from "../config/testerAuthBootstrap.js";
+import {
+  approveTesterAccess,
+  assertTesterAccess,
+  TesterAccessError,
+} from "./testerAccessService.js";
 
 export const USER_SESSION_COOKIE = "synchron_user_session";
 const SESSION_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
@@ -407,9 +412,27 @@ function mapAuthError(error, fallbackMessage) {
   );
 }
 
+function mapTesterAccessError(error) {
+  if (
+    error instanceof TesterAccessError ||
+    (typeof error?.code === "string" && error.code.startsWith("TESTER_ACCESS_"))
+  ) {
+    return new UserAuthError(
+      error.message || "Тестовият достъп беше отказан.",
+      Number(error.status) || 503,
+      error.code,
+    );
+  }
+  return new UserAuthError(
+    "Проверката на тестовия достъп временно не е достъпна.",
+    503,
+    "TESTER_ACCESS_UNAVAILABLE",
+  );
+}
+
 export async function signInUser(
   { email, password },
-  { env = process.env, client } = {},
+  { env = process.env, client, requireTesterAccess = assertTesterAccess } = {},
 ) {
   const authClient = client || createAuthClient(env);
   const credentials = {
@@ -420,12 +443,17 @@ export async function signInUser(
   if (error || !data?.user || !data?.session) {
     throw mapAuthError(error, "Имейлът или паролата са неправилни.");
   }
+  try {
+    await requireTesterAccess(data.user, { env });
+  } catch (error) {
+    throw mapTesterAccessError(error);
+  }
   return { user: data.user, session: sessionPayload(data.session) };
 }
 
 export async function registerTester(
   { email, password, displayName, inviteCode },
-  { env = process.env, client } = {},
+  { env = process.env, client, approveAccess = approveTesterAccess } = {},
 ) {
   if (!inviteCodeMatches(inviteCode, env)) {
     throw new UserAuthError(
@@ -452,6 +480,11 @@ export async function registerTester(
       error,
       "Потребителският профил не можа да бъде създаден.",
     );
+  }
+  try {
+    await approveAccess(data.user, { env });
+  } catch (error) {
+    throw mapTesterAccessError(error);
   }
   return {
     user: data.user,
@@ -485,7 +518,7 @@ function publicUser(user, env = process.env) {
 
 export async function resolveUserSession(
   cookieHeader,
-  { env = process.env, client } = {},
+  { env = process.env, client, requireTesterAccess = assertTesterAccess } = {},
 ) {
   const encrypted = parseCookies(cookieHeader)[USER_SESSION_COOKIE];
   const storedSession = decryptUserSession(encrypted, env);
@@ -513,6 +546,13 @@ export async function resolveUserSession(
     currentSession = sessionPayload(result.data.session);
     user = result.data.user;
     refreshed = true;
+  }
+
+  try {
+    await requireTesterAccess(user, { env });
+  } catch (error) {
+    if (error?.code === "TESTER_ACCESS_NOT_APPROVED") return null;
+    throw error;
   }
 
   return {

--- a/tests/testerAccessService.test.js
+++ b/tests/testerAccessService.test.js
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  approveTesterAccess,
+  assertTesterAccess,
+  TesterAccessError,
+} from "../src/services/testerAccessService.js";
+
+function createClient() {
+  const records = new Map();
+  return {
+    records,
+    async index({ id, body }) {
+      records.set(id, structuredClone(body));
+      return { body: { result: "created" } };
+    },
+    async get({ id }) {
+      if (!records.has(id)) {
+        const error = new Error("not found");
+        error.statusCode = 404;
+        throw error;
+      }
+      return { body: { _source: structuredClone(records.get(id)) } };
+    },
+  };
+}
+
+test("invite-approved registration stores a server-side access record", async () => {
+  const client = createClient();
+  const approved = await approveTesterAccess(
+    { id: "user-approved", email: "friend@example.com" },
+    { client },
+  );
+
+  assert.equal(approved.userId, "user-approved");
+  assert.deepEqual(Object.keys(client.records.get("user-approved")).sort(), [
+    "approvedAt",
+    "status",
+    "userId",
+  ]);
+  assert.equal(
+    await assertTesterAccess({ id: "user-approved" }, { client }),
+    true,
+  );
+});
+
+test("a direct Supabase signup cannot pass the application access boundary", async () => {
+  const client = createClient();
+
+  await assert.rejects(
+    assertTesterAccess({ id: "direct-signup" }, { client }),
+    (error) =>
+      error instanceof TesterAccessError &&
+      error.code === "TESTER_ACCESS_NOT_APPROVED" &&
+      error.status === 403,
+  );
+});
+
+test("the configured primary Supabase owner does not need a tester record", async () => {
+  const client = createClient();
+  assert.equal(
+    await assertTesterAccess(
+      { id: "primary-user-id" },
+      {
+        client,
+        env: { SYNCHRON_PRIMARY_SUPABASE_USER_ID: "primary-user-id" },
+      },
+    ),
+    true,
+  );
+});
+
+test("OpenSearch failures fail closed", async () => {
+  const client = {
+    async get() {
+      throw new Error("cluster unavailable");
+    },
+  };
+
+  await assert.rejects(
+    assertTesterAccess({ id: "user-a" }, { client }),
+    (error) =>
+      error instanceof TesterAccessError &&
+      error.code === "TESTER_ACCESS_UNAVAILABLE" &&
+      error.status === 503,
+  );
+});

--- a/tests/userAuthService.test.js
+++ b/tests/userAuthService.test.js
@@ -161,7 +161,7 @@ test("signs in with email and password through an isolated Supabase client", asy
 
   const result = await signInUser(
     { email: " Friend@Example.com ", password: "strong-pass-123" },
-    { env: ENV, client },
+    { env: ENV, client, requireTesterAccess: async () => true },
   );
   assert.equal(result.user.id, "user-login");
   assert.deepEqual(result.session, fakeSession);
@@ -204,7 +204,7 @@ test("uses the Supabase Auth password endpoint without exposing a service key", 
 
   const result = await signInUser(
     { email: "friend@example.com", password: "strong-pass-123" },
-    { env: ENV },
+    { env: ENV, requireTesterAccess: async () => true },
   );
 
   assert.equal(result.user.id, "rest-user");
@@ -226,6 +226,83 @@ test("tester registration requires the private invite code", async () => {
     (error) =>
       error instanceof UserAuthError &&
       error.code === "AUTH_INVALID_INVITE_CODE" &&
+      error.status === 403,
+  );
+});
+
+test("successful tester registration creates the application approval", async () => {
+  const fakeSession = session("register");
+  let approvedUser = null;
+  const client = {
+    auth: {
+      async signUp({ email, password, options }) {
+        assert.equal(email, "friend@example.com");
+        assert.equal(password, "strong-pass-123");
+        assert.equal(options.data.display_name, "Приятел");
+        return {
+          data: {
+            user: { id: "registered-user", email },
+            session: fakeSession,
+          },
+          error: null,
+        };
+      },
+    },
+  };
+
+  const result = await registerTester(
+    {
+      email: "friend@example.com",
+      password: "strong-pass-123",
+      displayName: "Приятел",
+      inviteCode: ENV.SYNCHRON_TEST_INVITE_CODE,
+    },
+    {
+      env: ENV,
+      client,
+      approveAccess: async (user) => {
+        approvedUser = user;
+      },
+    },
+  );
+
+  assert.equal(approvedUser.id, "registered-user");
+  assert.equal(result.user.id, "registered-user");
+  assert.deepEqual(result.session, fakeSession);
+});
+
+test("sign in refuses a valid Supabase user without application approval", async () => {
+  const client = {
+    auth: {
+      async signInWithPassword({ email }) {
+        return {
+          data: {
+            user: { id: "direct-signup", email },
+            session: session("direct"),
+          },
+          error: null,
+        };
+      },
+    },
+  };
+
+  await assert.rejects(
+    signInUser(
+      { email: "direct@example.com", password: "strong-pass-123" },
+      {
+        env: ENV,
+        client,
+        requireTesterAccess: async () => {
+          const error = new Error("not approved");
+          error.code = "TESTER_ACCESS_NOT_APPROVED";
+          error.status = 403;
+          throw error;
+        },
+      },
+    ),
+    (error) =>
+      error instanceof UserAuthError &&
+      error.code === "TESTER_ACCESS_NOT_APPROVED" &&
       error.status === 403,
   );
 });
@@ -259,6 +336,7 @@ test("two authenticated users receive different stable memory owners", async () 
       await resolveUserSession(cookie, {
         env: ENV,
         client,
+        requireTesterAccess: async () => true,
       }),
     );
   }


### PR DESCRIPTION
## Какво се поправя

Supabase регистрацията по имейл е активна и publishable key е публичен по предназначение. Досега кодът за покана се проверяваше само в сайта, така че директна заявка към Supabase можеше да създаде профил извън поканения поток и после да използва SYNCHRON-X.

## Промяна

- валидната регистрация с код за покана записва отделно сървърно одобрение в OpenSearch;
- входът и всяка възстановена Supabase сесия изискват това одобрение;
- директно създаден Supabase потребител се отказва с 403;
- при недостъпен регистър системата отказва по подразбиране;
- GitHub входът на собственика и постоянната памет не се променят;
- не се добавят нови secrets или платени услуги.

## Проверка

- 333 теста общо: 332 успешни, 0 неуспешни, 1 пропуснат реален OpenSearch тест без production credentials;
- целеви auth/access тестове: 22 успешни;
- production зависимости: 0 известни уязвимости;
- Prettier и diff проверките са чисти;
- петте файла в клона съвпадат точно с локално проверените версии.

## Риск

Нисък и fail-closed. Първият одобрен тестов профил ще създаде отделен индекс `synchron-tester-access-v1`. Истинската лична памет и съществуващите индекси не се променят.