### PR TITLE
Почиствай изтеклите MCP OAuth replay записи

### DIFF
--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -19,10 +19,13 @@ const ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
 const REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
 const AUTHORIZATION_CODE_TTL_SECONDS = 5 * 60;
 const MAX_CONSUMED_TOKEN_RECORDS = 10_000;
+const REPLAY_CLEANUP_INTERVAL_SECONDS = 6 * 60 * 60;
 const MCP_OAUTH_REPLAY_INDEX =
   process.env.MCP_OAUTH_REPLAY_INDEX || "synchron-mcp-oauth-replay-v1";
 const consumedAuthorizationCodes = new Map();
 const consumedRefreshTokens = new Map();
+let lastReplayCleanupAt = 0;
+let activeReplayCleanup = null;
 
 export class McpOAuthError extends Error {
   constructor(
@@ -373,6 +376,50 @@ export function requiresPersistentMcpReplayGuard(env = process.env) {
   return env.NODE_ENV === "production";
 }
 
+export async function cleanupExpiredMcpReplayRecords({
+  client = getOpenSearchClient(),
+  env = process.env,
+  now = Math.floor(Date.now() / 1_000),
+  force = false,
+} = {}) {
+  if (!client || typeof client.deleteByQuery !== "function") return false;
+  if (activeReplayCleanup) return activeReplayCleanup;
+  if (
+    !force &&
+    lastReplayCleanupAt > 0 &&
+    now - lastReplayCleanupAt < REPLAY_CLEANUP_INTERVAL_SECONDS
+  ) {
+    return false;
+  }
+
+  lastReplayCleanupAt = now;
+  activeReplayCleanup = client
+    .deleteByQuery({
+      index: env.MCP_OAUTH_REPLAY_INDEX || MCP_OAUTH_REPLAY_INDEX,
+      conflicts: "proceed",
+      refresh: false,
+      body: {
+        query: {
+          range: {
+            expiresAt: { lte: new Date(now * 1_000).toISOString() },
+          },
+        },
+      },
+    })
+    .then(() => true)
+    .catch((error) => {
+      if (openSearchStatus(error) !== 404) {
+        console.error("[MCP OAuth replay] Expired-record cleanup failed.");
+      }
+      return openSearchStatus(error) === 404;
+    })
+    .finally(() => {
+      activeReplayCleanup = null;
+    });
+
+  return activeReplayCleanup;
+}
+
 export async function consumeMcpGrantOnce({
   grantType,
   tokenId,
@@ -386,8 +433,9 @@ export async function consumeMcpGrantOnce({
 
   if (client) {
     try {
+      const replayIndex = env.MCP_OAUTH_REPLAY_INDEX || MCP_OAUTH_REPLAY_INDEX;
       await client.create({
-        index: env.MCP_OAUTH_REPLAY_INDEX || MCP_OAUTH_REPLAY_INDEX,
+        index: replayIndex,
         id: replayRecordId(grantType, tokenId),
         body: {
           grantType,
@@ -395,6 +443,7 @@ export async function consumeMcpGrantOnce({
         },
         refresh: true,
       });
+      await cleanupExpiredMcpReplayRecords({ client, env, now });
     } catch (error) {
       if (openSearchStatus(error) === 409) return false;
       if (requiresPersistentMcpReplayGuard(env)) {
@@ -637,4 +686,6 @@ export function verifyMcpAccessToken(
 export function resetMcpOAuthStateForTests() {
   consumedAuthorizationCodes.clear();
   consumedRefreshTokens.clear();
+  lastReplayCleanupAt = 0;
+  activeReplayCleanup = null;
 }

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import test from "node:test";
 
 import {
+  cleanupExpiredMcpReplayRecords,
   consumeMcpGrantOnce,
   createMcpAuthorizationCode,
   exchangeMcpAuthorizationCode,
@@ -335,4 +336,43 @@ test("production OAuth fails closed without the durable replay store", async () 
     }),
     (error) => error.code === "temporarily_unavailable" && error.status === 503,
   );
+});
+
+test("expired durable replay records are cleaned on a bounded schedule", async () => {
+  const calls = [];
+  const client = {
+    async deleteByQuery(input) {
+      calls.push(input);
+      return { deleted: 2 };
+    },
+  };
+  const env = {
+    ...ENV,
+    MCP_OAUTH_REPLAY_INDEX: "oauth-replay-test",
+  };
+
+  assert.equal(
+    await cleanupExpiredMcpReplayRecords({ client, env, now: 1_000 }),
+    true,
+  );
+  assert.equal(
+    await cleanupExpiredMcpReplayRecords({ client, env, now: 1_001 }),
+    false,
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].index, "oauth-replay-test");
+  assert.deepEqual(calls[0].body.query, {
+    range: { expiresAt: { lte: new Date(1_000_000).toISOString() } },
+  });
+
+  assert.equal(
+    await cleanupExpiredMcpReplayRecords({
+      client,
+      env,
+      now: 1_001,
+      force: true,
+    }),
+    true,
+  );
+  assert.equal(calls.length, 2);
 });


### PR DESCRIPTION
## Резултат
Завършва оставащата част от #155 след слятия PR #154:

- изтрива само изтеклите записи от `MCP_OAUTH_REPLAY_INDEX`
- cleanup се изпълнява най-много веднъж на 6 часа за Node process
- използва `deleteByQuery` с `conflicts: proceed`
- 404/липсващ индекс е безопасен, а други cleanup грешки не отслабват replay guard
- reset helper изолира cleanup state в тестовете
- няма нов secret, token формат, scope или permission промяна

## Проверки
- MCP/OAuth: 23/23 успешни
- целият пакет: 386 успешни, 0 неуспешни, 1 очаквано пропуснат
- production dependency audit: 0 уязвимости
- `git diff --check`: чист
- remote tree е точно същото като локалното

## Риск
Нисък и обратим. Първият OAuth grant след старт може да стартира една bounded cleanup заявка; следващата е най-рано след 6 часа.

Closes #155