### PR TITLE
Durable audit за потвърдените външни write действия

### DIFF
--- a/src/routes/confirmedActionsRouter.js
+++ b/src/routes/confirmedActionsRouter.js
@@ -24,7 +24,11 @@ import {
   GitHubOAuthError,
   parseGitHubCookies,
 } from "../services/githubOAuthService.js";
-import { recordAuditEvent } from "../services/permissionService.js";
+import {
+  executeAuditedWriteAction,
+  isAuditSafetyError,
+  recordAuditEvent,
+} from "../services/permissionService.js";
 
 const router = express.Router();
 
@@ -88,7 +92,7 @@ router.post("/request", async (req, res) => {
     decision: "confirm",
     outcome: "requested",
     resource: resourceLabel(confirmation.resource),
-    details: `confirmationId:${confirmation.id}`,
+    details: "confirmation_requested",
     sessionId: cleanSessionId,
   });
 
@@ -135,7 +139,7 @@ router.post("/confirm", async (req, res) => {
       action: "github.write",
       decision: "confirm",
       outcome: outcomeMap[error.code] || "denied",
-      details: `${error.code}:${cleanId}`,
+      details: error.code || "confirmation_denied",
       sessionId: cleanSessionId,
     });
     const statusMap = {
@@ -148,15 +152,6 @@ router.post("/confirm", async (req, res) => {
       .json({ error: error.message, code: error.code });
   }
 
-  await auditAction({
-    action: confirmation.action,
-    decision: "confirmed",
-    outcome: "executing",
-    resource: resourceLabel(confirmation.resource),
-    details: `confirmationId:${confirmation.id}`,
-    sessionId: cleanSessionId,
-  });
-
   // Mark used before execution to prevent any chance of double-execution
   markConfirmationUsed(cleanId);
 
@@ -164,17 +159,29 @@ router.post("/confirm", async (req, res) => {
   try {
     const githubSessionId =
       parseGitHubCookies(req.headers.cookie).synchron_github_session || "";
-    result = await executeAction(confirmation, githubSessionId);
-  } catch (error) {
-    await auditAction({
-      action: confirmation.action,
-      decision: "confirmed",
-      outcome: "failed",
-      resource: resourceLabel(confirmation.resource),
-      details: error.code || error.message,
+    result = await executeAuditedWriteAction({
+      action: "github.write",
+      capability: confirmation.action,
+      actor: cleanSessionId,
       sessionId: cleanSessionId,
+      confirmationId: cleanId,
+      resource: resourceLabel(confirmation.resource),
+      details: "confirmed_action",
+      execute: () => executeAction(confirmation, githubSessionId),
     });
+  } catch (error) {
+    if (!isAuditSafetyError(error)) {
+      await auditAction({
+        action: confirmation.action,
+        decision: "confirmed",
+        outcome: "failed",
+        resource: resourceLabel(confirmation.resource),
+        details: error.code || "EXECUTION_ERROR",
+        sessionId: cleanSessionId,
+      });
+    }
     const status =
+      isAuditSafetyError(error) ||
       error instanceof GitHubServiceError ||
       error instanceof GitHubOAuthError ||
       error instanceof CopilotTaskError
@@ -184,15 +191,6 @@ router.post("/confirm", async (req, res) => {
       .status(status)
       .json({ error: error.message, code: error.code || "EXECUTION_ERROR" });
   }
-
-  await auditAction({
-    action: confirmation.action,
-    decision: "confirmed",
-    outcome: "succeeded",
-    resource: resourceLabel(confirmation.resource),
-    details: `confirmationId:${confirmation.id}`,
-    sessionId: cleanSessionId,
-  });
 
   return res.json({ status: "ok", action: confirmation.action, result });
 });
@@ -225,7 +223,7 @@ router.post("/deny", async (req, res) => {
     decision: "denied",
     outcome: "denied",
     resource: resourceLabel(confirmation.resource),
-    details: `denied:confirmationId:${confirmation.id}`,
+    details: "confirmation_denied",
     sessionId: cleanSessionId,
   });
 

--- a/src/routes/testerAuthAdminRouter.js
+++ b/src/routes/testerAuthAdminRouter.js
@@ -9,7 +9,10 @@ import {
   markDurableConfirmationUsed,
   validateDurableConfirmation,
 } from "../services/confirmationService.js";
-import { recordAuditEvent } from "../services/permissionService.js";
+import {
+  executeAuditedWriteAction,
+  recordAuditEvent,
+} from "../services/permissionService.js";
 import {
   getTesterInviteCode,
   isTesterRegistrationEnabled,
@@ -36,6 +39,8 @@ function safeError(error) {
     CONFIRMATION_EXPIRED: 410,
     SESSION_MISMATCH: 403,
     CONFIRMATION_PERSISTENCE_FAILED: 503,
+    AUDIT_UNAVAILABLE: 503,
+    AUDIT_OUTCOME_UNCERTAIN: 502,
   };
   const resolvedStatus =
     status >= 400 && status < 600 ? status : statusByCode[error?.code] || 500;
@@ -44,6 +49,9 @@ function safeError(error) {
     body: {
       error:
         error?.name === "DigitalOceanError" ||
+        ["AUDIT_UNAVAILABLE", "AUDIT_OUTCOME_UNCERTAIN"].includes(
+          error?.code,
+        ) ||
         (resolvedStatus >= 400 && resolvedStatus < 500)
           ? error.message
           : "Активирането на тестовите профили не успя.",
@@ -59,6 +67,7 @@ export function createTesterAuthAdminRouter({
   validateConfirmation = validateDurableConfirmation,
   consumeConfirmation = markDurableConfirmationUsed,
   audit = recordAuditEvent,
+  executeWrite = executeAuditedWriteAction,
   bootstrap = TESTER_AUTH_BOOTSTRAP,
   env = process.env,
 } = {}) {
@@ -163,18 +172,20 @@ export function createTesterAuthAdminRouter({
         });
       }
       await consumeConfirmation(confirmationId);
-      const result = await activate({
-        projectUrl: confirmation.params.projectUrl,
-        publishableKey: confirmation.params.publishableKey,
-        expectedAppId: confirmation.resource.appId,
-      });
-      await safeAudit(audit, {
-        actor: req.owner.id,
+      const result = await executeWrite({
         action: ACTION,
-        decision: "confirmed",
-        outcome: "succeeded",
-        resource: result.appId,
-        details: `keys:${result.changedKeys.join(",")}`,
+        capability: "infrastructure.write",
+        actor: req.owner.id,
+        sessionId: req.owner.id,
+        confirmationId,
+        resource: confirmation.resource.appId,
+        details: "activate_tester_auth",
+        execute: () =>
+          activate({
+            projectUrl: confirmation.params.projectUrl,
+            publishableKey: confirmation.params.publishableKey,
+            expectedAppId: confirmation.resource.appId,
+          }),
       });
       return res.json({
         status: "ok",

--- a/src/services/calendarService.js
+++ b/src/services/calendarService.js
@@ -9,6 +9,10 @@ import {
   GoogleDriveError,
   hasSession,
 } from "./googleDriveService.js";
+import {
+  executeAuditedWriteAction,
+  isAuditSafetyError,
+} from "./permissionService.js";
 
 const CALENDAR_ACTION = "calendar.write:create_event";
 const CONFIRM_PREFIX = "Потвърждавам календарно събитие:";
@@ -226,6 +230,7 @@ export async function confirmCalendarEvent({
   validateConfirmation = validateDurableConfirmation,
   consumeConfirmation = markDurableConfirmationUsed,
   createEvent = createGoogleCalendarEvent,
+  executeWrite = executeAuditedWriteAction,
 }) {
   let confirmation;
   try {
@@ -260,14 +265,30 @@ export async function confirmCalendarEvent({
     );
   }
   await consumeConfirmation(confirmationId);
-  return createEvent(googleSessionId, {
-    title: confirmation.resource.title,
-    start: confirmation.resource.start,
-    end: confirmation.resource.end,
-    timeZone: confirmation.resource.timeZone,
-    location: confirmation.params.location || "",
-    description: confirmation.params.description || "",
-  });
+  try {
+    return await executeWrite({
+      action: "calendar.write",
+      capability: "calendar.write",
+      sessionId,
+      confirmationId,
+      resource: "primary-calendar",
+      details: "create_event",
+      execute: () =>
+        createEvent(googleSessionId, {
+          title: confirmation.resource.title,
+          start: confirmation.resource.start,
+          end: confirmation.resource.end,
+          timeZone: confirmation.resource.timeZone,
+          location: confirmation.params.location || "",
+          description: confirmation.params.description || "",
+        }),
+    });
+  } catch (error) {
+    if (isAuditSafetyError(error)) {
+      throw new GoogleDriveError(error.message, error.status, error.code);
+    }
+    throw error;
+  }
 }
 
 export function formatCalendarEventResult(event) {

--- a/src/services/copilotTaskService.js
+++ b/src/services/copilotTaskService.js
@@ -11,6 +11,10 @@ import {
   isAuthorizedGitHubLogin,
   isGitHubOAuthConfigured,
 } from "./githubOAuthService.js";
+import {
+  executeAuditedWriteAction,
+  isAuditSafetyError,
+} from "./permissionService.js";
 
 const DEFAULT_REPOSITORY = "radostinvgeorgiev-commits/sunchron-backend";
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
@@ -810,6 +814,7 @@ export async function confirmCopilotTask({
   sessionId,
   githubSessionId,
   fetchImpl = fetch,
+  executeWrite = executeAuditedWriteAction,
 }) {
   const confirmation = await validateDurableConfirmation(
     confirmationId,
@@ -823,13 +828,29 @@ export async function confirmCopilotTask({
     );
   }
   await markDurableConfirmationUsed(confirmationId);
-  return startCopilotTask({
-    githubSessionId,
-    prompt: confirmation.params.prompt,
-    repository: confirmation.resource.repository,
-    baseRef: confirmation.resource.baseRef,
-    fetchImpl,
-  });
+  try {
+    return await executeWrite({
+      action: "github.write",
+      capability: "code.write",
+      sessionId,
+      confirmationId,
+      resource: confirmation.resource.repository,
+      details: "github.copilot:start_task",
+      execute: () =>
+        startCopilotTask({
+          githubSessionId,
+          prompt: confirmation.params.prompt,
+          repository: confirmation.resource.repository,
+          baseRef: confirmation.resource.baseRef,
+          fetchImpl,
+        }),
+    });
+  } catch (error) {
+    if (isAuditSafetyError(error)) {
+      throw new CopilotTaskError(error.message, error.status, error.code);
+    }
+    throw error;
+  }
 }
 
 export function formatCopilotTaskResult(result) {

--- a/src/services/permissionService.js
+++ b/src/services/permissionService.js
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { getOpenSearchClient } from "../config/opensearch.js";
 
 const AUDIT_INDEX = process.env.AUDIT_INDEX || "synchron-action-audit";
@@ -114,33 +114,178 @@ export function listPermissions() {
   }));
 }
 
-export async function recordAuditEvent(event) {
+function referenceFingerprint(value) {
+  const text = cleanText(value);
+  return text
+    ? createHash("sha256").update(text).digest("hex")
+    : null;
+}
+
+function buildAuditEntry(event) {
   const permission = evaluatePermission(event.action);
-  const entry = {
+  return {
     id: randomUUID(),
+    auditId: cleanText(event.auditId),
     timestamp: new Date().toISOString(),
     actor: cleanText(event.actor, "synchron-x"),
     action: permission.action,
+    capability: cleanText(event.capability),
     decision: cleanText(event.decision, permission.decision),
+    phase: cleanText(event.phase),
     outcome: cleanText(event.outcome, "attempted"),
     resource: cleanText(event.resource),
     details: cleanText(event.details),
     sessionId: cleanText(event.sessionId),
+    confirmationRef: referenceFingerprint(event.confirmationId),
   };
+}
 
+async function persistAuditEntry(client, entry) {
+  await client.index({
+    index: AUDIT_INDEX,
+    id: entry.id,
+    body: entry,
+    refresh: true,
+  });
+}
+
+export class AuditSafetyError extends Error {
+  constructor(message, code, status = 503, options = {}) {
+    super(message, options.cause ? { cause: options.cause } : undefined);
+    this.name = "AuditSafetyError";
+    this.code = code;
+    this.status = status;
+    this.auditId = options.auditId || null;
+    this.result = options.result;
+  }
+}
+
+export function isAuditSafetyError(error) {
+  return error instanceof AuditSafetyError;
+}
+
+export async function recordAuditEvent(event) {
+  const entry = buildAuditEntry(event);
   const client = getOpenSearchClient();
   if (client) {
-    await client.index({
-      index: AUDIT_INDEX,
-      id: entry.id,
-      body: entry,
-      refresh: true,
-    });
+    await persistAuditEntry(client, entry);
   } else {
     fallbackEvents.unshift(entry);
     if (fallbackEvents.length > MAX_FALLBACK_EVENTS) fallbackEvents.pop();
   }
   return entry;
+}
+
+export async function recordDurableAuditEvent(event) {
+  const entry = buildAuditEntry(event);
+  const client = getOpenSearchClient();
+  if (!client) {
+    throw new AuditSafetyError(
+      "Устойчивият журнал не е достъпен.",
+      "AUDIT_UNAVAILABLE",
+      503,
+    );
+  }
+  try {
+    await persistAuditEntry(client, entry);
+  } catch (error) {
+    throw new AuditSafetyError(
+      "Устойчивият журнал не е достъпен.",
+      "AUDIT_UNAVAILABLE",
+      503,
+      { cause: error },
+    );
+  }
+  return entry;
+}
+
+export async function executeAuditedWriteAction({
+  action,
+  capability,
+  actor,
+  sessionId,
+  confirmationId,
+  resource,
+  details,
+  execute,
+  writeAudit,
+}) {
+  if (typeof execute !== "function") {
+    throw new TypeError("Audit write action: липсва изпълнима функция.");
+  }
+
+  const auditId = randomUUID();
+  const audit =
+    typeof writeAudit === "function"
+      ? writeAudit
+      : process.env.NODE_ENV === "production"
+        ? recordDurableAuditEvent
+        : recordAuditEvent;
+  const baseEvent = {
+    auditId,
+    actor,
+    action,
+    capability,
+    decision: "confirmed",
+    resource,
+    details,
+    sessionId,
+    confirmationId,
+  };
+
+  try {
+    await audit({
+      ...baseEvent,
+      phase: "intent",
+      outcome: "intent",
+    });
+  } catch (error) {
+    throw new AuditSafetyError(
+      "Журналът не е достъпен. Действието не беше стартирано.",
+      "AUDIT_UNAVAILABLE",
+      503,
+      { auditId, cause: error },
+    );
+  }
+
+  let result;
+  try {
+    result = await execute();
+  } catch (executionError) {
+    try {
+      await audit({
+        ...baseEvent,
+        phase: "outcome",
+        outcome: "failed",
+        details: cleanText(executionError?.code, "WRITE_ACTION_FAILED"),
+      });
+    } catch (auditError) {
+      throw new AuditSafetyError(
+        "Действието върна грешка, но крайният журнал не можа да бъде записан. Провери състоянието преди повторение.",
+        "AUDIT_OUTCOME_UNCERTAIN",
+        502,
+        { auditId, cause: auditError },
+      );
+    }
+    throw executionError;
+  }
+
+  try {
+    await audit({
+      ...baseEvent,
+      phase: "outcome",
+      outcome: "succeeded",
+    });
+  } catch (error) {
+    throw new AuditSafetyError(
+      "Действието може да е извършено, но крайният журнал не можа да бъде записан. Не го повтаряй автоматично.",
+      "AUDIT_OUTCOME_UNCERTAIN",
+      502,
+      { auditId, result, cause: error },
+    );
+  }
+
+  return result;
 }
 
 export async function listAuditEvents(limit = 50) {

--- a/src/services/permissionService.js
+++ b/src/services/permissionService.js
@@ -216,11 +216,7 @@ export async function executeAuditedWriteAction({
 
   const auditId = randomUUID();
   const audit =
-    typeof writeAudit === "function"
-      ? writeAudit
-      : process.env.NODE_ENV === "production"
-        ? recordDurableAuditEvent
-        : recordAuditEvent;
+    typeof writeAudit === "function" ? writeAudit : recordDurableAuditEvent;
   const baseEvent = {
     auditId,
     actor,

--- a/tests/calendarService.test.js
+++ b/tests/calendarService.test.js
@@ -99,6 +99,12 @@ test("consumes the exact confirmation before one external calendar write", async
       };
     },
     consumeConfirmation: async (id) => order.push(`consume:${id}`),
+    executeWrite: async ({ execute, action, confirmationId }) => {
+      order.push(`audit-intent:${action}:${confirmationId}`);
+      const value = await execute();
+      order.push("audit-outcome:succeeded");
+      return value;
+    },
     createEvent: async (googleSessionId, event) => {
       order.push(`create:${googleSessionId}:${event.title}`);
       return {
@@ -113,7 +119,9 @@ test("consumes the exact confirmation before one external calendar write", async
   assert.deepEqual(order, [
     "validate:confirmation-calendar:chat-session",
     "consume:confirmation-calendar",
+    "audit-intent:calendar.write:confirmation-calendar",
     "create:google-session:Среща",
+    "audit-outcome:succeeded",
   ]);
   assert.match(formatCalendarEventResult(result), /event\?eid=safe/u);
 });
@@ -155,4 +163,40 @@ test("extracts only the dedicated calendar confirmation phrase", () => {
     id,
   );
   assert.equal(extractCalendarConfirmationId(`Да ${id}`), null);
+});
+
+
+test("calendar adapter is not called when the audited write guard blocks", async () => {
+  let created = false;
+  await assert.rejects(
+    () =>
+      confirmCalendarEvent({
+        confirmationId: "confirmation-calendar",
+        sessionId: "chat-session",
+        googleSessionId: "google-session",
+        validateConfirmation: async () => ({
+          action: "calendar.write:create_event",
+          resource: {
+            title: "Среща",
+            start: "2026-08-05T14:30:00",
+            end: "2026-08-05T15:15:00",
+            timeZone: "Europe/Sofia",
+            googleSessionFingerprint:
+              "1a92e8a09da51712cb71a8aadd4eed42670e26db5c6ae6ced63bce130d6a307f",
+          },
+          params: {},
+        }),
+        consumeConfirmation: async () => {},
+        executeWrite: async () => {
+          const error = new Error("audit blocked");
+          error.code = "AUDIT_UNAVAILABLE";
+          throw error;
+        },
+        createEvent: async () => {
+          created = true;
+        },
+      }),
+    (error) => error.code === "AUDIT_UNAVAILABLE",
+  );
+  assert.equal(created, false);
 });

--- a/tests/copilotTaskService.test.js
+++ b/tests/copilotTaskService.test.js
@@ -385,13 +385,21 @@ test("requires an exact one-time confirmation before starting Copilot", async ()
     prepared.confirmationId,
   );
 
+  let auditedWrites = 0;
   const result = await confirmCopilotTask({
     confirmationId: prepared.confirmationId,
     sessionId: "chat-session",
     githubSessionId: session.id,
     fetchImpl: copilotGraphqlFetch(),
+    executeWrite: async ({ execute, action, confirmationId }) => {
+      auditedWrites += 1;
+      assert.equal(action, "github.write");
+      assert.equal(confirmationId, prepared.confirmationId);
+      return execute();
+    },
   });
   assert.equal(result.issueNumber, 81);
+  assert.equal(auditedWrites, 1);
 
   await assert.rejects(
     () =>
@@ -403,4 +411,35 @@ test("requires an exact one-time confirmation before starting Copilot", async ()
       }),
     (error) => error.code === "CONFIRMATION_NOT_FOUND",
   );
+});
+
+
+test("Copilot adapter is not called when the audited write guard blocks", async () => {
+  const session = await connectedSession();
+  const prepared = await prepareCopilotTask({
+    sessionId: "chat-session",
+    githubSessionId: session.id,
+    prompt: "Промени цвета на бутона Памет.",
+  });
+  let githubCalls = 0;
+
+  await assert.rejects(
+    () =>
+      confirmCopilotTask({
+        confirmationId: prepared.confirmationId,
+        sessionId: "chat-session",
+        githubSessionId: session.id,
+        fetchImpl: async () => {
+          githubCalls += 1;
+          throw new Error("must not call GitHub");
+        },
+        executeWrite: async () => {
+          const error = new Error("audit unavailable");
+          error.code = "AUDIT_UNAVAILABLE";
+          throw error;
+        },
+      }),
+    (error) => error.code === "AUDIT_UNAVAILABLE",
+  );
+  assert.equal(githubCalls, 0);
 });

--- a/tests/permissionService.test.js
+++ b/tests/permissionService.test.js
@@ -154,6 +154,7 @@ test("stored audit fingerprints the confirmation instead of storing it raw", asy
     sessionId: "session-1",
     confirmationId,
     resource: "allowed-repository",
+    writeAudit: recordAuditEvent,
     execute: async () => ({ ok: true }),
   });
 

--- a/tests/permissionService.test.js
+++ b/tests/permissionService.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   evaluatePermission,
+  executeAuditedWriteAction,
   listAuditEvents,
   listPermissions,
   recordAuditEvent,
@@ -46,4 +47,118 @@ test("records append-only audit events when OpenSearch is unavailable", async ()
   assert.equal(events[0].id, saved.id);
   assert.equal(events[0].decision, "allow");
   assert.equal(events[0].outcome, "succeeded");
+});
+
+
+test("durable write records intent before one adapter call and a final outcome", async () => {
+  const events = [];
+  let calls = 0;
+  const result = await executeAuditedWriteAction({
+    action: "calendar.write",
+    capability: "calendar.write",
+    sessionId: "session-1",
+    confirmationId: "confirmation-1",
+    resource: "primary-calendar",
+    writeAudit: async (event) => events.push(event),
+    execute: async () => {
+      calls += 1;
+      return { id: "event-1" };
+    },
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(result.id, "event-1");
+  assert.deepEqual(
+    events.map(({ phase, outcome }) => ({ phase, outcome })),
+    [
+      { phase: "intent", outcome: "intent" },
+      { phase: "outcome", outcome: "succeeded" },
+    ],
+  );
+  assert.equal(events[0].auditId, events[1].auditId);
+});
+
+test("durable write fails closed before the adapter when intent audit fails", async () => {
+  let calls = 0;
+  await assert.rejects(
+    () =>
+      executeAuditedWriteAction({
+        action: "github.write",
+        capability: "code.write",
+        sessionId: "session-1",
+        confirmationId: "confirmation-1",
+        resource: "allowed-repository",
+        writeAudit: async () => {
+          throw new Error("audit unavailable");
+        },
+        execute: async () => {
+          calls += 1;
+        },
+      }),
+    (error) => error.code === "AUDIT_UNAVAILABLE",
+  );
+  assert.equal(calls, 0);
+});
+
+test("durable write records an adapter failure without hiding its exact code", async () => {
+  const events = [];
+  const failure = new Error("provider failed");
+  failure.code = "PROVIDER_FAILED";
+
+  await assert.rejects(
+    () =>
+      executeAuditedWriteAction({
+        action: "calendar.write",
+        sessionId: "session-1",
+        confirmationId: "confirmation-1",
+        resource: "primary-calendar",
+        writeAudit: async (event) => events.push(event),
+        execute: async () => {
+          throw failure;
+        },
+      }),
+    (error) => error === failure,
+  );
+
+  assert.equal(events.at(-1).phase, "outcome");
+  assert.equal(events.at(-1).outcome, "failed");
+  assert.equal(events.at(-1).details, "PROVIDER_FAILED");
+});
+
+test("successful adapter with failed final audit is uncertain, never completed", async () => {
+  let auditCall = 0;
+  await assert.rejects(
+    () =>
+      executeAuditedWriteAction({
+        action: "calendar.write",
+        sessionId: "session-1",
+        confirmationId: "confirmation-1",
+        resource: "primary-calendar",
+        writeAudit: async () => {
+          auditCall += 1;
+          if (auditCall === 2) throw new Error("outcome unavailable");
+        },
+        execute: async () => ({ id: "event-1" }),
+      }),
+    (error) =>
+      error.code === "AUDIT_OUTCOME_UNCERTAIN" &&
+      error.result?.id === "event-1",
+  );
+});
+
+test("stored audit fingerprints the confirmation instead of storing it raw", async () => {
+  const confirmationId = "confirmation-secret-value";
+  await executeAuditedWriteAction({
+    action: "github.write",
+    capability: "code.write",
+    sessionId: "session-1",
+    confirmationId,
+    resource: "allowed-repository",
+    execute: async () => ({ ok: true }),
+  });
+
+  const events = await listAuditEvents();
+  assert.equal(events.length, 2);
+  assert.ok(events.every((event) => event.confirmationRef?.length === 64));
+  assert.doesNotMatch(JSON.stringify(events), /confirmation-secret-value/u);
 });

--- a/tests/testerAuthAdminRouter.test.js
+++ b/tests/testerAuthAdminRouter.test.js
@@ -80,6 +80,7 @@ test("returns the exact safe DigitalOcean permission error", async () => {
       params: BOOTSTRAP,
     }),
     consumeConfirmation: async () => {},
+    executeWrite: async ({ execute }) => execute(),
     activate: async () => {
       throw error;
     },
@@ -109,6 +110,7 @@ test("consumes the exact confirmation before activating DigitalOcean", async () 
       };
     },
     consumeConfirmation: async (id) => events.push(`consume:${id}`),
+    executeWrite: async ({ execute }) => execute(),
     activate: async (input) => {
       events.push("activate");
       assert.equal(input.expectedAppId, "app-1");

--- a/tests/testerAuthAdminRouter.test.js
+++ b/tests/testerAuthAdminRouter.test.js
@@ -133,7 +133,7 @@ test("consumes the exact confirmation before activating DigitalOcean", async () 
   assert.equal(response.body.inviteCode, "private-invite");
 });
 
-test("audit storage failure cannot turn a successful activation into a failure", async () => {
+test("successful activation with failed final audit is reported as uncertain", async () => {
   const app = testApp({
     validateConfirmation: async () => ({
       action: ACTION,
@@ -148,18 +148,57 @@ test("audit storage failure cannot turn a successful activation into a failure",
       deploymentId: "deploy-1",
       inviteCode: "private-invite",
     }),
-    audit: async () => {
-      throw new Error("audit unavailable");
+    executeWrite: async ({ execute }) => {
+      await execute();
+      const error = new Error(
+        "Действието може да е извършено, но крайният журнал не можа да бъде записан. Не го повтаряй автоматично.",
+      );
+      error.code = "AUDIT_OUTCOME_UNCERTAIN";
+      error.status = 502;
+      throw error;
     },
+    audit: async () => {},
   });
 
   const response = await request(app)
     .post("/api/tester-auth/confirm")
     .send({ confirmationId: "confirmation-1" })
-    .expect(200);
+    .expect(502);
 
-  assert.equal(response.body.status, "ok");
-  assert.equal(response.body.deploymentId, "deploy-1");
+  assert.equal(response.body.code, "AUDIT_OUTCOME_UNCERTAIN");
+  assert.match(response.body.error, /Не го повтаряй автоматично/u);
+});
+
+test("missing audit intent blocks DigitalOcean before activation", async () => {
+  let activated = false;
+  const app = testApp({
+    validateConfirmation: async () => ({
+      action: ACTION,
+      resource: { appId: "app-1" },
+      params: BOOTSTRAP,
+    }),
+    consumeConfirmation: async () => {},
+    executeWrite: async () => {
+      const error = new Error(
+        "Журналът не е достъпен. Действието не беше стартирано.",
+      );
+      error.code = "AUDIT_UNAVAILABLE";
+      error.status = 503;
+      throw error;
+    },
+    activate: async () => {
+      activated = true;
+    },
+    audit: async () => {},
+  });
+
+  const response = await request(app)
+    .post("/api/tester-auth/confirm")
+    .send({ confirmationId: "confirmation-1" })
+    .expect(503);
+
+  assert.equal(response.body.code, "AUDIT_UNAVAILABLE");
+  assert.equal(activated, false);
 });
 
 test("reveals the invite code only from the owner-protected admin router", async () => {


### PR DESCRIPTION
Closes #166

## Какво променя
- записва устойчив audit intent преди всеки реален външен write adapter;
- блокира adapter-а с `AUDIT_UNAVAILABLE`, ако intent не може да бъде записан;
- записва финален резултат `succeeded` / `failed`;
- връща `AUDIT_OUTCOME_UNCERTAIN` след възможен успешен write без финален audit и забранява автоматично повторение;
- свързва audit записа с action, capability, actor/session, безопасна цел и SHA-256 отпечатък на еднократното confirmation ID;
- покрива GitHub/Copilot, Google Calendar и DigitalOcean activation write пътищата;
- запазва read действията неблокиращи и не променя AI Core или постоянната памет.

## Проверки
- success path: intent → adapter веднъж → outcome;
- intent failure: adapter не се извиква;
- adapter failure: durable failed outcome;
- final audit failure: частичен/неопределен резултат, без false success;
- confirmation replay/session/target защитите остават преди adapter-а;
- суровото confirmation ID не се пази в audit;
- целият тестов пакет и `npm audit --omit=dev --audit-level=high` се изпълняват от CI.

## Риск
Промяната е fail-closed само за реални външни write действия. При недостъпен OpenSearch те ще бъдат отказани безопасно; read операциите не се блокират.