### PR TITLE
Audit: fail-closed журнал за постоянната памет

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -52,7 +52,10 @@ import {
   formatCopilotTaskResult,
   isCopilotBridgeStatusRequest,
 } from "../services/copilotTaskService.js";
-import { recordAuditEvent } from "../services/permissionService.js";
+import {
+  isAuditSafetyError,
+  recordAuditEvent,
+} from "../services/permissionService.js";
 import {
   isWebSearchRequest,
   WebSearchError,
@@ -843,7 +846,10 @@ router.post("/chat", async (req, res) => {
       `[Memory] Failure for ${cleanSessionId}:`,
       error?.code || error?.message || "unknown",
     );
-    if (error instanceof MemoryDeleteConfirmationError) {
+    if (
+      error instanceof MemoryDeleteConfirmationError ||
+      isAuditSafetyError(error)
+    ) {
       return res.status(error.status).json({
         error: error.message,
         code: error.code,
@@ -971,14 +977,6 @@ router.post("/chat", async (req, res) => {
         fullReply,
         ownerId,
       );
-      await auditAction({
-        action: "memory.write",
-        decision: "confirmed",
-        outcome: "succeeded",
-        resource: "profile-memory",
-        details: `chat:confirmed:${items.length}`,
-        sessionId: cleanSessionId,
-      });
       sendEvent("token", { token: fullReply });
       sendEvent("done", {
         ok: true,
@@ -992,21 +990,32 @@ router.post("/chat", async (req, res) => {
         "[Memory write confirmation]",
         error?.code || error?.message || "unknown",
       );
-      await auditAction({
-        action: "memory.write",
-        decision: "confirmed",
-        outcome: "failed",
-        resource: "profile-memory",
-        details: `chat:failed:${error?.code || "unknown"}`,
-        sessionId: cleanSessionId,
-      });
+      if (!isAuditSafetyError(error)) {
+        await auditAction({
+          action: "memory.write",
+          decision: "confirmed",
+          outcome: "failed",
+          resource: "profile-memory",
+          details: `chat:failed:${error?.code || "unknown"}`,
+          sessionId: cleanSessionId,
+        });
+      }
       sendEvent("error", {
         status:
-          error instanceof MemoryWriteConfirmationError ? error.status : 500,
+          error instanceof MemoryWriteConfirmationError ||
+          isAuditSafetyError(error)
+            ? error.status
+            : 500,
         message:
-          error instanceof MemoryWriteConfirmationError
+          error instanceof MemoryWriteConfirmationError ||
+          isAuditSafetyError(error)
             ? error.message
             : "Постоянният запис не можа да бъде потвърден.",
+        code:
+          error instanceof MemoryWriteConfirmationError ||
+          isAuditSafetyError(error)
+            ? error.code
+            : "MEMORY_WRITE_FAILED",
       });
     }
     res.end();
@@ -1116,7 +1125,11 @@ router.post("/chat", async (req, res) => {
   }
 
   const memoryReply = buildMemoryReply(memoryAction);
-  if (memoryAction) {
+  if (
+    memoryAction &&
+    memoryAction.type !== "cleared" &&
+    memoryAction.type !== "forgot"
+  ) {
     const isDeleteAction =
       memoryAction.type === "cleared" ||
       memoryAction.type === "forgot" ||

--- a/src/routes/memoryRouter.js
+++ b/src/routes/memoryRouter.js
@@ -4,7 +4,10 @@ import {
   listConversationSummaries,
   listProfileMemories,
 } from "../services/memoryService.js";
-import { recordAuditEvent } from "../services/permissionService.js";
+import {
+  isAuditSafetyError,
+  recordAuditEvent,
+} from "../services/permissionService.js";
 import { CANONICAL_PROJECT_MEMORY_ID } from "../config/projectIdentity.js";
 import {
   confirmMemoryWrite,
@@ -34,7 +37,8 @@ function sendMemoryError(res, error) {
   console.error("[Memory]", error?.message || error);
   if (
     error instanceof MemoryWriteConfirmationError ||
-    error instanceof MemoryDeleteConfirmationError
+    error instanceof MemoryDeleteConfirmationError ||
+    isAuditSafetyError(error)
   ) {
     return res.status(status).json({
       error: error.message,
@@ -105,24 +109,18 @@ async function runProtectedMemoryDelete({
       ownerId: req.owner.memoryOwnerId,
       expectedTarget: target,
     });
-    await audit({
-      action: "memory.delete",
-      decision: "confirmed",
-      outcome: result.deleted ? "succeeded" : "not-found",
-      resource: "profile-memory",
-      details: `api:${target.kind}:${result.deleted ? "deleted" : "not-found"}`,
-      sessionId,
-    });
     return res.json({ status: "ok", deleted: result.deleted });
   } catch (error) {
-    await audit({
-      action: "memory.delete",
-      decision: confirmationId ? "confirmed" : "confirm",
-      outcome: "failed",
-      resource: "profile-memory",
-      details: `api:${target.kind}:failed:${error?.code || "unknown"}`,
-      sessionId,
-    });
+    if (!isAuditSafetyError(error)) {
+      await audit({
+        action: "memory.delete",
+        decision: confirmationId ? "confirmed" : "confirm",
+        outcome: "failed",
+        resource: "profile-memory",
+        details: `api:${target.kind}:failed:${error?.code || "unknown"}`,
+        sessionId,
+      });
+    }
     return sendMemoryError(res, error);
   }
 }
@@ -195,16 +193,6 @@ export function createProfileMemoryWriteHandler({
           ownerId: req.owner.memoryOwnerId,
           source: "confirmed-memory-api",
         });
-        await audit({
-          action: "memory.write",
-          decision: "confirmed",
-          outcome: "succeeded",
-          resource: "profile-memory",
-          details: `api:confirmed:${items.length}:${[
-            ...new Set(items.map(({ scope }) => scope)),
-          ].join(",")}`,
-          sessionId,
-        });
         return res.status(201).json({ status: "ok", items });
       }
 
@@ -238,7 +226,7 @@ export function createProfileMemoryWriteHandler({
           .at(-1),
       });
     } catch (error) {
-      if (confirmationId) {
+      if (confirmationId && !isAuditSafetyError(error)) {
         await audit({
           action: "memory.write",
           decision: "confirmed",

--- a/src/services/memoryAcceptanceService.js
+++ b/src/services/memoryAcceptanceService.js
@@ -66,6 +66,7 @@ export async function runMemoryAcceptanceTest({
     dependencies.deleteProfileMemoryByFact || deleteProfileMemoryByFact;
   const prepareDelete = dependencies.prepareMemoryDelete || prepareMemoryDelete;
   const confirmDelete = dependencies.confirmMemoryDelete || confirmMemoryDelete;
+  const executeWrite = dependencies.executeAuditedWriteAction;
   const runId = randomUUID();
   const testOwnerId = `memory-self-test:${ownerId}:${runId}`;
   const testSessionId = `memory-self-test-session:${runId}`;
@@ -177,6 +178,7 @@ export async function runMemoryAcceptanceTest({
       ownerId: testOwnerId,
       expectedTarget: preparedDelete.target,
       deleteByFact: remove,
+      ...(executeWrite ? { executeWrite } : {}),
     });
     if (confirmedDelete.deleted < 1) {
       throw new Error("Потвърденото почистване не изтри тестовия запис.");
@@ -189,6 +191,7 @@ export async function runMemoryAcceptanceTest({
         ownerId: testOwnerId,
         expectedTarget: preparedDelete.target,
         deleteByFact: remove,
+        ...(executeWrite ? { executeWrite } : {}),
       });
     } catch {
       reusable = false;

--- a/src/services/memoryDeleteConfirmationService.js
+++ b/src/services/memoryDeleteConfirmationService.js
@@ -11,6 +11,7 @@ import {
   deleteProfileMemoryByFact,
   normalizeProfileMemoryDraft,
 } from "./memoryService.js";
+import { executeAuditedWriteAction } from "./permissionService.js";
 
 export const MEMORY_DELETE_ACTION = "memory.delete:profile";
 export const MEMORY_DELETE_CONFIRM_PREFIX =
@@ -175,6 +176,7 @@ export async function confirmMemoryDelete({
   deleteByFact = deleteProfileMemoryByFact,
   deleteById = deleteProfileMemory,
   deleteAll = clearProfileMemories,
+  executeWrite = executeAuditedWriteAction,
 }) {
   let confirmation;
   try {
@@ -216,13 +218,24 @@ export async function confirmMemoryDelete({
   }
 
   await consumeConfirmation(confirmationId);
-  let deleted;
-  if (target.kind === "fact") {
-    deleted = await deleteByFact(target.fact, target.scope, ownerId);
-  } else if (target.kind === "id") {
-    deleted = await deleteById(target.id, ownerId);
-  } else {
-    deleted = await deleteAll(target.scope || undefined, ownerId);
-  }
-  return Object.freeze({ target, deleted });
+  return executeWrite({
+    action: "memory.delete",
+    capability: MEMORY_DELETE_ACTION,
+    actor: "synchron-x-memory",
+    sessionId,
+    confirmationId,
+    resource: "profile-memory",
+    details: `confirmed-target:${target.kind}`,
+    execute: async () => {
+      let deleted;
+      if (target.kind === "fact") {
+        deleted = await deleteByFact(target.fact, target.scope, ownerId);
+      } else if (target.kind === "id") {
+        deleted = await deleteById(target.id, ownerId);
+      } else {
+        deleted = await deleteAll(target.scope || undefined, ownerId);
+      }
+      return Object.freeze({ target, deleted });
+    },
+  });
 }

--- a/src/services/memoryWriteConfirmationService.js
+++ b/src/services/memoryWriteConfirmationService.js
@@ -8,6 +8,7 @@ import {
   normalizeProfileMemoryDraft,
   saveProfileMemory,
 } from "./memoryService.js";
+import { executeAuditedWriteAction } from "./permissionService.js";
 
 export const MEMORY_WRITE_ACTION = "memory.write:save_profile";
 export const MEMORY_WRITE_CONFIRM_PREFIX = "Потвърждавам постоянен запис:";
@@ -133,6 +134,7 @@ export async function confirmMemoryWrite({
   validateConfirmation = validateDurableConfirmation,
   consumeConfirmation = markDurableConfirmationUsed,
   saveMemory = saveProfileMemory,
+  executeWrite = executeAuditedWriteAction,
   source = "confirmed-memory-write",
 }) {
   let confirmation;
@@ -165,15 +167,26 @@ export async function confirmMemoryWrite({
   }
 
   await consumeConfirmation(confirmationId);
-  const savedItems = [];
-  for (const item of items) {
-    const saved = await saveMemory(item.fact, source, item.scope, ownerId);
-    savedItems.push({
-      id: saved.id,
-      fact: saved.fact,
-      scope: saved.scope,
-      replaced: Boolean(saved.replaced),
-    });
-  }
-  return Object.freeze(savedItems);
+  return executeWrite({
+    action: "memory.write",
+    capability: MEMORY_WRITE_ACTION,
+    actor: "synchron-x-memory",
+    sessionId,
+    confirmationId,
+    resource: "profile-memory",
+    details: `confirmed-items:${items.length}`,
+    execute: async () => {
+      const savedItems = [];
+      for (const item of items) {
+        const saved = await saveMemory(item.fact, source, item.scope, ownerId);
+        savedItems.push({
+          id: saved.id,
+          fact: saved.fact,
+          scope: saved.scope,
+          replaced: Boolean(saved.replaced),
+        });
+      }
+      return Object.freeze(savedItems);
+    },
+  });
 }

--- a/tests/memoryAcceptanceService.test.js
+++ b/tests/memoryAcceptanceService.test.js
@@ -35,6 +35,9 @@ function createMemoryDouble() {
       owners.set(ownerId, after);
       return before.length - after.length;
     },
+    async executeAuditedWriteAction({ execute }) {
+      return execute();
+    },
     seed(ownerId, items) {
       owners.set(
         ownerId,

--- a/tests/memoryDeleteConfirmationService.test.js
+++ b/tests/memoryDeleteConfirmationService.test.js
@@ -13,8 +13,19 @@ import {
   MEMORY_DELETE_ACTION,
   prepareMemoryDelete,
 } from "../src/services/memoryDeleteConfirmationService.js";
+import {
+  executeAuditedWriteAction,
+  listAuditEvents,
+  recordAuditEvent,
+  resetAuditFallbackForTests,
+} from "../src/services/permissionService.js";
 
-test.beforeEach(() => resetConfirmationsForTests());
+test.beforeEach(() => {
+  resetConfirmationsForTests();
+  resetAuditFallbackForTests();
+});
+
+const executeWithoutAudit = async ({ execute }) => execute();
 
 test("prepares an exact fact without storing the raw owner id", async () => {
   let created;
@@ -62,6 +73,10 @@ test("consumes before deleting the exact target", async () => {
       return stored;
     },
     consumeConfirmation: async () => order.push("consume"),
+    executeWrite: async (input) => {
+      order.push("audit:intent");
+      return input.execute();
+    },
     deleteByFact: async (fact, scope, ownerId) => {
       order.push(`delete:${fact}:${scope}:${ownerId}`);
       return 1;
@@ -71,6 +86,7 @@ test("consumes before deleting the exact target", async () => {
   assert.deepEqual(order, [
     "validate",
     "consume",
+    "audit:intent",
     "delete:Точен факт:project:owner-a",
   ]);
   assert.equal(result.deleted, 1);
@@ -139,6 +155,7 @@ test("blocks a different session and replay", async () => {
       validateConfirmation(id, sessionId),
     consumeConfirmation: async (id) => markConfirmationUsed(id),
     deleteAll: async () => 2,
+    executeWrite: executeWithoutAudit,
   };
 
   await assert.rejects(
@@ -167,6 +184,127 @@ test("blocks a different session and replay", async () => {
         ...dependencies,
       }),
     (error) => error.code === "CONFIRMATION_NOT_FOUND" && error.status === 404,
+  );
+});
+
+test("durable intent failure consumes once but never calls the delete adapter", async () => {
+  let stored;
+  await prepareMemoryDelete({
+    sessionId: "session-a",
+    ownerId: "owner-a",
+    target: { kind: "all", scope: "personal" },
+    createConfirmation: async (input) => {
+      stored = { ...input, id: "confirmation-1" };
+      return stored;
+    },
+  });
+  let consumed = 0;
+  let deleted = 0;
+
+  await assert.rejects(
+    () =>
+      confirmMemoryDelete({
+        confirmationId: "confirmation-1",
+        sessionId: "session-a",
+        ownerId: "owner-a",
+        validateConfirmation: async () => stored,
+        consumeConfirmation: async () => {
+          consumed += 1;
+        },
+        deleteAll: async () => {
+          deleted += 1;
+        },
+        executeWrite: (input) =>
+          executeAuditedWriteAction({
+            ...input,
+            writeAudit: async () => {
+              throw new Error("audit unavailable");
+            },
+          }),
+      }),
+    (error) => error.code === "AUDIT_UNAVAILABLE" && error.status === 503,
+  );
+
+  assert.equal(consumed, 1);
+  assert.equal(deleted, 0);
+});
+
+test("successful memory delete with failed outcome audit is uncertain", async () => {
+  let stored;
+  await prepareMemoryDelete({
+    sessionId: "session-a",
+    ownerId: "owner-a",
+    target: { kind: "all", scope: "personal" },
+    createConfirmation: async (input) => {
+      stored = { ...input, id: "confirmation-1" };
+      return stored;
+    },
+  });
+  let auditCalls = 0;
+
+  await assert.rejects(
+    () =>
+      confirmMemoryDelete({
+        confirmationId: "confirmation-1",
+        sessionId: "session-a",
+        ownerId: "owner-a",
+        validateConfirmation: async () => stored,
+        consumeConfirmation: async () => {},
+        deleteAll: async () => 2,
+        executeWrite: (input) =>
+          executeAuditedWriteAction({
+            ...input,
+            writeAudit: async () => {
+              auditCalls += 1;
+              if (auditCalls === 2) throw new Error("outcome unavailable");
+            },
+          }),
+      }),
+    (error) =>
+      error.code === "AUDIT_OUTCOME_UNCERTAIN" && error.result?.deleted === 2,
+  );
+});
+
+test("memory delete audit stores one intent/outcome pair without raw private values", async () => {
+  let stored;
+  await prepareMemoryDelete({
+    sessionId: "session-a",
+    ownerId: "private-owner-id",
+    target: {
+      kind: "fact",
+      fact: "Строго частен факт",
+      scope: "personal",
+    },
+    createConfirmation: async (input) => {
+      stored = { ...input, id: "confirmation-secret" };
+      return stored;
+    },
+  });
+
+  const result = await confirmMemoryDelete({
+    confirmationId: "confirmation-secret",
+    sessionId: "session-a",
+    ownerId: "private-owner-id",
+    validateConfirmation: async () => stored,
+    consumeConfirmation: async () => {},
+    deleteByFact: async () => 1,
+    executeWrite: (input) =>
+      executeAuditedWriteAction({ ...input, writeAudit: recordAuditEvent }),
+  });
+
+  assert.equal(result.deleted, 1);
+  const events = await listAuditEvents();
+  assert.deepEqual(
+    events.map(({ phase, outcome }) => ({ phase, outcome })).reverse(),
+    [
+      { phase: "intent", outcome: "intent" },
+      { phase: "outcome", outcome: "succeeded" },
+    ],
+  );
+  assert.equal(events[0].auditId, events[1].auditId);
+  assert.doesNotMatch(
+    JSON.stringify(events),
+    /private-owner-id|Строго частен факт|confirmation-secret/u,
   );
 });
 

--- a/tests/memoryRouter.test.js
+++ b/tests/memoryRouter.test.js
@@ -9,6 +9,7 @@ import {
   createProfileMemoryWriteHandler,
 } from "../src/routes/memoryRouter.js";
 import { MemoryWriteConfirmationError } from "../src/services/memoryWriteConfirmationService.js";
+import { AuditSafetyError } from "../src/services/permissionService.js";
 
 function writeTestApp(options) {
   const app = express();
@@ -196,9 +197,38 @@ test("memory API writes only the fact stored in the one-time confirmation", asyn
   assert.equal(confirmedInput.sessionId, "session-a");
   assert.equal(confirmedInput.source, "confirmed-memory-api");
   assert.equal(response.body.items[0].fact, "Точният потвърден факт");
-  assert.equal(auditEvents[0].decision, "confirmed");
+  assert.deepEqual(auditEvents, []);
   assert.doesNotMatch(JSON.stringify(auditEvents), /Точният потвърден факт/u);
   assert.doesNotMatch(JSON.stringify(auditEvents), /123e4567/u);
+});
+
+test("memory API returns an exact audit safety error without a duplicate audit", async () => {
+  const auditEvents = [];
+  const app = writeTestApp({
+    confirm: async () => {
+      throw new AuditSafetyError(
+        "Журналът не е достъпен. Действието не беше стартирано.",
+        "AUDIT_UNAVAILABLE",
+        503,
+      );
+    },
+    audit: async (event) => auditEvents.push(event),
+  });
+
+  const response = await request(app)
+    .post("/memory/profile")
+    .send({
+      sessionId: "session-a",
+      confirmationId: "123e4567-e89b-12d3-a456-426614174000",
+    })
+    .expect(503);
+
+  assert.equal(response.body.code, "AUDIT_UNAVAILABLE");
+  assert.equal(
+    response.body.error,
+    "Журналът не е достъпен. Действието не беше стартирано.",
+  );
+  assert.deepEqual(auditEvents, []);
 });
 
 test("memory API requires a session before preparing a write", async () => {

--- a/tests/memoryWriteConfirmationService.test.js
+++ b/tests/memoryWriteConfirmationService.test.js
@@ -13,8 +13,19 @@ import {
   MEMORY_WRITE_ACTION,
   prepareMemoryWrite,
 } from "../src/services/memoryWriteConfirmationService.js";
+import {
+  executeAuditedWriteAction,
+  listAuditEvents,
+  recordAuditEvent,
+  resetAuditFallbackForTests,
+} from "../src/services/permissionService.js";
 
-test.beforeEach(() => resetConfirmationsForTests());
+const executeWithoutAudit = async ({ execute }) => execute();
+
+test.beforeEach(() => {
+  resetConfirmationsForTests();
+  resetAuditFallbackForTests();
+});
 
 test("prepares the exact fact without writing or storing the raw owner id", async () => {
   let created;
@@ -60,6 +71,10 @@ test("consumes before one write bound to the same owner and exact fact", async (
       return storedConfirmation;
     },
     consumeConfirmation: async (id) => order.push(`consume:${id}`),
+    executeWrite: async (input) => {
+      order.push("audit:intent");
+      return input.execute();
+    },
     saveMemory: async (fact, source, scope, ownerId) => {
       order.push(`save:${ownerId}:${source}`);
       return { id: "memory-1", fact, scope, replaced: false };
@@ -69,6 +84,7 @@ test("consumes before one write bound to the same owner and exact fact", async (
   assert.deepEqual(order, [
     "validate:confirmation-1:session-a",
     "consume:confirmation-1",
+    "audit:intent",
     "save:owner-a:confirmed-memory-write",
   ]);
   assert.deepEqual(items, [
@@ -132,6 +148,7 @@ test("blocks a different session and a replay of a consumed confirmation", async
       scope,
       replaced: false,
     }),
+    executeWrite: executeWithoutAudit,
   };
 
   await assert.rejects(
@@ -160,6 +177,133 @@ test("blocks a different session and a replay of a consumed confirmation", async
         ...dependencies,
       }),
     (error) => error.code === "CONFIRMATION_NOT_FOUND" && error.status === 404,
+  );
+});
+
+test("durable intent failure consumes once but never calls the memory adapter", async () => {
+  let storedConfirmation;
+  await prepareMemoryWrite({
+    sessionId: "session-a",
+    ownerId: "owner-a",
+    items: [{ fact: "Частен факт" }],
+    createConfirmation: async (input) => {
+      storedConfirmation = { ...input, id: "confirmation-1" };
+      return storedConfirmation;
+    },
+  });
+  let consumed = 0;
+  let written = 0;
+
+  await assert.rejects(
+    () =>
+      confirmMemoryWrite({
+        confirmationId: "confirmation-1",
+        sessionId: "session-a",
+        ownerId: "owner-a",
+        validateConfirmation: async () => storedConfirmation,
+        consumeConfirmation: async () => {
+          consumed += 1;
+        },
+        saveMemory: async () => {
+          written += 1;
+        },
+        executeWrite: (input) =>
+          executeAuditedWriteAction({
+            ...input,
+            writeAudit: async () => {
+              throw new Error("audit unavailable");
+            },
+          }),
+      }),
+    (error) => error.code === "AUDIT_UNAVAILABLE" && error.status === 503,
+  );
+
+  assert.equal(consumed, 1);
+  assert.equal(written, 0);
+});
+
+test("successful memory write with failed outcome audit is uncertain", async () => {
+  let storedConfirmation;
+  await prepareMemoryWrite({
+    sessionId: "session-a",
+    ownerId: "owner-a",
+    items: [{ fact: "Частен факт" }],
+    createConfirmation: async (input) => {
+      storedConfirmation = { ...input, id: "confirmation-1" };
+      return storedConfirmation;
+    },
+  });
+  let auditCalls = 0;
+
+  await assert.rejects(
+    () =>
+      confirmMemoryWrite({
+        confirmationId: "confirmation-1",
+        sessionId: "session-a",
+        ownerId: "owner-a",
+        validateConfirmation: async () => storedConfirmation,
+        consumeConfirmation: async () => {},
+        saveMemory: async (fact, _source, scope) => ({
+          id: "memory-1",
+          fact,
+          scope,
+          replaced: false,
+        }),
+        executeWrite: (input) =>
+          executeAuditedWriteAction({
+            ...input,
+            writeAudit: async () => {
+              auditCalls += 1;
+              if (auditCalls === 2) throw new Error("outcome unavailable");
+            },
+          }),
+      }),
+    (error) =>
+      error.code === "AUDIT_OUTCOME_UNCERTAIN" &&
+      error.result?.[0]?.id === "memory-1",
+  );
+});
+
+test("memory write audit stores one intent/outcome pair without raw private values", async () => {
+  let storedConfirmation;
+  await prepareMemoryWrite({
+    sessionId: "session-a",
+    ownerId: "private-owner-id",
+    items: [{ fact: "Строго частен факт" }],
+    createConfirmation: async (input) => {
+      storedConfirmation = { ...input, id: "confirmation-secret" };
+      return storedConfirmation;
+    },
+  });
+
+  await confirmMemoryWrite({
+    confirmationId: "confirmation-secret",
+    sessionId: "session-a",
+    ownerId: "private-owner-id",
+    validateConfirmation: async () => storedConfirmation,
+    consumeConfirmation: async () => {},
+    saveMemory: async (fact, _source, scope) => ({
+      id: "memory-1",
+      fact,
+      scope,
+      replaced: false,
+    }),
+    executeWrite: (input) =>
+      executeAuditedWriteAction({ ...input, writeAudit: recordAuditEvent }),
+  });
+
+  const events = await listAuditEvents();
+  assert.deepEqual(
+    events.map(({ phase, outcome }) => ({ phase, outcome })).reverse(),
+    [
+      { phase: "intent", outcome: "intent" },
+      { phase: "outcome", outcome: "succeeded" },
+    ],
+  );
+  assert.equal(events[0].auditId, events[1].auditId);
+  assert.doesNotMatch(
+    JSON.stringify(events),
+    /private-owner-id|Строго частен факт|confirmation-secret/u,
   );
 });
 


### PR DESCRIPTION
Closes #173

## Какво променя
- потвърдените memory write/delete операции записват durable intent преди adapter-а
- липсващ intent audit блокира действието с `AUDIT_UNAVAILABLE`
- успешен adapter с липсващ outcome се връща като `AUDIT_OUTCOME_UNCERTAIN` и не се представя за пълен успех
- API и чатът запазват точния безопасен audit status/code
- премахнати са дублиращите best-effort success/failure записи около durable потока
- production memory acceptance използва същата граница
- журналът не съдържа суров owner ID, факт, memory key или confirmation token

## Проверки
- целеви memory confirmation/route/acceptance тестове: 27 успешни
- `npm test`: 405 успешни, 0 неуспешни
- `npm audit --omit=dev --audit-level=high`: 0 уязвимости

## Production критерий
- CI и production smoke са зелени
- exact merge commit е активен
- `/health/ready` показва OpenSearch green и isolated memory acceptance 9/9
- `realMemoryUnchanged` и `cleanupCompleted` са true