### PR TITLE
Добави repository инструкции за Copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,36 @@
+# SYNCHRON-X repository instructions
+
+Read and follow `AGENTS.md` before changing anything. It is the authoritative
+project workflow and safety policy.
+
+## Project and commands
+
+- This is a Node.js 22 / Express application. Use `npm ci` for dependencies.
+- Run `npm test` before every proposed commit.
+- Run `npm audit --omit=dev --audit-level=high` for production dependencies.
+- Keep generated dependencies, virtual environments, logs and secrets out of
+  Git. Never add `node_modules`, `venv`, `.env` files or token values.
+
+## Change boundaries
+
+- Work from the current `main` in a separate branch and open a Draft PR.
+- Never push directly to `main`, merge your own PR or deploy production.
+- Keep each task narrow. Preserve unrelated user changes and existing behavior.
+- Do not modify personal memory, OpenSearch data, AI Core architecture,
+  production secrets or paid resources unless the issue explicitly requires it.
+- Treat GitHub, DigitalOcean, Google and memory writes as external side effects.
+  Keep the existing permission and confirmation boundaries.
+- Never claim that an external action, assignment, check, merge or deployment
+  happened without reading the real provider response.
+
+## Code and verification
+
+- Prefer the existing Tool Registry, Capability Engine, services and adapters;
+  do not create a second execution path for the same capability.
+- Fail closed for missing configuration, invalid identity or insufficient scope.
+- Do not return or log tokens, passwords, secret values or personal data.
+- Add focused regression tests for every behavior change and keep the full suite
+  green.
+- User-facing text is Bulgarian. Code identifiers may remain English.
+- A task is not production-ready merely because local or PR tests pass. Report
+  the exact unverified production step instead of asserting success.

--- a/tests/copilotInstructions.test.js
+++ b/tests/copilotInstructions.test.js
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("repository-wide Copilot instructions preserve the project safety contract", async () => {
+  const instructions = await readFile(
+    new URL("../.github/copilot-instructions.md", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(instructions, /AGENTS\.md/u);
+  assert.match(instructions, /npm ci/u);
+  assert.match(instructions, /npm test/u);
+  assert.match(instructions, /npm audit --omit=dev --audit-level=high/u);
+  assert.match(instructions, /separate branch/u);
+  assert.match(instructions, /Draft PR/u);
+  assert.match(instructions, /Never push directly to `main`/u);
+  assert.match(instructions, /Do not return or log tokens/u);
+  assert.match(instructions, /User-facing text is Bulgarian/u);
+  assert.doesNotMatch(instructions, /ghp_[A-Za-z0-9]+/u);
+  assert.doesNotMatch(instructions, /sk-[A-Za-z0-9]+/u);
+});


### PR DESCRIPTION
Closes #4

## Промяна

- добавя официалния repository-wide файл `.github/copilot-instructions.md`
- пази `AGENTS.md` като авторитетна политика
- задава точните `npm ci`, `npm test` и production audit команди
- забранява директен push към `main`, тайни, лична памет и непроверени твърдения за външни действия
- добавя regression тест за основния safety contract

Следва официалните GitHub препоръки за Copilot coding agent custom instructions.

## Проверки

- 370 успешни теста, 0 неуспешни, 1 очаквано пропуснат production тест
- 0 production dependency уязвимости