### PR TITLE
MCP OAuth: отделен dedicated key с legacy migration fallback

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -38,6 +38,9 @@ services:
       - key: MCP_ACCESS_TOKEN
         scope: RUN_TIME
         type: SECRET
+      - key: MCP_OAUTH_SECRET
+        scope: RUN_TIME
+        type: SECRET
       - key: MCP_RESOURCE_URL
         value: https://synchron.foundation/mcp
         scope: RUN_TIME

--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,11 @@ TESTER_ACCESS_INDEX=synchron-tester-access-v1
 # Required stable owner identifier used to isolate the primary user's memory.
 MEMORY_OWNER_ID=your-stable-memory-owner-id
 # Required bearer token for the protected MCP bridge. Use a long random secret.
-# The same secret derives a separate OAuth signing key; its raw value is never
-# used as an OAuth access token.
+# It remains the OAuth fallback only while MCP_OAUTH_SECRET is absent.
 MCP_ACCESS_TOKEN=your-long-random-mcp-access-token
+# Optional dedicated OAuth key (minimum 32 characters). Leave empty until the
+# controlled migration; never reuse the static bearer value.
+MCP_OAUTH_SECRET=
 # Optional canonical HTTPS MCP resource. Production defaults to this URL.
 MCP_RESOURCE_URL=https://synchron.foundation/mcp
 # Optional OpenSearch index for one-time OAuth grant consumption.

--- a/docs/BRIDGE_AND_DIAGNOSTICS.md
+++ b/docs/BRIDGE_AND_DIAGNOSTICS.md
@@ -2,16 +2,19 @@
 
 ## Какво работи
 
-SYNCHRON-X има MCP Streamable HTTP адрес `/mcp` и четири инструмента само за
-четене:
+SYNCHRON-X има MCP Streamable HTTP адрес `/mcp` и 11 инструмента: 10 само за
+четене и един двустъпков потвърждаван cleanup flow. Основните read инструменти
+включват:
 
 - `get_personal_context`;
 - `get_project_context`;
 - `list_synchron_conversations`;
 - `get_synchron_conversation`.
 
-Достъпът е ограничен с `MCP_ACCESS_TOKEN`. Токенът не се показва в
-диагностиката, логовете или отговорите.
+Legacy техническият достъп е ограничен с `MCP_ACCESS_TOKEN`. Новите OAuth
+authorization codes, access tokens и refresh tokens използват отделния
+`MCP_OAUTH_SECRET`, когато е конфигуриран. Нито една от стойностите не се
+показва в диагностиката, логовете или отговорите.
 
 ## Диагностика
 
@@ -35,7 +38,30 @@ SYNCHRON-X има MCP Streamable HTTP адрес `/mcp` и четири инст
 2. protected resource metadata;
 3. `securitySchemes` за всеки инструмент;
 4. проверка на issuer, audience, срок и scopes за всеки access token;
-5. реален end-to-end тест от ChatGPT до четирите read инструмента.
+5. реален end-to-end тест от ChatGPT до разрешените read инструменти.
 
 Тази стъпка не трябва да се симулира и не трябва да се реализира чрез
 публичен достъп до личната памет.
+
+## Миграция на OAuth ключа
+
+Фаза 1 поддържа безопасен преход:
+
+- без `MCP_OAUTH_SECRET` OAuth продължава със стария derivation от
+  `MCP_ACCESS_TOKEN`;
+- след добавяне на валиден `MCP_OAUTH_SECRET` всички нови OAuth артефакти се
+  издават само с него;
+- старите OAuth code/access/refresh артефакти временно остават валидни;
+- refresh на стар token издава нов access и refresh token с dedicated ключа;
+- `MCP_OAUTH_SECRET` никога не се приема като legacy static bearer.
+
+Безопасен ред за фаза 2:
+
+1. Генерирай случаен `MCP_OAUTH_SECRET` с поне 32 знака и го добави само като
+   DigitalOcean runtime secret — никога в Git или в чат.
+2. Провери нов OAuth вход, read tool call и refresh след отделен deployment.
+3. Запази legacy OAuth verification fallback поне 30 дни — текущия refresh TTL.
+4. След наблюдаван успешен преход премахни legacy OAuth verification fallback
+   в отделен PR.
+5. Едва след доказан owner OAuth acceptance ротирай или премахни
+   `MCP_ACCESS_TOKEN` static bearer в отделна задача с rollback.

--- a/src/config/environmentCatalog.js
+++ b/src/config/environmentCatalog.js
@@ -125,8 +125,13 @@ export const ENVIRONMENT_CATALOG = Object.freeze(
     secret(
       "MCP_ACCESS_TOKEN",
       "ChatGPT / MCP",
-      "Защита на MCP и основа за отделните OAuth ключове.",
+      "Legacy защита на MCP; не се използва за нови OAuth артефакти след миграцията.",
       { requiredNow: true },
+    ),
+    secret(
+      "MCP_OAUTH_SECRET",
+      "ChatGPT / MCP",
+      "Отделен криптографски ключ за нови OAuth code/access/refresh артефакти.",
     ),
     general(
       "MCP_RESOURCE_URL",

--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -65,7 +65,11 @@ export function resolveMcpIssuerUrl(env = process.env) {
   return new URL(resolveMcpResourceUrl(env)).origin;
 }
 
-function oauthSecret(env = process.env) {
+function deriveOAuthSecret(label, source) {
+  return createHash("sha256").update(`${label}\0`).update(source).digest();
+}
+
+function legacyOAuthSecret(env = process.env) {
   const source =
     typeof env.MCP_ACCESS_TOKEN === "string" ? env.MCP_ACCESS_TOKEN.trim() : "";
   if (source.length < 32) {
@@ -75,17 +79,61 @@ function oauthSecret(env = process.env) {
       "temporarily_unavailable",
     );
   }
+  return deriveOAuthSecret("synchron-mcp-oauth-v1", source);
+}
+
+function dedicatedOAuthSecret(env = process.env) {
+  const source =
+    typeof env.MCP_OAUTH_SECRET === "string"
+      ? env.MCP_OAUTH_SECRET.trim()
+      : "";
+  if (!source) return null;
+  if (source.length < 32) {
+    throw new McpOAuthError(
+      "Отделният MCP OAuth ключ е невалиден.",
+      503,
+      "temporarily_unavailable",
+    );
+  }
+  return deriveOAuthSecret("synchron-mcp-oauth-dedicated-v1", source);
+}
+
+function oauthSecret(env = process.env) {
+  return dedicatedOAuthSecret(env) || legacyOAuthSecret(env);
+}
+
+function oauthVerificationSecrets(env = process.env) {
+  const dedicated = dedicatedOAuthSecret(env);
+  if (!dedicated) return [legacyOAuthSecret(env)];
+  const secrets = [dedicated];
+  try {
+    const legacy = legacyOAuthSecret(env);
+    if (!legacy.equals(dedicated)) secrets.push(legacy);
+  } catch {
+    // A dedicated key can run OAuth without enabling the legacy bearer.
+  }
+  return secrets;
+}
+
+function deriveGrantSecret(secret) {
   return createHash("sha256")
-    .update("synchron-mcp-oauth-v1\0")
-    .update(source)
+    .update(secret)
+    .update("synchron-mcp-oauth-grants-v2\0")
     .digest();
 }
 
 function grantSecret(env = process.env) {
-  return createHash("sha256")
-    .update(oauthSecret(env))
-    .update("synchron-mcp-oauth-grants-v2\0")
-    .digest();
+  return deriveGrantSecret(oauthSecret(env));
+}
+
+function grantVerificationSecrets(env = process.env) {
+  return oauthVerificationSecrets(env).map(deriveGrantSecret);
+}
+
+export function getMcpOAuthSecretMode(env = process.env) {
+  if (dedicatedOAuthSecret(env)) return "dedicated";
+  legacyOAuthSecret(env);
+  return "legacy_fallback";
 }
 
 export function isMcpOAuthConfigured(env = process.env) {
@@ -184,6 +232,14 @@ function decryptPayload(value, prefix, key) {
   } catch {
     return null;
   }
+}
+
+function decryptPayloadWithFallback(value, prefix, keys) {
+  for (const key of keys) {
+    const payload = decryptPayload(value, prefix, key);
+    if (payload) return payload;
+  }
+  return null;
 }
 
 function parseScopes(value) {
@@ -516,7 +572,11 @@ export async function exchangeMcpAuthorizationCode(
   { consumeGrant = consumeMcpGrantOnce } = {},
 ) {
   const code = String(input?.code || "");
-  const payload = decryptPayload(code, "sx-code", grantSecret(env));
+  const payload = decryptPayloadWithFallback(
+    code,
+    "sx-code",
+    grantVerificationSecrets(env),
+  );
   const now = Math.floor(Date.now() / 1_000);
   if (
     !payload ||
@@ -577,10 +637,10 @@ export async function exchangeMcpRefreshToken(
   env = process.env,
   { consumeGrant = consumeMcpGrantOnce } = {},
 ) {
-  const payload = decryptPayload(
+  const payload = decryptPayloadWithFallback(
     String(input?.refresh_token || ""),
     "sx-refresh",
-    grantSecret(env),
+    grantVerificationSecrets(env),
   );
   const now = Math.floor(Date.now() / 1_000);
   if (
@@ -639,10 +699,10 @@ export function verifyMcpAccessToken(
   ) {
     return null;
   }
-  const payload = decryptPayload(
+  const payload = decryptPayloadWithFallback(
     authorizationHeader.slice(7),
     "sx-token",
-    oauthSecret(env),
+    oauthVerificationSecrets(env),
   );
   const now = Math.floor(Date.now() / 1_000);
   if (

--- a/tests/environmentContract.test.js
+++ b/tests/environmentContract.test.js
@@ -39,7 +39,11 @@ function appSpecKeyBlock(source, key) {
 test("required MCP and memory variables stay declared in DigitalOcean", () => {
   const keys = appSpecEnvironmentKeys(appSpec);
 
-  for (const key of ["MCP_ACCESS_TOKEN", "MEMORY_OWNER_ID"]) {
+  for (const key of [
+    "MCP_ACCESS_TOKEN",
+    "MCP_OAUTH_SECRET",
+    "MEMORY_OWNER_ID",
+  ]) {
     assert.equal(keys.has(key), true, `${key} is missing from .do/app.yaml`);
 
     const block = appSpecKeyBlock(appSpec, key);
@@ -58,6 +62,7 @@ test("bridge variables stay documented without real secret values", () => {
   const keys = exampleEnvironmentKeys(envExample);
   const documentedKeys = [
     "MCP_ACCESS_TOKEN",
+    "MCP_OAUTH_SECRET",
     "MCP_RESOURCE_URL",
     "MEMORY_OWNER_ID",
     "DIGITALOCEAN_API_TOKEN",

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -8,6 +8,8 @@ import { createMcpOAuthRouter } from "../src/routes/mcpOAuthRouter.js";
 import mcpRouter from "../src/routes/mcpRouter.js";
 
 const SECRET = "router-test-secret-with-more-than-thirty-two-characters";
+const DEDICATED_SECRET =
+  "router-dedicated-oauth-secret-with-more-than-thirty-two-characters";
 
 test("OAuth discovery is public and describes the exact MCP resource", async () => {
   const previous = process.env.MCP_ACCESS_TOKEN;
@@ -91,6 +93,34 @@ test("an invalid bearer token is rejected with HTTP 401", async () => {
   assert.match(response.headers["www-authenticate"], /invalid_token/u);
   if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
   else process.env.MCP_ACCESS_TOKEN = previous;
+});
+
+test("the dedicated OAuth secret is never accepted as a legacy static bearer", async () => {
+  const previousAccess = process.env.MCP_ACCESS_TOKEN;
+  const previousOAuth = process.env.MCP_OAUTH_SECRET;
+  process.env.MCP_ACCESS_TOKEN = SECRET;
+  process.env.MCP_OAUTH_SECRET = DEDICATED_SECRET;
+  try {
+    const app = express();
+    app.use(express.json());
+    app.use("/mcp", mcpRouter);
+    const response = await request(app)
+      .post("/mcp")
+      .set("Authorization", `Bearer ${DEDICATED_SECRET}`)
+      .send({
+        jsonrpc: "2.0",
+        id: 5,
+        method: "tools/call",
+        params: { name: "get_personal_context", arguments: {} },
+      })
+      .expect(401);
+    assert.equal(response.body.error.code, -32001);
+  } finally {
+    if (previousAccess === undefined) delete process.env.MCP_ACCESS_TOKEN;
+    else process.env.MCP_ACCESS_TOKEN = previousAccess;
+    if (previousOAuth === undefined) delete process.env.MCP_OAUTH_SECRET;
+    else process.env.MCP_OAUTH_SECRET = previousOAuth;
+  }
 });
 
 test("authorization consent issues a code bound to the browser profile", async () => {

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -8,8 +8,10 @@ import {
   createMcpAuthorizationCode,
   exchangeMcpAuthorizationCode,
   exchangeMcpRefreshToken,
+  getMcpOAuthSecretMode,
   getMcpAuthorizationServerMetadata,
   getMcpProtectedResourceMetadata,
+  isMcpOAuthConfigured,
   MCP_GITHUB_WRITE_SCOPE,
   MCP_READ_SCOPE,
   requiresPersistentMcpReplayGuard,
@@ -21,6 +23,10 @@ import {
 const ENV = {
   MCP_ACCESS_TOKEN: "mcp-oauth-test-secret-with-more-than-32-characters",
   MCP_RESOURCE_URL: "https://synchron.foundation/mcp",
+};
+const DEDICATED_ENV = {
+  ...ENV,
+  MCP_OAUTH_SECRET: "dedicated-oauth-test-secret-with-more-than-32-characters",
 };
 const CLIENT_ID = "https://chatgpt.com/oauth/synchron/client.json";
 const REDIRECT_URI = "https://chatgpt.com/connector/oauth/test-callback";
@@ -54,6 +60,29 @@ function clientMetadataFetch(url) {
   );
 }
 
+async function issueTokens(env = ENV) {
+  const request = await validateMcpAuthorizationRequest(authorizationInput(), {
+    env,
+    fetchImpl: clientMetadataFetch,
+  });
+  const code = createMcpAuthorizationCode(
+    request,
+    { id: "owner-id", memoryOwnerId: "primary-user", role: "owner" },
+    env,
+  );
+  return exchangeMcpAuthorizationCode(
+    {
+      grant_type: "authorization_code",
+      code,
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: VERIFIER,
+      resource: ENV.MCP_RESOURCE_URL,
+    },
+    env,
+  );
+}
+
 test.beforeEach(() => resetMcpOAuthStateForTests());
 
 test("publishes OAuth 2.1 protected-resource and authorization metadata", () => {
@@ -73,6 +102,156 @@ test("publishes OAuth 2.1 protected-resource and authorization metadata", () => 
     "refresh_token",
   ]);
   assert.deepEqual(authorization.code_challenge_methods_supported, ["S256"]);
+});
+
+test("uses an explicit dedicated or legacy fallback OAuth key mode", () => {
+  assert.equal(getMcpOAuthSecretMode(ENV), "legacy_fallback");
+  assert.equal(getMcpOAuthSecretMode(DEDICATED_ENV), "dedicated");
+  assert.equal(isMcpOAuthConfigured(DEDICATED_ENV), true);
+  assert.equal(
+    isMcpOAuthConfigured({
+      MCP_OAUTH_SECRET: DEDICATED_ENV.MCP_OAUTH_SECRET,
+      MCP_RESOURCE_URL: ENV.MCP_RESOURCE_URL,
+    }),
+    true,
+  );
+  assert.equal(
+    isMcpOAuthConfigured({ ...ENV, MCP_OAUTH_SECRET: "too-short" }),
+    false,
+  );
+  assert.throws(
+    () =>
+      createMcpAuthorizationCode(
+        {
+          clientId: CLIENT_ID,
+          redirectUri: REDIRECT_URI,
+          codeChallenge: createHash("sha256")
+            .update(VERIFIER)
+            .digest("base64url"),
+          resource: ENV.MCP_RESOURCE_URL,
+          scopes: [MCP_READ_SCOPE],
+        },
+        { id: "owner-id", memoryOwnerId: "primary-user", role: "owner" },
+        { ...ENV, MCP_OAUTH_SECRET: "too-short" },
+      ),
+    (error) =>
+      error.code === "temporarily_unavailable" && error.status === 503,
+  );
+});
+
+test("dedicated mode accepts a legacy authorization code and issues dedicated tokens", async () => {
+  const request = await validateMcpAuthorizationRequest(authorizationInput(), {
+    env: ENV,
+    fetchImpl: clientMetadataFetch,
+  });
+  const legacyCode = createMcpAuthorizationCode(
+    request,
+    { id: "owner-id", memoryOwnerId: "primary-user", role: "owner" },
+    ENV,
+  );
+
+  const token = await exchangeMcpAuthorizationCode(
+    {
+      grant_type: "authorization_code",
+      code: legacyCode,
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: VERIFIER,
+      resource: ENV.MCP_RESOURCE_URL,
+    },
+    DEDICATED_ENV,
+  );
+
+  assert.equal(
+    verifyMcpAccessToken(
+      `Bearer ${token.access_token}`,
+      [MCP_READ_SCOPE],
+      DEDICATED_ENV,
+    ).memoryOwnerId,
+    "primary-user",
+  );
+  assert.throws(
+    () =>
+      verifyMcpAccessToken(
+        `Bearer ${token.access_token}`,
+        [MCP_READ_SCOPE],
+        ENV,
+      ),
+    (error) => error.code === "invalid_token",
+  );
+});
+
+test("dedicated tokens cannot be verified or refreshed with only the legacy key", async () => {
+  const token = await issueTokens(DEDICATED_ENV);
+  assert.equal(
+    verifyMcpAccessToken(
+      `Bearer ${token.access_token}`,
+      [MCP_READ_SCOPE],
+      DEDICATED_ENV,
+    ).memoryOwnerId,
+    "primary-user",
+  );
+  assert.throws(
+    () =>
+      verifyMcpAccessToken(
+        `Bearer ${token.access_token}`,
+        [MCP_READ_SCOPE],
+        ENV,
+      ),
+    (error) => error.code === "invalid_token",
+  );
+  await assert.rejects(
+    () =>
+      exchangeMcpRefreshToken(
+        {
+          grant_type: "refresh_token",
+          refresh_token: token.refresh_token,
+          client_id: CLIENT_ID,
+          resource: ENV.MCP_RESOURCE_URL,
+        },
+        ENV,
+      ),
+    (error) => error.code === "invalid_grant",
+  );
+});
+
+test("dedicated mode accepts legacy access and rotates legacy refresh tokens", async () => {
+  const legacyToken = await issueTokens(ENV);
+  assert.equal(
+    verifyMcpAccessToken(
+      `Bearer ${legacyToken.access_token}`,
+      [MCP_READ_SCOPE],
+      DEDICATED_ENV,
+    ).memoryOwnerId,
+    "primary-user",
+  );
+
+  const rotated = await exchangeMcpRefreshToken(
+    {
+      grant_type: "refresh_token",
+      refresh_token: legacyToken.refresh_token,
+      client_id: CLIENT_ID,
+      resource: ENV.MCP_RESOURCE_URL,
+    },
+    DEDICATED_ENV,
+  );
+  assert.equal(
+    verifyMcpAccessToken(
+      `Bearer ${rotated.access_token}`,
+      [MCP_READ_SCOPE],
+      DEDICATED_ENV,
+    ).memoryOwnerId,
+    "primary-user",
+  );
+  assert.throws(
+    () =>
+      verifyMcpAccessToken(
+        `Bearer ${rotated.access_token}`,
+        [MCP_READ_SCOPE],
+        ENV,
+      ),
+    (error) => error.code === "invalid_token",
+  );
 });
 
 test("validates OpenAI CIMD metadata and exact callback and resource", async () => {


### PR DESCRIPTION
Closes #172

## Фаза 1
- добавя optional `MCP_OAUTH_SECRET` (минимум 32 знака)
- новите OAuth code/access/refresh артефакти използват dedicated ключа, когато е наличен
- старите OAuth code/access/refresh артефакти временно се приемат чрез legacy verification fallback
- refresh на стар token издава нови dedicated access/refresh tokens
- къс non-empty dedicated secret fail-ва OAuth безопасно, без silent fallback
- `MCP_ACCESS_TOKEN` остава единствената legacy static bearer стойност
- не ротира и не добавя реален production secret
- добавя migration runbook за отделна фаза 2 след owner acceptance и 30-дневен преход
- актуализира bridge документацията до реалните 11 инструмента

## Проверки
- OAuth/MCP целеви тестове: 20 успешни
- `npm test`: 410 успешни, 0 неуспешни
- `npm audit --omit=dev --audit-level=high`: 0 уязвимости

## Production критерий
- production остава в backwards-compatible `legacy_fallback`, докато secret не бъде конфигуриран отделно
- exact merge commit, CI, production smoke, readiness, 9/9 memory acceptance и MCP bridge трябва да са зелени