### PR TITLE
Добави безопасен OpenSearch backup инвентар

### DIFF
--- a/src/services/digitalOceanService.js
+++ b/src/services/digitalOceanService.js
@@ -453,6 +453,64 @@ function safeArray(value) {
   return Array.isArray(value) ? value : [];
 }
 
+function validIsoDate(value) {
+  if (typeof value !== "string" || !value.trim()) return null;
+  const stamp = Date.parse(value);
+  return Number.isFinite(stamp) ? new Date(stamp).toISOString() : null;
+}
+
+export async function getDigitalOceanDatabaseBackupInventory(
+  databases,
+  options = {},
+) {
+  return Promise.all(
+    safeArray(databases).map(async (database) => {
+      const engine =
+        typeof database?.engine === "string" ? database.engine : "unknown";
+      if (typeof database?.id !== "string" || !database.id.trim()) {
+        return {
+          engine,
+          status: "unverified",
+          backupCount: null,
+          oldestCreatedAt: null,
+          newestCreatedAt: null,
+          errorCode: "DATABASE_ID_MISSING",
+          errorStatus: null,
+        };
+      }
+      try {
+        const data = await request(
+          `/databases/${encodeURIComponent(database.id)}/backups?per_page=200`,
+          options,
+        );
+        const dates = safeArray(data?.backups)
+          .map((backup) => validIsoDate(backup?.created_at))
+          .filter(Boolean)
+          .sort();
+        return {
+          engine,
+          status: "verified",
+          backupCount: safeArray(data?.backups).length,
+          oldestCreatedAt: dates[0] || null,
+          newestCreatedAt: dates.at(-1) || null,
+          errorCode: null,
+          errorStatus: null,
+        };
+      } catch (error) {
+        return {
+          engine,
+          status: "unverified",
+          backupCount: null,
+          oldestCreatedAt: null,
+          newestCreatedAt: null,
+          errorCode: error?.code || "DIGITALOCEAN_UPSTREAM_ERROR",
+          errorStatus: error?.status || null,
+        };
+      }
+    }),
+  );
+}
+
 function regionSlug(resource) {
   return resource?.region?.slug || resource?.region || null;
 }
@@ -738,6 +796,31 @@ function buildFindings(audit) {
       message: `${unhealthyDatabases.length} управлявана база не е със статус online.`,
     });
   }
+  const opensearchBackups = safeArray(audit.databaseBackups).filter(
+    ({ engine }) => engine === "opensearch",
+  );
+  if (
+    audit.databases.some(({ engine }) => engine === "opensearch") &&
+    !opensearchBackups.some(({ status }) => status === "verified")
+  ) {
+    findings.push({
+      severity: "warning",
+      code: "OPENSEARCH_BACKUPS_UNVERIFIED",
+      message:
+        "Backup точките на управлявания OpenSearch не можаха да бъдат проверени.",
+    });
+  } else if (
+    opensearchBackups.some(
+      ({ status, backupCount }) => status === "verified" && backupCount === 0,
+    )
+  ) {
+    findings.push({
+      severity: "warning",
+      code: "OPENSEARCH_BACKUPS_EMPTY",
+      message:
+        "DigitalOcean backup API не върна restore точки за управлявания OpenSearch.",
+    });
+  }
   const unassignedReservedIps = audit.reservedIps.filter(
     (reservedIp) => !reservedIp.assigned,
   );
@@ -827,6 +910,11 @@ export async function getDigitalOceanAccountAudit(options = {}) {
     ? results.account.data?.account || {}
     : {};
   const balance = results.balance?.ok ? results.balance.data || {} : {};
+  const rawDatabases = read("databases", "databases");
+  const databaseBackups = await getDigitalOceanDatabaseBackupInventory(
+    rawDatabases,
+    options,
+  );
   const audit = {
     checkedAt: new Date().toISOString(),
     account: {
@@ -847,7 +935,8 @@ export async function getDigitalOceanAccountAudit(options = {}) {
     },
     apps: read("apps", "apps").map(mapApp),
     droplets: read("droplets", "droplets").map(mapDroplet),
-    databases: read("databases", "databases").map(mapDatabase),
+    databases: rawDatabases.map(mapDatabase),
+    databaseBackups,
     volumes: read("volumes", "volumes").map(mapVolume),
     snapshots: read("snapshots", "snapshots").map(mapSnapshot),
     vpcs: read("vpcs", "vpcs").map(mapVpc),
@@ -912,12 +1001,26 @@ export function formatDigitalOceanAudit(audit) {
     audit.billing.monthToDateUsage || audit.billing.accountBalance
       ? `Разход този месец: ${audit.billing.monthToDateUsage || "няма данни"} ${audit.billing.currency || ""}; баланс: ${audit.billing.accountBalance || "няма данни"} ${audit.billing.currency || ""}.`
       : "Разходи: няма достъпни данни.";
+  const databaseBackups = safeArray(audit.databaseBackups);
+  const backupLines = databaseBackups.length
+    ? databaseBackups.map((backup, index) => {
+        if (backup.status !== "verified") {
+          return `• ${backup.engine} база #${index + 1}: backup точките не са проверени (${backup.errorCode || "неизвестна причина"}).`;
+        }
+        const range = backup.backupCount
+          ? `; период ${backup.oldestCreatedAt || "неизвестен"} – ${backup.newestCreatedAt || "неизвестен"}`
+          : "";
+        return `• ${backup.engine} база #${index + 1}: ${backup.backupCount} налични backup точки${range}.`;
+      })
+    : ["• Няма открити управлявани бази за backup проверка."];
   return [
     "DigitalOcean — преглед на ресурсите само за четене.",
     `Акаунт: ${audit.account.status || "неизвестен статус"}.`,
     `Покритие: проверени ${checkedSections} от ${AUDIT_RESOURCES.length} заявени секции.`,
     `Ресурси: ${counts}.`,
     billing,
+    "Backup точки на управляваните бази:",
+    ...backupLines,
     "Находки:",
     ...audit.findings.map((finding) => `• ${finding.message}`),
     audit.unavailable.length

--- a/tests/infrastructureBridges.test.js
+++ b/tests/infrastructureBridges.test.js
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   getDigitalOceanAccountAudit,
+  getDigitalOceanDatabaseBackupInventory,
   getDigitalOceanAppStatus,
   formatDigitalOceanAudit,
   formatDigitalOceanStatus,
@@ -99,6 +100,14 @@ test("DigitalOcean full audit reads account resources without writes or secrets"
         ],
       });
     }
+    if (path === "/v2/databases/db-1/backups") {
+      return Response.json({
+        backups: [
+          { created_at: "2026-07-31T02:00:00Z" },
+          { created_at: "2026-07-30T02:00:00Z" },
+        ],
+      });
+    }
     if (path === "/v2/volumes") {
       return Response.json({
         volumes: [
@@ -156,6 +165,17 @@ test("DigitalOcean full audit reads account resources without writes or secrets"
   assert.equal(audit.apps.length, 1);
   assert.equal(audit.droplets.length, 1);
   assert.equal(audit.databases[0].engine, "opensearch");
+  assert.deepEqual(audit.databaseBackups, [
+    {
+      engine: "opensearch",
+      status: "verified",
+      backupCount: 2,
+      oldestCreatedAt: "2026-07-30T02:00:00.000Z",
+      newestCreatedAt: "2026-07-31T02:00:00.000Z",
+      errorCode: null,
+      errorStatus: null,
+    },
+  ]);
   assert.match(formatDigitalOceanAudit(audit), /преглед на ресурсите/u);
   assert.match(formatDigitalOceanAudit(audit), /проверени 23 от 23/u);
   assert.match(
@@ -163,10 +183,53 @@ test("DigitalOcean full audit reads account resources without writes or secrets"
     /без включени автоматични backups/u,
   );
   assert.match(formatDigitalOceanAudit(audit), /Не са направени промени/u);
+  assert.match(formatDigitalOceanAudit(audit), /2 налични backup точки/u);
   assert.equal(audit.unavailable.length, 0);
-  assert.equal(calls.length, 23);
+  assert.equal(calls.length, 24);
   assert.ok(calls.every((call) => call.options.method === "GET"));
   assert.doesNotMatch(JSON.stringify(audit), /secret/u);
+});
+
+test("database backup inventory reports denied access as unverified without leaking the token", async () => {
+  const inventory = await getDigitalOceanDatabaseBackupInventory(
+    [{ id: "db-private", engine: "opensearch" }],
+    {
+      env: { DIGITALOCEAN_API_TOKEN: "secret-backup-token" },
+      fetchImpl: async () =>
+        Response.json(
+          { message: "Bearer secret-backup-token is not allowed" },
+          { status: 403 },
+        ),
+    },
+  );
+
+  assert.deepEqual(inventory, [
+    {
+      engine: "opensearch",
+      status: "unverified",
+      backupCount: null,
+      oldestCreatedAt: null,
+      newestCreatedAt: null,
+      errorCode: "DIGITALOCEAN_FORBIDDEN",
+      errorStatus: 403,
+    },
+  ]);
+  assert.doesNotMatch(JSON.stringify(inventory), /secret-backup-token/u);
+});
+
+test("database backup inventory distinguishes a verified empty backup list", async () => {
+  const inventory = await getDigitalOceanDatabaseBackupInventory(
+    [{ id: "db-empty", engine: "opensearch" }],
+    {
+      env: { DIGITALOCEAN_API_TOKEN: "test-token" },
+      fetchImpl: async () => Response.json({ backups: [] }),
+    },
+  );
+
+  assert.equal(inventory[0].status, "verified");
+  assert.equal(inventory[0].backupCount, 0);
+  assert.equal(inventory[0].oldestCreatedAt, null);
+  assert.equal(inventory[0].newestCreatedAt, null);
 });
 
 test("Cloudflare bridge reads zone and DNS without writes", async () => {


### PR DESCRIPTION
## Резултат

- разширява съществуващия DigitalOcean одит с read-only заявка за backup точки на всяка управлявана база;
- връща само engine, проверен/непроверен статус, брой и най-стара/най-нова дата;
- не връща database ID, име, connection string, token, индекс или документи;
- различава отказан/неподдържан достъп от доказано празен backup списък;
- не създава restore/fork ресурс и не поражда платена операция.

## Проверки

- `npm test`: 397 pass, 0 fail, 1 очаквано пропуснат production OpenSearch тест;
- `npm audit --omit=dev --audit-level=high`: 0 уязвимости;
- целеви инфраструктурни тестове: 6/6.

Продължава #161. Задачата остава отворена до реална production read-only проверка.