### PR TITLE
Възстанови прекъсната регистрация на тестов профил

### DIFF
--- a/src/services/testerAccessService.js
+++ b/src/services/testerAccessService.js
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { getOpenSearchClient } from "../config/opensearch.js";
 
 const DEFAULT_INDEX = "synchron-tester-access-v1";
@@ -21,6 +23,16 @@ function cleanUserId(user) {
     );
   }
   return userId;
+}
+
+function cleanEmailHash(value) {
+  const email = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (!email) return "";
+  return createHash("sha256").update(email).digest("hex");
+}
+
+function emailApprovalId(emailHash) {
+  return `email:${emailHash}`;
 }
 
 function accessIndex(env = process.env) {
@@ -74,6 +86,41 @@ export async function approveTesterAccess(
   return { userId, approvedAt };
 }
 
+export async function approveTesterEmail(
+  email,
+  { client, env = process.env } = {},
+) {
+  const emailHash = cleanEmailHash(email);
+  if (!emailHash) {
+    throw new TesterAccessError(
+      "Липсва валиден имейл за тестовия достъп.",
+      400,
+      "TESTER_ACCESS_INVALID_EMAIL",
+    );
+  }
+  const approvedAt = new Date().toISOString();
+  try {
+    await requireClient(client).index({
+      index: accessIndex(env),
+      id: emailApprovalId(emailHash),
+      body: {
+        emailHash,
+        status: "approved",
+        approvedAt,
+      },
+      refresh: true,
+    });
+  } catch (error) {
+    if (error instanceof TesterAccessError) throw error;
+    throw new TesterAccessError(
+      "Предварителното одобрение на тестовия профил не можа да бъде запазено.",
+      503,
+      "TESTER_ACCESS_PERSISTENCE_FAILED",
+    );
+  }
+  return { emailHash, approvedAt };
+}
+
 export async function assertTesterAccess(
   user,
   { client, env = process.env } = {},
@@ -85,8 +132,9 @@ export async function assertTesterAccess(
       : "";
   if (primaryUserId && userId === primaryUserId) return true;
 
+  const accessClient = requireClient(client);
   try {
-    const response = await requireClient(client).get({
+    const response = await accessClient.get({
       index: accessIndex(env),
       id: userId,
     });
@@ -102,6 +150,28 @@ export async function assertTesterAccess(
         503,
         "TESTER_ACCESS_UNAVAILABLE",
       );
+    }
+  }
+
+  const emailHash = cleanEmailHash(user?.email);
+  if (emailHash) {
+    try {
+      const response = await accessClient.get({
+        index: accessIndex(env),
+        id: emailApprovalId(emailHash),
+      });
+      const source = response.body?._source ?? response._source;
+      if (source?.emailHash === emailHash && source?.status === "approved") {
+        return true;
+      }
+    } catch (error) {
+      if (Number(statusCode(error)) !== 404) {
+        throw new TesterAccessError(
+          "Проверката на одобрения тестов профил временно не е достъпна.",
+          503,
+          "TESTER_ACCESS_UNAVAILABLE",
+        );
+      }
     }
   }
 

--- a/src/services/testerAccessService.js
+++ b/src/services/testerAccessService.js
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 
 import { getOpenSearchClient } from "../config/opensearch.js";
 
@@ -25,10 +25,33 @@ function cleanUserId(user) {
   return userId;
 }
 
-function cleanEmailHash(value) {
+function emailApprovalKey(env = process.env) {
+  const secret = (
+    env.SUPABASE_SESSION_ENCRYPTION_KEY ||
+    env.GITHUB_SESSION_ENCRYPTION_KEY ||
+    env.MCP_ACCESS_TOKEN ||
+    env.SYNCHRON_TEST_INVITE_CODE ||
+    ""
+  ).trim();
+  if (secret.length < 16) {
+    throw new TesterAccessError(
+      "Защитата на одобренията по имейл не е конфигурирана.",
+      503,
+      "TESTER_ACCESS_UNAVAILABLE",
+    );
+  }
+  return createHash("sha256")
+    .update("synchron-tester-email-approval-v1\0")
+    .update(secret)
+    .digest();
+}
+
+function cleanEmailHash(value, env = process.env) {
   const email = typeof value === "string" ? value.trim().toLowerCase() : "";
   if (!email) return "";
-  return createHash("sha256").update(email).digest("hex");
+  return createHmac("sha256", emailApprovalKey(env))
+    .update(email)
+    .digest("hex");
 }
 
 function emailApprovalId(emailHash) {
@@ -90,7 +113,7 @@ export async function approveTesterEmail(
   email,
   { client, env = process.env } = {},
 ) {
-  const emailHash = cleanEmailHash(email);
+  const emailHash = cleanEmailHash(email, env);
   if (!emailHash) {
     throw new TesterAccessError(
       "Липсва валиден имейл за тестовия достъп.",
@@ -153,7 +176,7 @@ export async function assertTesterAccess(
     }
   }
 
-  const emailHash = cleanEmailHash(user?.email);
+  const emailHash = cleanEmailHash(user?.email, env);
   if (emailHash) {
     try {
       const response = await accessClient.get({

--- a/src/services/userAuthService.js
+++ b/src/services/userAuthService.js
@@ -10,6 +10,7 @@ import {
 import { TESTER_AUTH_BOOTSTRAP } from "../config/testerAuthBootstrap.js";
 import {
   approveTesterAccess,
+  approveTesterEmail,
   assertTesterAccess,
   TesterAccessError,
 } from "./testerAccessService.js";
@@ -453,7 +454,12 @@ export async function signInUser(
 
 export async function registerTester(
   { email, password, displayName, inviteCode },
-  { env = process.env, client, approveAccess = approveTesterAccess } = {},
+  {
+    env = process.env,
+    client,
+    approveAccess = approveTesterAccess,
+    approveEmail = approveTesterEmail,
+  } = {},
 ) {
   if (!inviteCodeMatches(inviteCode, env)) {
     throw new UserAuthError(
@@ -467,7 +473,13 @@ export async function registerTester(
     password: cleanPassword(password),
   };
   const authClient = client || createAuthClient(env);
-  const { data, error } = await authClient.auth.signUp({
+  try {
+    await approveEmail(cleanCredentials.email, { env });
+  } catch (error) {
+    throw mapTesterAccessError(error);
+  }
+
+  let { data, error } = await authClient.auth.signUp({
     ...cleanCredentials,
     options: {
       data: {
@@ -475,6 +487,16 @@ export async function registerTester(
       },
     },
   });
+
+  if (error || !data?.user) {
+    const recovered =
+      await authClient.auth.signInWithPassword(cleanCredentials);
+    if (!recovered.error && recovered.data?.user && recovered.data?.session) {
+      data = recovered.data;
+      error = null;
+    }
+  }
+
   if (error || !data?.user) {
     throw mapAuthError(
       error,

--- a/tests/testerAccessService.test.js
+++ b/tests/testerAccessService.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import test from "node:test";
 
 import {
@@ -26,6 +27,10 @@ function createClient() {
     },
   };
 }
+
+const ACCESS_ENV = {
+  MCP_ACCESS_TOKEN: "test-access-secret-with-enough-entropy",
+};
 
 test("invite-approved registration stores a server-side access record", async () => {
   const client = createClient();
@@ -58,15 +63,18 @@ test("a direct Supabase signup cannot pass the application access boundary", asy
   );
 });
 
-test("an invite-approved email can recover access without storing the raw email", async () => {
+test("an invite-approved email can recover access without storing a guessable email hash", async () => {
   const client = createClient();
-  const approved = await approveTesterEmail(" Friend@Example.com ", { client });
+  const approved = await approveTesterEmail(" Friend@Example.com ", {
+    client,
+    env: ACCESS_ENV,
+  });
 
   assert.equal(approved.emailHash.length, 64);
   assert.equal(
     await assertTesterAccess(
       { id: "recovered-user", email: "friend@example.com" },
-      { client },
+      { client, env: ACCESS_ENV },
     ),
     true,
   );
@@ -75,6 +83,10 @@ test("an invite-approved email can recover access without storing the raw email"
   );
   assert.ok(stored);
   assert.doesNotMatch(JSON.stringify(stored), /friend@example\.com/iu);
+  assert.notEqual(
+    approved.emailHash,
+    createHash("sha256").update("friend@example.com").digest("hex"),
+  );
 });
 
 test("the configured primary Supabase owner does not need a tester record", async () => {

--- a/tests/testerAccessService.test.js
+++ b/tests/testerAccessService.test.js
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   approveTesterAccess,
+  approveTesterEmail,
   assertTesterAccess,
   TesterAccessError,
 } from "../src/services/testerAccessService.js";
@@ -55,6 +56,25 @@ test("a direct Supabase signup cannot pass the application access boundary", asy
       error.code === "TESTER_ACCESS_NOT_APPROVED" &&
       error.status === 403,
   );
+});
+
+test("an invite-approved email can recover access without storing the raw email", async () => {
+  const client = createClient();
+  const approved = await approveTesterEmail(" Friend@Example.com ", { client });
+
+  assert.equal(approved.emailHash.length, 64);
+  assert.equal(
+    await assertTesterAccess(
+      { id: "recovered-user", email: "friend@example.com" },
+      { client },
+    ),
+    true,
+  );
+  const stored = [...client.records.values()].find(
+    (record) => record.emailHash === approved.emailHash,
+  );
+  assert.ok(stored);
+  assert.doesNotMatch(JSON.stringify(stored), /friend@example\.com/iu);
 });
 
 test("the configured primary Supabase owner does not need a tester record", async () => {

--- a/tests/userAuthService.test.js
+++ b/tests/userAuthService.test.js
@@ -260,6 +260,7 @@ test("successful tester registration creates the application approval", async ()
     {
       env: ENV,
       client,
+      approveEmail: async () => {},
       approveAccess: async (user) => {
         approvedUser = user;
       },
@@ -269,6 +270,92 @@ test("successful tester registration creates the application approval", async ()
   assert.equal(approvedUser.id, "registered-user");
   assert.equal(result.user.id, "registered-user");
   assert.deepEqual(result.session, fakeSession);
+});
+
+test("registration pre-approves the email before creating the Supabase user", async () => {
+  const calls = [];
+  const client = {
+    auth: {
+      async signUp({ email }) {
+        calls.push(`signup:${email}`);
+        return {
+          data: {
+            user: { id: "preapproved-user", email },
+            session: session("preapproved"),
+          },
+          error: null,
+        };
+      },
+    },
+  };
+
+  await registerTester(
+    {
+      email: "friend@example.com",
+      password: "strong-pass-123",
+      displayName: "Приятел",
+      inviteCode: ENV.SYNCHRON_TEST_INVITE_CODE,
+    },
+    {
+      env: ENV,
+      client,
+      approveEmail: async (email) => calls.push(`approve-email:${email}`),
+      approveAccess: async (user) => calls.push(`approve-user:${user.id}`),
+    },
+  );
+
+  assert.deepEqual(calls, [
+    "approve-email:friend@example.com",
+    "signup:friend@example.com",
+    "approve-user:preapproved-user",
+  ]);
+});
+
+test("registration recovers an existing invited user with the same password", async () => {
+  const fakeSession = session("recovered");
+  let approvedUser = null;
+  const client = {
+    auth: {
+      async signUp() {
+        return { data: null, error: { status: 422 } };
+      },
+      async signInWithPassword(credentials) {
+        assert.deepEqual(credentials, {
+          email: "friend@example.com",
+          password: "strong-pass-123",
+        });
+        return {
+          data: {
+            user: { id: "existing-user", email: credentials.email },
+            session: fakeSession,
+          },
+          error: null,
+        };
+      },
+    },
+  };
+
+  const result = await registerTester(
+    {
+      email: "friend@example.com",
+      password: "strong-pass-123",
+      displayName: "Приятел",
+      inviteCode: ENV.SYNCHRON_TEST_INVITE_CODE,
+    },
+    {
+      env: ENV,
+      client,
+      approveEmail: async () => {},
+      approveAccess: async (user) => {
+        approvedUser = user;
+      },
+    },
+  );
+
+  assert.equal(approvedUser.id, "existing-user");
+  assert.equal(result.user.id, "existing-user");
+  assert.deepEqual(result.session, fakeSession);
+  assert.equal(result.confirmationRequired, false);
 });
 
 test("sign in refuses a valid Supabase user without application approval", async () => {


### PR DESCRIPTION
## Какво поправя

След защитата в PR №139 оставаше граничен случай: Supabase може да създаде потребителя, а записът за одобрение в OpenSearch временно да се провали. При повторен опит съществуващият профил не можеше да завърши регистрацията.

## Промяна

- валидният код за покана записва предварително одобрение чрез domain-separated HMAC-SHA256 на нормализирания имейл;
- HMAC използва вече наличен високoентропиен production secret — не се добавя нова тайна;
- суровият имейл не се пази в регистъра за достъп и идентификаторът не може да се изчисли само чрез отгатване на имейла;
- директно създаден профил без валидна покана остава блокиран;
- ако Supabase профилът вече съществува, повторната регистрация проверява същите email/password и безопасно възстановява одобрението;
- няма service-role ключ, schema промени или достъп до личната памет.

## Проверки

- 336 теста общо: 335 успешни, 0 неуспешни, 1 пропуснат само без production OpenSearch credentials;
- 22/22 целеви теста успешни;
- Prettier: чисто;
- production npm audit: 0 уязвимости;
- Supabase security/performance advisors: 0 предупреждения.