### PR TITLE
Добави ясни стъпки за ChatGPT приложението

### DIFF
--- a/public/appshell.css
+++ b/public/appshell.css
@@ -72,6 +72,7 @@
 .work-center-status.external{color:#7c4a03;background:#fff4d7}.work-center-status.internal{color:#137333;background:#e6f4ea}
 .work-center-arrow{color:#94a3b8}.featured .work-center-arrow{color:#fff}
 .work-center-close{width:100%;min-height:48px;margin-top:8px;border:1px solid #cbd5e1;border-radius:14px;color:#17212b;background:#fff;font:inherit;font-weight:750;cursor:pointer}
+.chatgpt-app-setup{margin-top:2px}.chatgpt-app-steps{margin:12px 0;padding-left:22px}.chatgpt-app-steps li{margin:8px 0}.chatgpt-app-label{display:block;margin-top:12px;font-size:12px;font-weight:800}.chatgpt-app-endpoint{display:block;margin-top:6px;padding:11px;border-radius:10px;color:#0f172a;background:#e8eef7;overflow-wrap:anywhere}.chatgpt-app-actions{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}.chatgpt-app-copy,.chatgpt-app-link{min-height:44px;padding:10px 13px;border:0;border-radius:10px;color:#fff;background:#1d4ed8;font:inherit;font-weight:800;text-decoration:none;cursor:pointer}.chatgpt-app-link.secondary{color:#17212b;background:#e2e8f0}
 .system-control-link{width:100%;font:inherit;text-align:left;background:#fff;cursor:pointer}
 .system-summary p{margin:5px 0}.system-summary small{display:block;margin-top:8px}
 .configuration-group{margin-bottom:10px;border:1px solid #e2e8f0;border-radius:12px;background:#fff}
@@ -93,5 +94,6 @@
   .permission-card-actions,.tool-status-actions{width:100%;align-items:stretch}
   .tool-status-card .permission-badge{max-width:100%;align-self:flex-start}
   .work-center-card{min-height:104px;grid-template-columns:44px minmax(0,1fr);align-items:start}
+  .chatgpt-app-actions>*{width:100%;text-align:center}
   .work-center-arrow{display:none}
 }

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
     />
     <title>SYNCHRON-X · Лична AI операционна система</title>
     <link rel="stylesheet" href="/styles.css?v=20260727-connection-actions" />
-    <link rel="stylesheet" href="/appshell.css?v=20260728-work-center" />
+    <link rel="stylesheet" href="/appshell.css?v=20260731-chatgpt-app" />
     <link rel="stylesheet" href="/search.css?v=20260726-search" />
     <link rel="stylesheet" href="/modules.css?v=20260726-modules" />
     <link rel="stylesheet" href="/accessibility.css?v=20260728-font-stepper" />

--- a/public/work-center.js
+++ b/public/work-center.js
@@ -1,6 +1,9 @@
 (() => {
   const REPOSITORY_URL =
     "https://github.com/radostinvgeorgiev-commits/sunchron-backend";
+  const MCP_RESOURCE_URL = "https://synchron.foundation/mcp";
+  const CHATGPT_APP_GUIDE_URL =
+    "https://developers.openai.com/apps-sdk/deploy/testing";
   const FALLBACK_CONFIG = Object.freeze({
     chatgptWorkUrl: "https://chatgpt.com/",
     digitalOceanUrl: "https://cloud.digitalocean.com/",
@@ -181,6 +184,25 @@
     };
   }
 
+  function resolveChatGptAppStatus(readiness) {
+    const bridge = readiness?.checks?.bridge;
+    if (
+      bridge?.configured === true &&
+      bridge?.responding === true &&
+      bridge?.authentication?.chatgptOAuthReady === true &&
+      bridge?.tools >= 11
+    ) {
+      return {
+        label: `${bridge.tools} инструмента · OAuth е готов`,
+        className: "internal",
+      };
+    }
+    return {
+      label: "Мостът още не е потвърден",
+      className: "warning",
+    };
+  }
+
   function renderWorkCenter(
     config,
     readiness = null,
@@ -241,6 +263,18 @@
         connectionName: "Google",
       },
     );
+    const chatGptAppStatus = resolveChatGptAppStatus(readiness);
+    const chatGptAppCard = createActionCard({
+      title: "ChatGPT приложение — SYNCHRON-X",
+      description:
+        "Свързва ChatGPT с разрешените инструменти чрез защитен OAuth вход.",
+      action: "show-chatgpt-app-setup",
+      icon: "fa-solid fa-plug-circle-check",
+      status: chatGptAppStatus.label,
+      statusClass: chatGptAppStatus.className,
+      actionLabel: "Покажи еднократните стъпки",
+    });
+    chatGptAppCard.dataset.chatgptUrl = chatgptUrl;
     const cards = [
       createInternalCard({
         title: "SYNCHRON-X — свързан разговор",
@@ -252,14 +286,7 @@
         status: coreStatus.label,
         statusClass: coreStatus.className,
       }),
-      createExternalCard({
-        title: "ChatGPT — отделен разговор",
-        description:
-          "Отваря ChatGPT, но не му дава автоматичен достъп до паметта на SYNCHRON-X.",
-        url: chatgptUrl,
-        icon: "fa-solid fa-comment-dots",
-        status: "Външна услуга · Без автоматична връзка с паметта",
-      }),
+      chatGptAppCard,
       createExternalCard({
         title: "GitHub — хранилище",
         description: "Кодът и историята на SYNCHRON-X.",
@@ -395,6 +422,76 @@
     } else {
       body.prepend(panel);
     }
+    panel.scrollIntoView?.({ behavior: "smooth", block: "nearest" });
+  }
+
+  function showChatGptAppSetup(card) {
+    body.querySelector("[data-chatgpt-app-setup]")?.remove();
+    const panel = document.createElement("section");
+    panel.className = "work-center-intro chatgpt-app-setup";
+    panel.dataset.chatgptAppSetup = "";
+    addText(panel, "strong", "Свържи SYNCHRON-X с ChatGPT");
+    addText(
+      panel,
+      "p",
+      "Мостът е готов. Създаването на приложението се прави еднократно от ChatGPT в браузър на компютър, не от приложението за iPhone.",
+    );
+
+    const steps = document.createElement("ol");
+    steps.className = "chatgpt-app-steps";
+    [
+      "Отвори chatgpt.com на компютър и влез в своя профил.",
+      "В Settings отвори Apps / Connectors и включи Developer mode. За служебен workspace отвори Workspace settings → Apps.",
+      "Избери Create app, напиши име SYNCHRON-X и постави MCP адреса отдолу.",
+      "Завърши OAuth входа в SYNCHRON-X. Не изпращай парола или код в чата.",
+    ].forEach((step) => addText(steps, "li", step));
+    panel.appendChild(steps);
+
+    addText(panel, "span", "MCP адрес", "chatgpt-app-label");
+    const endpoint = addText(
+      panel,
+      "code",
+      MCP_RESOURCE_URL,
+      "chatgpt-app-endpoint",
+    );
+    endpoint.dataset.mcpResourceUrl = "";
+
+    const actions = document.createElement("div");
+    actions.className = "chatgpt-app-actions";
+    const copyButton = addText(
+      actions,
+      "button",
+      "Копирай MCP адреса",
+      "chatgpt-app-copy",
+    );
+    copyButton.type = "button";
+    copyButton.dataset.copyMcpUrl = "";
+
+    const chatGptLink = addText(
+      actions,
+      "a",
+      "Отвори ChatGPT web",
+      "chatgpt-app-link",
+    );
+    chatGptLink.href = safeHttpsUrl(
+      card?.dataset.chatgptUrl,
+      FALLBACK_CONFIG.chatgptWorkUrl,
+    );
+    chatGptLink.target = "_blank";
+    chatGptLink.rel = "noopener noreferrer";
+
+    const guideLink = addText(
+      actions,
+      "a",
+      "Официални инструкции",
+      "chatgpt-app-link secondary",
+    );
+    guideLink.href = CHATGPT_APP_GUIDE_URL;
+    guideLink.target = "_blank";
+    guideLink.rel = "noopener noreferrer";
+    panel.appendChild(actions);
+
+    card.insertAdjacentElement("afterend", panel);
     panel.scrollIntoView?.({ behavior: "smooth", block: "nearest" });
   }
 
@@ -556,7 +653,17 @@
       copyInvite.textContent = "Копирано";
       return;
     }
+    const copyMcpUrl = event.target.closest("[data-copy-mcp-url]");
+    if (copyMcpUrl) {
+      await globalThis.navigator?.clipboard?.writeText(MCP_RESOURCE_URL);
+      copyMcpUrl.textContent = "Копирано";
+      return;
+    }
     const actionCard = event.target.closest("[data-work-center-action]");
+    if (actionCard?.dataset.workCenterAction === "show-chatgpt-app-setup") {
+      showChatGptAppSetup(actionCard);
+      return;
+    }
     if (actionCard?.dataset.workCenterAction === "activate-tester-auth") {
       await activateTesterAuth(actionCard);
       return;
@@ -584,6 +691,7 @@
 
   globalThis.SynchronWorkCenter = Object.freeze({
     openWorkCenter,
+    resolveChatGptAppStatus,
     resolveCoreStatus,
     resolveToolStatus,
     safeHttpsUrl,

--- a/tests/workCenterUi.test.js
+++ b/tests/workCenterUi.test.js
@@ -87,6 +87,13 @@ function createHarness({
     console,
     document: dom.window.document,
     Event: dom.window.Event,
+    navigator: {
+      clipboard: {
+        writeText: async (value) => {
+          dom.window.document.body.dataset.copiedText = value;
+        },
+      },
+    },
     location: {
       assign: (url) => {
         dom.window.document.body.dataset.redirectedTo = url;
@@ -188,15 +195,61 @@ test("work center uses safe GitHub links without duplicating the task journal", 
   });
 });
 
-test("ChatGPT falls back safely when public config is unavailable", async () => {
+test("ChatGPT app setup falls back safely and never sends the user to /plugins", async () => {
   const harness = createHarness({ fetchFails: true });
   await openCenter(harness);
-  const chatGptLink = [
-    ...harness.dom.window.document.querySelectorAll("a"),
-  ].find((link) => link.textContent.includes("ChatGPT"));
+  const { document } = harness.dom.window;
+  const card = document.querySelector(
+    '[data-work-center-action="show-chatgpt-app-setup"]',
+  );
+  card.click();
+  const setup = document.querySelector("[data-chatgpt-app-setup]");
+  const chatGptLink = [...setup.querySelectorAll("a")].find((link) =>
+    link.textContent.includes("ChatGPT web"),
+  );
 
   assert.equal(chatGptLink.href, "https://chatgpt.com/");
-  assert.match(chatGptLink.textContent, /Без автоматична връзка с паметта/u);
+  assert.doesNotMatch(chatGptLink.href, /\/plugins/u);
+  assert.match(setup.textContent, /браузър на компютър/u);
+  assert.match(setup.textContent, /не от приложението за iPhone/u);
+  assert.match(setup.textContent, /Developer mode/u);
+  assert.match(setup.textContent, /https:\/\/synchron\.foundation\/mcp/u);
+});
+
+test("ChatGPT app card reports the live bridge and copies the exact MCP URL", async () => {
+  const harness = createHarness({
+    readiness: {
+      status: "ready",
+      checks: {
+        chatAgent: { ready: true },
+        memory: { ready: true, status: "green" },
+        bridge: {
+          configured: true,
+          responding: true,
+          tools: 11,
+          authentication: { chatgptOAuthReady: true },
+        },
+      },
+    },
+  });
+  await openCenter(harness);
+  const { document } = harness.dom.window;
+  const card = document.querySelector(
+    '[data-work-center-action="show-chatgpt-app-setup"]',
+  );
+
+  assert.match(card.textContent, /11 инструмента · OAuth е готов/u);
+  card.click();
+  document.querySelector("[data-copy-mcp-url]").click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(
+    document.body.dataset.copiedText,
+    "https://synchron.foundation/mcp",
+  );
+  assert.equal(
+    document.querySelector("[data-copy-mcp-url]").textContent,
+    "Копирано",
+  );
 });
 
 test("featured connected chat reports real core readiness and returns to chat", async () => {


### PR DESCRIPTION
## Резултат

- заменя подвеждащата карта за отделен ChatGPT разговор с реална настройка на SYNCHRON-X приложението
- показва live MCP/OAuth готовност и броя инструменти
- дава точния MCP адрес и бутон за копиране
- обяснява честно, че еднократното създаване е през ChatGPT web на компютър
- премахва грешната посока към `/plugins` и Cloud Browser
- добавя официалната OpenAI инструкция

## Проверки

- 369 успешни теста, 0 неуспешни, 1 очаквано пропуснат production тест
- 0 production dependency уязвимости
- мобилните бутони остават на пълна ширина