### PR TITLE
Поправи възстановяването при прикрит Supabase signup

### DIFF
--- a/src/services/userAuthService.js
+++ b/src/services/userAuthService.js
@@ -488,7 +488,7 @@ export async function registerTester(
     },
   });
 
-  if (error || !data?.user) {
+  if (error || !data?.user || !data?.session) {
     const recovered =
       await authClient.auth.signInWithPassword(cleanCredentials);
     if (!recovered.error && recovered.data?.user && recovered.data?.session) {

--- a/tests/userAuthService.test.js
+++ b/tests/userAuthService.test.js
@@ -358,6 +358,104 @@ test("registration recovers an existing invited user with the same password", as
   assert.equal(result.confirmationRequired, false);
 });
 
+test("registration recovers an existing invited user from an obfuscated signup response", async () => {
+  const fakeSession = session("recovered-obfuscated");
+  let approvedUser = null;
+  const client = {
+    auth: {
+      async signUp({ email }) {
+        return {
+          data: {
+            user: { id: "obfuscated-user", email, identities: [] },
+            session: null,
+          },
+          error: null,
+        };
+      },
+      async signInWithPassword(credentials) {
+        assert.deepEqual(credentials, {
+          email: "friend@example.com",
+          password: "strong-pass-123",
+        });
+        return {
+          data: {
+            user: { id: "existing-user", email: credentials.email },
+            session: fakeSession,
+          },
+          error: null,
+        };
+      },
+    },
+  };
+
+  const result = await registerTester(
+    {
+      email: "friend@example.com",
+      password: "strong-pass-123",
+      displayName: "Приятел",
+      inviteCode: ENV.SYNCHRON_TEST_INVITE_CODE,
+    },
+    {
+      env: ENV,
+      client,
+      approveEmail: async () => {},
+      approveAccess: async (user) => {
+        approvedUser = user;
+      },
+    },
+  );
+
+  assert.equal(approvedUser.id, "existing-user");
+  assert.equal(result.user.id, "existing-user");
+  assert.deepEqual(result.session, fakeSession);
+  assert.equal(result.confirmationRequired, false);
+});
+
+test("registration keeps a new unconfirmed user when immediate sign in is unavailable", async () => {
+  let approvedUser = null;
+  const client = {
+    auth: {
+      async signUp({ email }) {
+        return {
+          data: {
+            user: { id: "new-unconfirmed-user", email },
+            session: null,
+          },
+          error: null,
+        };
+      },
+      async signInWithPassword() {
+        return {
+          data: { user: null, session: null },
+          error: { status: 400, message: "Email not confirmed" },
+        };
+      },
+    },
+  };
+
+  const result = await registerTester(
+    {
+      email: "new@example.com",
+      password: "strong-pass-123",
+      displayName: "Нов тестер",
+      inviteCode: ENV.SYNCHRON_TEST_INVITE_CODE,
+    },
+    {
+      env: ENV,
+      client,
+      approveEmail: async () => {},
+      approveAccess: async (user) => {
+        approvedUser = user;
+      },
+    },
+  );
+
+  assert.equal(approvedUser.id, "new-unconfirmed-user");
+  assert.equal(result.user.id, "new-unconfirmed-user");
+  assert.equal(result.session, null);
+  assert.equal(result.confirmationRequired, true);
+});
+
 test("sign in refuses a valid Supabase user without application approval", async () => {
   const client = {
     auth: {


### PR DESCRIPTION
## Проблем

Supabase може да прикрие вече съществуващ имейл като успешен `signUp` без сесия. Досегашното възстановяване се задействаше само при грешка или липсващ потребител.

## Поправка

- прави безопасен опит за вход и когато `signUp` няма сесия;
- възстановява истинския съществуващ профил при правилна парола;
- запазва нормалния поток за нов потребител, който още чака потвърждение по имейл;
- не добавя тайни и не променя schema или лична памет.

## Проверки

- 338 теста общо: 337 успешни, 0 неуспешни, 1 пропуснат без локални production OpenSearch credentials;
- 24/24 целеви auth теста успешни;
- production npm audit: 0 уязвимости;
- поведението е сверено с актуалната Supabase `auth.signUp` документация.