### PR TITLE
Показвай честно, когато разговорът не е запазен

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1234,6 +1234,20 @@ function createAssistantTurn(text = "", showActions = true) {
   return { turn, message, actions };
 }
 
+function showConversationPersistenceWarning(message) {
+  const turn = message?.closest(".assistant-turn");
+  if (!turn || turn.querySelector(".conversation-persistence-warning")) return;
+
+  const warning = document.createElement("div");
+  warning.className = "conversation-persistence-warning";
+  warning.setAttribute("role", "status");
+  warning.textContent =
+    "Отговорът е получен, но разговорът не е запазен. Копирай важната информация преди да затвориш чата.";
+
+  const actions = turn.querySelector(".message-actions");
+  turn.insertBefore(warning, actions || null);
+}
+
 async function handleMessageAction(event) {
   const button = event.target.closest("button[data-action]");
   if (!button) return;
@@ -1428,6 +1442,13 @@ async function sendMessage() {
           logAction(parsed.data.message);
         } else if (parsed.event === "done") {
           completed = true;
+          if (
+            parsed.data?.conversationPersisted === false &&
+            parsed.data?.warningCode === "CONVERSATION_NOT_SAVED"
+          ) {
+            showConversationPersistenceWarning(responseBubble);
+            logAction("Разговорът не е запазен");
+          }
           if (parsed.data?.task?.status === "completed") {
             logAction(
               parsed.data.task.verified

--- a/public/styles.css
+++ b/public/styles.css
@@ -621,6 +621,17 @@ input {
     width: 100%;
 }
 
+.conversation-persistence-warning {
+    margin-top: 8px;
+    padding: 10px 12px;
+    border: 1px solid #d9902f;
+    border-radius: 12px;
+    color: #6f4308;
+    background: #fff4df;
+    font-size: var(--synchron-readable-text, 16px);
+    line-height: 1.4;
+}
+
 .user-turn {
     max-width: 82%;
     align-self: flex-end;

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -114,6 +114,15 @@ async function saveConversationTurnBestEffort(
   }
 }
 
+export function getConversationPersistenceMetadata(conversationPersisted) {
+  return conversationPersisted
+    ? { conversationPersisted: true }
+    : {
+        conversationPersisted: false,
+        warningCode: "CONVERSATION_NOT_SAVED",
+      };
+}
+
 const ASSISTANT_CONTEXT = [
   "[КОНТЕКСТ И ПРАВИЛА ЗА ТОЗИ РАЗГОВОР]",
   "Ти си Synchron-X — личната AI операционна система на Радко.",
@@ -914,7 +923,7 @@ router.post("/chat", async (req, res) => {
         prompt: cleanMessage,
         context: messages[0].content,
       });
-      await saveConversationTurnBestEffort(
+      const conversationPersisted = await saveConversationTurnBestEffort(
         cleanSessionId,
         cleanMessage,
         fullReply,
@@ -928,7 +937,11 @@ router.post("/chat", async (req, res) => {
         sessionId: cleanSessionId,
       });
       sendEvent("token", { token: fullReply });
-      sendEvent("done", { ok: true, tool: "vision" });
+      sendEvent("done", {
+        ok: true,
+        tool: "vision",
+        ...getConversationPersistenceMetadata(conversationPersisted),
+      });
     } catch (error) {
       console.error(`[Vision] Failure for ${cleanSessionId}:`, error);
       sendEvent("error", {
@@ -952,7 +965,7 @@ router.post("/chat", async (req, res) => {
         source: "confirmed-chat-command",
       });
       const fullReply = formatMemoryWriteResult(items);
-      await saveConversationTurnBestEffort(
+      const conversationPersisted = await saveConversationTurnBestEffort(
         cleanSessionId,
         cleanMessage,
         fullReply,
@@ -972,6 +985,7 @@ router.post("/chat", async (req, res) => {
         mode: "confirmed-memory-write",
         memoryUpdated: true,
         count: items.length,
+        ...getConversationPersistenceMetadata(conversationPersisted),
       });
     } catch (error) {
       console.error(
@@ -1007,7 +1021,7 @@ router.post("/chat", async (req, res) => {
         googleSessionId,
       });
       const fullReply = formatCalendarEventResult(result);
-      await saveConversationTurnBestEffort(
+      const conversationPersisted = await saveConversationTurnBestEffort(
         cleanSessionId,
         cleanMessage,
         fullReply,
@@ -1026,6 +1040,7 @@ router.post("/chat", async (req, res) => {
         ok: true,
         mode: "calendar-event",
         eventId: result.id,
+        ...getConversationPersistenceMetadata(conversationPersisted),
       });
     } catch (error) {
       console.error("[Calendar confirmation]", error);
@@ -1057,7 +1072,7 @@ router.post("/chat", async (req, res) => {
         githubSessionId,
       });
       const fullReply = formatCopilotTaskResult(result);
-      await saveConversationTurnBestEffort(
+      const conversationPersisted = await saveConversationTurnBestEffort(
         cleanSessionId,
         cleanMessage,
         fullReply,
@@ -1076,6 +1091,7 @@ router.post("/chat", async (req, res) => {
         ok: true,
         mode: "copilot-task",
         issueNumber: result.issueNumber,
+        ...getConversationPersistenceMetadata(conversationPersisted),
       });
     } catch (error) {
       console.error("[Copilot confirmation]", error);
@@ -1148,14 +1164,18 @@ router.post("/chat", async (req, res) => {
       ? [heading, ...scopedMemories.map(({ fact }) => `• ${fact}`)].join("\n")
       : emptyReply;
 
-    await saveConversationTurnBestEffort(
+    const conversationPersisted = await saveConversationTurnBestEffort(
       cleanSessionId,
       cleanMessage,
       fullReply,
       ownerId,
     );
     sendEvent("token", { token: fullReply });
-    sendEvent("done", { ok: true, memoryCount: scopedMemories.length });
+    sendEvent("done", {
+      ok: true,
+      memoryCount: scopedMemories.length,
+      ...getConversationPersistenceMetadata(conversationPersisted),
+    });
     console.info(
       `[Chat] Response completed (memory overview) for ${cleanSessionId}`,
     );
@@ -1234,7 +1254,7 @@ router.post("/chat", async (req, res) => {
     shouldReplyWithVerifiedToolOutput(capabilityResults)
   ) {
     const fullReply = capabilityReplies.join("\n\n");
-    await saveConversationTurnBestEffort(
+    const conversationPersisted = await saveConversationTurnBestEffort(
       cleanSessionId,
       cleanMessage,
       fullReply,
@@ -1247,6 +1267,7 @@ router.post("/chat", async (req, res) => {
       task: taskResult,
       mode: "verified-tool-output",
       memoryAvailable,
+      ...getConversationPersistenceMetadata(conversationPersisted),
     });
     console.info(
       `[Chat] Response completed with verified infrastructure output for ${cleanSessionId}`,
@@ -1259,7 +1280,7 @@ router.post("/chat", async (req, res) => {
     const fullReply = [...capabilityReplies, memoryReply]
       .filter(Boolean)
       .join("\n\n");
-    await saveConversationTurnBestEffort(
+    const conversationPersisted = await saveConversationTurnBestEffort(
       cleanSessionId,
       cleanMessage,
       fullReply,
@@ -1273,6 +1294,7 @@ router.post("/chat", async (req, res) => {
       task: taskResult,
       mode: capabilityResults.length ? "deterministic" : undefined,
       memoryAvailable,
+      ...getConversationPersistenceMetadata(conversationPersisted),
     });
     console.info(
       `[Chat] Response completed (memory shortcut) for ${cleanSessionId}`,
@@ -1286,7 +1308,7 @@ router.post("/chat", async (req, res) => {
       const fullReply = [...capabilityReplies, memoryReply]
         .filter(Boolean)
         .join("\n\n");
-      await saveConversationTurnBestEffort(
+      const conversationPersisted = await saveConversationTurnBestEffort(
         cleanSessionId,
         cleanMessage,
         fullReply,
@@ -1301,6 +1323,7 @@ router.post("/chat", async (req, res) => {
         task: taskResult,
         mode: "deterministic-fallback",
         memoryAvailable,
+        ...getConversationPersistenceMetadata(conversationPersisted),
       });
       res.end();
       return;
@@ -1369,7 +1392,7 @@ router.post("/chat", async (req, res) => {
       throw new Error("AI ядрото приключи без текстов отговор.");
     }
 
-    await saveConversationTurnBestEffort(
+    const conversationPersisted = await saveConversationTurnBestEffort(
       cleanSessionId,
       cleanMessage,
       fullReply,
@@ -1384,6 +1407,7 @@ router.post("/chat", async (req, res) => {
       task: taskResult,
       mode: capabilityResults.length ? "agentic" : "conversation",
       provider: "openai",
+      ...getConversationPersistenceMetadata(conversationPersisted),
     });
     console.log(`[AI Core] openai success for ${cleanSessionId}`);
     console.info(

--- a/tests/chatResilience.test.js
+++ b/tests/chatResilience.test.js
@@ -48,6 +48,8 @@ test("normal AI chat continues when persistent memory is unavailable", async () 
 
     assert.match(response.text, /Работя нормално\./u);
     assert.match(response.text, /"memoryAvailable":false/u);
+    assert.match(response.text, /"conversationPersisted":false/u);
+    assert.match(response.text, /"warningCode":"CONVERSATION_NOT_SAVED"/u);
     assert.match(response.text, /event: done/u);
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/conversationPersistenceStatus.test.js
+++ b/tests/conversationPersistenceStatus.test.js
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { getConversationPersistenceMetadata } from "../src/routes/chat.js";
+
+test("conversation persistence metadata distinguishes saved and unsaved answers", () => {
+  assert.deepEqual(getConversationPersistenceMetadata(true), {
+    conversationPersisted: true,
+  });
+  assert.deepEqual(getConversationPersistenceMetadata(false), {
+    conversationPersisted: false,
+    warningCode: "CONVERSATION_NOT_SAVED",
+  });
+});
+
+test("every successful conversation save path forwards the real persistence result", async () => {
+  const source = await readFile(
+    new URL("../src/routes/chat.js", import.meta.url),
+    "utf8",
+  );
+  const saveCalls = source.match(
+    /const conversationPersisted = await saveConversationTurnBestEffort\(/gu,
+  );
+  const metadataCalls = source.match(
+    /\.\.\.getConversationPersistenceMetadata\(conversationPersisted\)/gu,
+  );
+
+  assert.equal(saveCalls?.length, 9);
+  assert.equal(metadataCalls?.length, saveCalls?.length);
+});

--- a/tests/memoryWriteRoute.test.js
+++ b/tests/memoryWriteRoute.test.js
@@ -132,7 +132,7 @@ test("chat never persists an ordinary fact and writes an explicit fact only afte
     );
 
   try {
-    await request(app)
+    const ordinaryResponse = await request(app)
       .post("/chat/chat")
       .set("Cookie", ownerCookie)
       .send({
@@ -140,6 +140,8 @@ test("chat never persists an ordinary fact and writes an explicit fact only afte
         message: "Казвам се Иван и живея във Варна.",
       })
       .expect(200);
+    assert.match(ordinaryResponse.text, /"conversationPersisted":true/u);
+    assert.doesNotMatch(ordinaryResponse.text, /CONVERSATION_NOT_SAVED/u);
     assert.deepEqual(client.profileFor("primary-user"), []);
 
     const prepared = await request(app)

--- a/tests/synchronVisionUi.test.js
+++ b/tests/synchronVisionUi.test.js
@@ -84,3 +84,16 @@ test("the chat shows live autonomous task progress", async () => {
   assert.match(script, /Задачата е изпълнена и проверена/u);
   assert.match(css, /data-task-status="waiting_confirmation"/u);
 });
+
+test("the chat keeps a successful answer visible when conversation persistence fails", async () => {
+  const [script, css] = await Promise.all([
+    readFile(new URL("../public/app.js", import.meta.url), "utf8"),
+    readFile(new URL("../public/styles.css", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(script, /conversationPersisted === false/u);
+  assert.match(script, /warningCode === "CONVERSATION_NOT_SAVED"/u);
+  assert.match(script, /Отговорът е получен, но разговорът не е запазен/u);
+  assert.match(script, /showConversationPersistenceWarning\(responseBubble\)/u);
+  assert.match(css, /\.conversation-persistence-warning/u);
+});


### PR DESCRIPTION
## Какво се променя

- всеки успешен чат път връща реалния `conversationPersisted` статус;
- при неуспешен OpenSearch запис отговорът остава видим;
- UI показва ясно предупреждение с код `CONVERSATION_NOT_SAVED`;
- успешният запис връща `conversationPersisted: true` без предупреждение;
- покрити са всичките 9 call sites на conversation save.

## Граници

- не се променят AI Core, профилната памет, OpenSearch mappings/данни, OAuth или потвържденията;
- не се добавя неидемпотентен retry;
- няма промяна по production конфигурацията или secrets.

## Проверка

- `npm test`: 393 успешни, 0 неуспешни, 0 пропуснати;
- `npm audit --omit=dev --audit-level=high`: 0 уязвимости;
- route тест доказва и успешен, и неуспешен conversation persistence резултат;
- UI regression тест доказва, че отговорът остава и предупреждението се показва.

Closes #168.
Refs #75, #77.