### PR TITLE
Докажи точния MCP каталог в production

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -132,6 +132,93 @@ jobs:
             });
           '
 
+      - name: Check MCP tool catalog and OAuth challenge
+        shell: bash
+        run: |
+          set -euo pipefail
+          catalog_ready=false
+          for attempt in $(seq 1 12); do
+            response="$(curl --fail --silent --show-error \
+              --max-time 30 \
+              --header 'Cache-Control: no-cache' \
+              --header 'Content-Type: application/json' \
+              --header 'Accept: application/json, text/event-stream' \
+              --data '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+              "https://synchron.foundation/mcp?catalog-check=${attempt}" 2>/dev/null || true)"
+
+            if printf '%s' "${response}" | node -e '
+              let input = "";
+              process.stdin.on("data", (chunk) => { input += chunk; });
+              process.stdin.on("end", () => {
+                try {
+                  const tools = JSON.parse(input).result?.tools;
+                  const expected = [
+                    "get_personal_context",
+                    "get_project_context",
+                    "list_synchron_conversations",
+                    "get_synchron_conversation",
+                    "get_digitalocean_app_status",
+                    "get_system_configuration",
+                    "get_digitalocean_account_audit",
+                    "get_cloudflare_zone_status",
+                    "get_github_copilot_task_status",
+                    "prepare_github_merged_branch_cleanup",
+                    "confirm_github_merged_branch_cleanup",
+                  ];
+                  const names = Array.isArray(tools) ? tools.map((tool) => tool.name) : [];
+                  const tracker = tools?.find(
+                    (tool) => tool.name === "get_github_copilot_task_status",
+                  );
+                  const trackerScopes = tracker?.securitySchemes?.flatMap(
+                    (scheme) => scheme.scopes || [],
+                  ) || [];
+                  const valid =
+                    names.length === expected.length &&
+                    new Set(names).size === names.length &&
+                    expected.every((name) => names.includes(name)) &&
+                    tracker?.annotations?.readOnlyHint === true &&
+                    trackerScopes.includes("synchron:read");
+                  console.log(JSON.stringify({ names, trackerReadOnly: tracker?.annotations?.readOnlyHint }));
+                  process.exit(valid ? 0 : 1);
+                } catch {
+                  process.exit(1);
+                }
+              });
+            '; then
+              catalog_ready=true
+              break
+            fi
+
+            echo "Attempt ${attempt}/12: MCP tool catalog is not on the expected version yet."
+            sleep 10
+          done
+
+          if [ "${catalog_ready}" != "true" ]; then
+            echo "Production MCP tool catalog did not reach the expected version." >&2
+            exit 1
+          fi
+
+          challenge="$(curl --fail --silent --show-error \
+            --max-time 30 \
+            --header 'Content-Type: application/json' \
+            --header 'Accept: application/json, text/event-stream' \
+            --data '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_github_copilot_task_status","arguments":{"issueNumber":83}}}' \
+            https://synchron.foundation/mcp)"
+          printf '%s' "${challenge}" | node -e '
+            let input = "";
+            process.stdin.on("data", (chunk) => { input += chunk; });
+            process.stdin.on("end", () => {
+              const result = JSON.parse(input).result;
+              const challenges = result?._meta?.["mcp/www_authenticate"] || [];
+              const valid =
+                result?.isError === true &&
+                challenges.some(
+                  (value) => value.includes("Bearer") && value.includes("synchron:read"),
+                );
+              if (!valid) process.exit(1);
+            });
+          '
+
       - name: Check tester auth readiness
         shell: bash
         run: |

--- a/tests/productionSmokeWorkflow.test.js
+++ b/tests/productionSmokeWorkflow.test.js
@@ -13,5 +13,10 @@ test("production smoke publishes a readable commit status without a custom secre
   assert.match(workflow, /GH_TOKEN:\s*\$\{\{ github\.token \}\}/u);
   assert.match(workflow, /synchron\/production-smoke/u);
   assert.match(workflow, /statuses\/\$\{GITHUB_SHA\}/u);
+  assert.match(workflow, /Check MCP tool catalog and OAuth challenge/u);
+  assert.match(workflow, /get_github_copilot_task_status/u);
+  assert.match(workflow, /names\.length === expected\.length/u);
+  assert.match(workflow, /mcp\/www_authenticate/u);
+  assert.match(workflow, /synchron:read/u);
   assert.doesNotMatch(workflow, /secrets\./u);
 });


### PR DESCRIPTION
## Причина

Production smoke доказваше, че MCP отговаря, но не и че rolling deployment вече обявява актуалния каталог. След PR №146 за кратко зеленото състояние съвпадна с отговор от стара инстанция с 10 инструмента.

## Промяна

- изчаква точните 11 MCP инструмента с ограничен retry
- проверява tracker-а като read-only със scope `synchron:read`
- проверява реален `mcp/www_authenticate` challenge без потребителски данни
- не използва custom secrets

## Проверки

- 368 успешни теста, 0 неуспешни, 1 очаквано пропуснат production тест
- 0 production dependency уязвимости