### PR TITLE
Публикувай проверим production smoke статус

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 concurrency:
   group: production-smoke-check
@@ -161,3 +162,44 @@ jobs:
               }
             });
           '
+
+      - name: Publish production verification status
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          case "${JOB_STATUS}" in
+            success)
+              state="success"
+              description="Production smoke check passed."
+              ;;
+            failure)
+              state="failure"
+              description="Production smoke check failed."
+              ;;
+            *)
+              state="error"
+              description="Production smoke check did not complete."
+              ;;
+          esac
+
+          export state description
+          payload="$(node -e '
+            process.stdout.write(JSON.stringify({
+              state: process.env.state,
+              context: "synchron/production-smoke",
+              description: process.env.description,
+              target_url: `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+            }));
+          ')"
+
+          curl --fail --silent --show-error \
+            --request POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --data "${payload}" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}"

--- a/tests/productionSmokeWorkflow.test.js
+++ b/tests/productionSmokeWorkflow.test.js
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("production smoke publishes a readable commit status without a custom secret", async () => {
+  const workflow = await readFile(
+    new URL("../.github/workflows/production-smoke.yml", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(workflow, /statuses:\s*write/u);
+  assert.match(workflow, /if:\s*always\(\)/u);
+  assert.match(workflow, /GH_TOKEN:\s*\$\{\{ github\.token \}\}/u);
+  assert.match(workflow, /synchron\/production-smoke/u);
+  assert.match(workflow, /statuses\/\$\{GITHUB_SHA\}/u);
+  assert.doesNotMatch(workflow, /secrets\./u);
+});


### PR DESCRIPTION
## Цел

GitHub приложението вижда commit statuses, но не може да прочете push-triggered Actions check run. Този PR прави резултата от production smoke пряко проверим след всеки deployment.

## Промяна

- дава на единствения production smoke workflow само `statuses: write`;
- публикува контекст `synchron/production-smoke` върху точния commit;
- използва автоматичния краткотраен `github.token`, без нов secret или ключ;
- публикува `success`, `failure` или `error` и връзка към точния Actions run;
- не променя код на приложението, production данни или памет.

## Проверки

- 343 теста общо: 342 успешни, 0 неуспешни, 1 пропуснат без локални production OpenSearch credentials;
- workflow YAML: валиден;
- production npm audit: 0 уязвимости.