### PR TITLE
Направи MCP OAuth устойчив при deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,8 @@ MEMORY_OWNER_ID=your-stable-memory-owner-id
 MCP_ACCESS_TOKEN=your-long-random-mcp-access-token
 # Optional canonical HTTPS MCP resource. Production defaults to this URL.
 MCP_RESOURCE_URL=https://synchron.foundation/mcp
+# Optional OpenSearch index for one-time OAuth grant consumption.
+MCP_OAUTH_REPLAY_INDEX=synchron-mcp-oauth-replay-v1
 
 SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_PUBLISHABLE_KEY=your-supabase-publishable-key

--- a/src/config/environmentCatalog.js
+++ b/src/config/environmentCatalog.js
@@ -134,6 +134,12 @@ export const ENVIRONMENT_CATALOG = Object.freeze(
       "Каноничен HTTPS адрес на MCP ресурса.",
       { hasDefault: true },
     ),
+    general(
+      "MCP_OAUTH_REPLAY_INDEX",
+      "ChatGPT / MCP",
+      "Индекс за устойчивата еднократна OAuth защита.",
+      { hasDefault: true },
+    ),
 
     general(
       "SUPABASE_URL",

--- a/src/routes/mcpOAuthRouter.js
+++ b/src/routes/mcpOAuthRouter.js
@@ -158,15 +158,20 @@ export function createMcpOAuthRouter({
     },
   );
 
-  router.post("/oauth/token", oauthRateLimiter, formParser, (req, res) => {
-    try {
-      const token = exchangeMcpToken(req.body || {});
-      noStore(res);
-      return res.json(token);
-    } catch (error) {
-      return oauthError(res, error);
-    }
-  });
+  router.post(
+    "/oauth/token",
+    oauthRateLimiter,
+    formParser,
+    async (req, res) => {
+      try {
+        const token = await exchangeMcpToken(req.body || {});
+        noStore(res);
+        return res.json(token);
+      } catch (error) {
+        return oauthError(res, error);
+      }
+    },
+  );
 
   return router;
 }

--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -5,6 +5,7 @@ import {
   randomBytes,
   timingSafeEqual,
 } from "node:crypto";
+import { getOpenSearchClient } from "../config/opensearch.js";
 
 export const DEFAULT_MCP_RESOURCE_URL = "https://synchron.foundation/mcp";
 export const MCP_READ_SCOPE = "synchron:read";
@@ -18,7 +19,8 @@ const ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
 const REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
 const AUTHORIZATION_CODE_TTL_SECONDS = 5 * 60;
 const MAX_CONSUMED_TOKEN_RECORDS = 10_000;
-const codeInstanceSecret = randomBytes(32);
+const MCP_OAUTH_REPLAY_INDEX =
+  process.env.MCP_OAUTH_REPLAY_INDEX || "synchron-mcp-oauth-replay-v1";
 const consumedAuthorizationCodes = new Map();
 const consumedRefreshTokens = new Map();
 
@@ -76,10 +78,10 @@ function oauthSecret(env = process.env) {
     .digest();
 }
 
-function codeSecret(env = process.env) {
+function grantSecret(env = process.env) {
   return createHash("sha256")
     .update(oauthSecret(env))
-    .update(codeInstanceSecret)
+    .update("synchron-mcp-oauth-grants-v2\0")
     .digest();
 }
 
@@ -325,7 +327,7 @@ export function createMcpAuthorizationCode(
       iat: now,
       exp: now + AUTHORIZATION_CODE_TTL_SECONDS,
     },
-    codeSecret(env),
+    grantSecret(env),
   );
 }
 
@@ -347,6 +349,72 @@ function markTokenConsumed(store, tokenId, expiresAt) {
   while (store.size > MAX_CONSUMED_TOKEN_RECORDS) {
     store.delete(store.keys().next().value);
   }
+}
+
+function replayStore(grantType) {
+  return grantType === "authorization_code"
+    ? consumedAuthorizationCodes
+    : consumedRefreshTokens;
+}
+
+function replayRecordId(grantType, tokenId) {
+  return createHash("sha256")
+    .update(String(grantType))
+    .update("\0")
+    .update(String(tokenId))
+    .digest("hex");
+}
+
+function openSearchStatus(error) {
+  return error?.statusCode || error?.meta?.statusCode || 0;
+}
+
+export function requiresPersistentMcpReplayGuard(env = process.env) {
+  return env.NODE_ENV === "production";
+}
+
+export async function consumeMcpGrantOnce({
+  grantType,
+  tokenId,
+  expiresAt,
+  env = process.env,
+  client = getOpenSearchClient(),
+}) {
+  const store = replayStore(grantType);
+  const now = Math.floor(Date.now() / 1_000);
+  if (wasTokenConsumed(store, tokenId, now)) return false;
+
+  if (client) {
+    try {
+      await client.create({
+        index: env.MCP_OAUTH_REPLAY_INDEX || MCP_OAUTH_REPLAY_INDEX,
+        id: replayRecordId(grantType, tokenId),
+        body: {
+          grantType,
+          expiresAt: new Date(expiresAt * 1_000).toISOString(),
+        },
+        refresh: true,
+      });
+    } catch (error) {
+      if (openSearchStatus(error) === 409) return false;
+      if (requiresPersistentMcpReplayGuard(env)) {
+        throw new McpOAuthError(
+          "MCP OAuth еднократната защита временно не е достъпна.",
+          503,
+          "temporarily_unavailable",
+        );
+      }
+    }
+  } else if (requiresPersistentMcpReplayGuard(env)) {
+    throw new McpOAuthError(
+      "MCP OAuth еднократната защита не е конфигурирана.",
+      503,
+      "temporarily_unavailable",
+    );
+  }
+
+  markTokenConsumed(store, tokenId, expiresAt);
+  return true;
 }
 
 function createAccessAndRefreshTokens(payload, env, now) {
@@ -382,7 +450,7 @@ function createAccessAndRefreshTokens(payload, env, now) {
       iat: now,
       exp: now + REFRESH_TOKEN_TTL_SECONDS,
     },
-    codeSecret(env),
+    grantSecret(env),
   );
   return {
     access_token: accessToken,
@@ -393,17 +461,20 @@ function createAccessAndRefreshTokens(payload, env, now) {
   };
 }
 
-export function exchangeMcpAuthorizationCode(input, env = process.env) {
+export async function exchangeMcpAuthorizationCode(
+  input,
+  env = process.env,
+  { consumeGrant = consumeMcpGrantOnce } = {},
+) {
   const code = String(input?.code || "");
-  const payload = decryptPayload(code, "sx-code", codeSecret(env));
+  const payload = decryptPayload(code, "sx-code", grantSecret(env));
   const now = Math.floor(Date.now() / 1_000);
   if (
     !payload ||
     payload.typ !== "authorization_code" ||
     payload.iss !== resolveMcpIssuerUrl(env) ||
     payload.aud !== resolveMcpResourceUrl(env) ||
-    payload.exp <= now ||
-    wasTokenConsumed(consumedAuthorizationCodes, payload.jti, now)
+    payload.exp <= now
   ) {
     throw new McpOAuthError(
       "Невалиден или изтекъл authorization code.",
@@ -436,15 +507,31 @@ export function exchangeMcpAuthorizationCode(input, env = process.env) {
     );
   }
 
-  markTokenConsumed(consumedAuthorizationCodes, payload.jti, payload.exp);
+  const consumed = await consumeGrant({
+    grantType: "authorization_code",
+    tokenId: payload.jti,
+    expiresAt: payload.exp,
+    env,
+  });
+  if (!consumed) {
+    throw new McpOAuthError(
+      "Невалиден или изтекъл authorization code.",
+      400,
+      "invalid_grant",
+    );
+  }
   return createAccessAndRefreshTokens(payload, env, now);
 }
 
-export function exchangeMcpRefreshToken(input, env = process.env) {
+export async function exchangeMcpRefreshToken(
+  input,
+  env = process.env,
+  { consumeGrant = consumeMcpGrantOnce } = {},
+) {
   const payload = decryptPayload(
     String(input?.refresh_token || ""),
     "sx-refresh",
-    codeSecret(env),
+    grantSecret(env),
   );
   const now = Math.floor(Date.now() / 1_000);
   if (
@@ -453,7 +540,6 @@ export function exchangeMcpRefreshToken(input, env = process.env) {
     payload.iss !== resolveMcpIssuerUrl(env) ||
     payload.aud !== resolveMcpResourceUrl(env) ||
     payload.exp <= now ||
-    wasTokenConsumed(consumedRefreshTokens, payload.jti, now) ||
     !safeStringEqual(input?.client_id, payload.clientId) ||
     !safeStringEqual(input?.resource, payload.aud)
   ) {
@@ -463,11 +549,23 @@ export function exchangeMcpRefreshToken(input, env = process.env) {
       "invalid_grant",
     );
   }
-  markTokenConsumed(consumedRefreshTokens, payload.jti, payload.exp);
+  const consumed = await consumeGrant({
+    grantType: "refresh_token",
+    tokenId: payload.jti,
+    expiresAt: payload.exp,
+    env,
+  });
+  if (!consumed) {
+    throw new McpOAuthError(
+      "Невалиден или изтекъл refresh token.",
+      400,
+      "invalid_grant",
+    );
+  }
   return createAccessAndRefreshTokens(payload, env, now);
 }
 
-export function exchangeMcpToken(input, env = process.env) {
+export async function exchangeMcpToken(input, env = process.env) {
   if (input?.grant_type === "authorization_code") {
     return exchangeMcpAuthorizationCode(input, env);
   }

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -132,6 +132,20 @@ test("authorization consent issues a code bound to the browser profile", async (
   assert.equal(callback.origin, "https://chatgpt.com");
   assert.equal(callback.searchParams.get("state"), "state-123");
   assert.match(callback.searchParams.get("code"), /^sx-code\./u);
+  const token = await request(app)
+    .post("/oauth/token")
+    .type("form")
+    .send({
+      grant_type: "authorization_code",
+      code: callback.searchParams.get("code"),
+      client_id: oauthRequest.clientId,
+      redirect_uri: oauthRequest.redirectUri,
+      code_verifier: verifier,
+      resource: oauthRequest.resource,
+    })
+    .expect(200);
+  assert.equal(token.body.token_type, "Bearer");
+  assert.ok(token.body.refresh_token);
   if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
   else process.env.MCP_ACCESS_TOKEN = previous;
 });

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import test from "node:test";
 
 import {
+  consumeMcpGrantOnce,
   createMcpAuthorizationCode,
   exchangeMcpAuthorizationCode,
   exchangeMcpRefreshToken,
@@ -10,6 +11,7 @@ import {
   getMcpProtectedResourceMetadata,
   MCP_GITHUB_WRITE_SCOPE,
   MCP_READ_SCOPE,
+  requiresPersistentMcpReplayGuard,
   resetMcpOAuthStateForTests,
   validateMcpAuthorizationRequest,
   verifyMcpAccessToken,
@@ -113,7 +115,7 @@ test("exchanges a one-time PKCE code for an opaque owner-scoped token", async ()
     code_verifier: VERIFIER,
     resource: ENV.MCP_RESOURCE_URL,
   };
-  const token = exchangeMcpAuthorizationCode(input, ENV);
+  const token = await exchangeMcpAuthorizationCode(input, ENV);
   assert.equal(token.token_type, "Bearer");
   assert.doesNotMatch(token.access_token, /owner-id|primary-user/u);
   assert.deepEqual(
@@ -130,7 +132,7 @@ test("exchanges a one-time PKCE code for an opaque owner-scoped token", async ()
       clientId: CLIENT_ID,
     },
   );
-  const refreshed = exchangeMcpRefreshToken(
+  const refreshed = await exchangeMcpRefreshToken(
     {
       grant_type: "refresh_token",
       refresh_token: token.refresh_token,
@@ -141,7 +143,7 @@ test("exchanges a one-time PKCE code for an opaque owner-scoped token", async ()
   );
   assert.ok(refreshed.access_token);
   assert.notEqual(refreshed.refresh_token, token.refresh_token);
-  assert.throws(
+  await assert.rejects(
     () =>
       exchangeMcpRefreshToken(
         {
@@ -154,7 +156,7 @@ test("exchanges a one-time PKCE code for an opaque owner-scoped token", async ()
       ),
     (error) => error.code === "invalid_grant",
   );
-  assert.throws(
+  await assert.rejects(
     () => exchangeMcpAuthorizationCode(input, ENV),
     (error) => error.code === "invalid_grant",
   );
@@ -195,7 +197,7 @@ test("distinguishes an invalid token from a valid token without scope", async ()
     { id: "owner-id", memoryOwnerId: "primary-user", role: "owner" },
     ENV,
   );
-  const token = exchangeMcpAuthorizationCode(
+  const token = await exchangeMcpAuthorizationCode(
     {
       grant_type: "authorization_code",
       code,
@@ -234,7 +236,7 @@ test("rejects an invalid PKCE verifier without consuming the code", async () => 
     redirect_uri: REDIRECT_URI,
     resource: ENV.MCP_RESOURCE_URL,
   };
-  assert.throws(
+  await assert.rejects(
     () =>
       exchangeMcpAuthorizationCode(
         { ...base, code_verifier: "x".repeat(64) },
@@ -243,7 +245,94 @@ test("rejects an invalid PKCE verifier without consuming the code", async () => 
     (error) => error.code === "invalid_grant",
   );
   assert.ok(
-    exchangeMcpAuthorizationCode({ ...base, code_verifier: VERIFIER }, ENV)
-      .access_token,
+    (
+      await exchangeMcpAuthorizationCode(
+        { ...base, code_verifier: VERIFIER },
+        ENV,
+      )
+    ).access_token,
+  );
+});
+
+test("refresh tokens survive a fresh application module instance", async () => {
+  const first =
+    await import("../src/services/mcpOAuthService.js?oauth-instance=first");
+  const second =
+    await import("../src/services/mcpOAuthService.js?oauth-instance=second");
+  const request = {
+    clientId: CLIENT_ID,
+    redirectUri: REDIRECT_URI,
+    codeChallenge: createHash("sha256").update(VERIFIER).digest("base64url"),
+    resource: ENV.MCP_RESOURCE_URL,
+    scopes: [MCP_READ_SCOPE],
+  };
+  const code = first.createMcpAuthorizationCode(
+    request,
+    { id: "owner-id", memoryOwnerId: "primary-user", role: "owner" },
+    ENV,
+  );
+  const token = await first.exchangeMcpAuthorizationCode(
+    {
+      grant_type: "authorization_code",
+      code,
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: VERIFIER,
+      resource: ENV.MCP_RESOURCE_URL,
+    },
+    ENV,
+  );
+
+  const refreshed = await second.exchangeMcpRefreshToken(
+    {
+      grant_type: "refresh_token",
+      refresh_token: token.refresh_token,
+      client_id: CLIENT_ID,
+      resource: ENV.MCP_RESOURCE_URL,
+    },
+    ENV,
+  );
+  assert.ok(refreshed.access_token);
+});
+
+test("production replay guard is atomic across local state resets", async () => {
+  const seen = new Set();
+  const client = {
+    async create({ id }) {
+      if (seen.has(id)) {
+        const error = new Error("version conflict");
+        error.meta = { statusCode: 409 };
+        throw error;
+      }
+      seen.add(id);
+    },
+  };
+  const input = {
+    grantType: "refresh_token",
+    tokenId: "one-time-token-id",
+    expiresAt: Math.floor(Date.now() / 1_000) + 60,
+    env: { ...ENV, NODE_ENV: "production" },
+    client,
+  };
+
+  assert.equal(await consumeMcpGrantOnce(input), true);
+  resetMcpOAuthStateForTests();
+  assert.equal(await consumeMcpGrantOnce(input), false);
+});
+
+test("production OAuth fails closed without the durable replay store", async () => {
+  assert.equal(
+    requiresPersistentMcpReplayGuard({ NODE_ENV: "production" }),
+    true,
+  );
+  await assert.rejects(
+    consumeMcpGrantOnce({
+      grantType: "authorization_code",
+      tokenId: "code-id",
+      expiresAt: Math.floor(Date.now() / 1_000) + 60,
+      env: { ...ENV, NODE_ENV: "production" },
+      client: null,
+    }),
+    (error) => error.code === "temporarily_unavailable" && error.status === 503,
   );
 });


### PR DESCRIPTION
## Резултат

- премахва process-local тайната, която обезсилваше authorization/refresh token-ите след restart или deployment;
- използва стабилен domain-separated ключ, извлечен от съществуващия `MCP_ACCESS_TOKEN`, без нов secret;
- консумира authorization code и въртящ refresh token атомарно чрез OpenSearch `create`, така че повторение между инстанции да се блокира;
- отказва затворено в production, ако устойчивият replay guard не е достъпен;
- описва незадължителния индекс `MCP_OAUTH_REPLAY_INDEX` без да показва стойности на тайни.

## Причина

Досегашният `codeInstanceSecret` се генерираше наново при всеки процес. Access token-ът оставаше валиден, но refresh token-ът не можеше да бъде разшифрован след deployment, а OAuth обменът беше зависим от конкретната инстанция.

## Проверки

- 385 успешни теста;
- 0 неуспешни;
- 1 очаквано пропуснат локален production OpenSearch тест;
- отделен тест доказва refresh през нов ESM module instance;
- отделен тест доказва атомарна еднократна консумация през reset на локалното състояние;
- `npm audit --omit=dev --audit-level=high`: 0 уязвимости;
- `git diff --check`: чист.