### PR TITLE
Protect upstream response bodies from production logs

### DIFF
--- a/src/services/aiCoreService.js
+++ b/src/services/aiCoreService.js
@@ -61,8 +61,7 @@ export async function requestOpenAIText({
   });
 
   if (!response.ok) {
-    const responseBody = await response.text();
-    console.error(`[OpenAI] ${response.status}:`, responseBody || "<empty>");
+    console.error(`[OpenAI] Upstream request failed: ${response.status}`);
     throw new AiCoreError(
       `OpenAI върна грешка ${response.status}.`,
       "OPENAI_UPSTREAM_ERROR",

--- a/src/services/githubService.js
+++ b/src/services/githubService.js
@@ -54,8 +54,7 @@ async function githubRequest(path, options = {}) {
       ...options,
     });
     if (!response.ok) {
-      const details = await response.text();
-      console.error(`[GitHub] ${response.status}:`, details || "<empty>");
+      console.error(`[GitHub] Upstream request failed: ${response.status}`);
       throw new GitHubServiceError(
         response.status === 404
           ? "GitHub ресурсът не е намерен."

--- a/src/services/githubWriteService.js
+++ b/src/services/githubWriteService.js
@@ -57,8 +57,9 @@ async function githubWriteRequest(path, options = {}) {
     });
 
     if (!response.ok) {
-      const details = await response.text();
-      console.error(`[GitHub Write] ${response.status}:`, details || "<empty>");
+      console.error(
+        `[GitHub Write] Upstream request failed: ${response.status}`,
+      );
       throw new GitHubServiceError(
         `GitHub върна грешка ${response.status}.`,
         response.status,

--- a/src/services/imageService.js
+++ b/src/services/imageService.js
@@ -114,8 +114,7 @@ export async function analyzeImage({
   });
 
   if (!response.ok) {
-    const body = await response.text();
-    console.error(`[Vision] ${response.status}:`, body || "<empty>");
+    console.error(`[Vision] Upstream request failed: ${response.status}`);
     throw new ImageServiceError(
       `Разпознаването на снимката върна грешка ${response.status}.`,
       502,

--- a/src/services/webSearchService.js
+++ b/src/services/webSearchService.js
@@ -123,8 +123,9 @@ export async function searchWeb(
   }
 
   if (!response.ok) {
-    const body = await response.text();
-    console.error("[Web search] OpenAI error:", response.status, body);
+    console.error(
+      `[Web search] OpenAI upstream request failed: ${response.status}`,
+    );
     throw new WebSearchError(
       "Интернет търсенето временно не е достъпно.",
       502,

--- a/tests/upstreamLogPrivacy.test.js
+++ b/tests/upstreamLogPrivacy.test.js
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { requestOpenAIText } from "../src/services/aiCoreService.js";
+import { getRepositorySummary } from "../src/services/githubService.js";
+import { createFile } from "../src/services/githubWriteService.js";
+import { analyzeImage } from "../src/services/imageService.js";
+import { searchWeb } from "../src/services/webSearchService.js";
+
+const SENTINEL = "Bearer private-token personal@example.com private prompt";
+const tinyPng = {
+  dataUrl: "data:image/png;base64,iVBORw0KGgo=",
+  mimeType: "image/png",
+};
+
+async function captureUpstreamFailure(run) {
+  const originalConsoleError = console.error;
+  const logs = [];
+  console.error = (...values) => logs.push(values.join(" "));
+  try {
+    await assert.rejects(run);
+  } finally {
+    console.error = originalConsoleError;
+  }
+  const output = logs.join("\n");
+  assert.doesNotMatch(output, new RegExp(SENTINEL, "u"));
+  assert.match(output, /503/u);
+}
+
+function failedResponse() {
+  return new Response(SENTINEL, { status: 503 });
+}
+
+test("OpenAI chat failure logs status without the upstream response body", async () => {
+  await captureUpstreamFailure(() =>
+    requestOpenAIText({
+      apiKey: "test-key",
+      input: [{ role: "user", content: "test" }],
+      fetchImpl: async () => failedResponse(),
+    }),
+  );
+});
+
+test("web search failure logs status without the upstream response body", async () => {
+  await captureUpstreamFailure(() =>
+    searchWeb("test", {
+      apiKey: "test-key",
+      fetchImpl: async () => failedResponse(),
+    }),
+  );
+});
+
+test("vision failure logs status without the upstream response body", async () => {
+  await captureUpstreamFailure(() =>
+    analyzeImage({
+      image: tinyPng,
+      prompt: "test",
+      modelAccessKey: "test-key",
+      fetchImpl: async () => failedResponse(),
+    }),
+  );
+});
+
+test("GitHub read failure logs status without the upstream response body", async () => {
+  const originalFetch = global.fetch;
+  const originalRepository = process.env.GITHUB_REPOSITORY;
+  const originalApiUrl = process.env.GITHUB_API_URL;
+  global.fetch = async () => failedResponse();
+  process.env.GITHUB_REPOSITORY = "radostinvgeorgiev-commits/sunchron-backend";
+  process.env.GITHUB_API_URL = "https://github.test";
+  try {
+    await captureUpstreamFailure(() => getRepositorySummary());
+  } finally {
+    global.fetch = originalFetch;
+    if (originalRepository === undefined) delete process.env.GITHUB_REPOSITORY;
+    else process.env.GITHUB_REPOSITORY = originalRepository;
+    if (originalApiUrl === undefined) delete process.env.GITHUB_API_URL;
+    else process.env.GITHUB_API_URL = originalApiUrl;
+  }
+});
+
+test("GitHub write failure logs status without the upstream response body", async () => {
+  const originalFetch = global.fetch;
+  const originalRepository = process.env.GITHUB_REPOSITORY;
+  const originalApiUrl = process.env.GITHUB_API_URL;
+  const originalToken = process.env.GITHUB_TOKEN;
+  global.fetch = async () => failedResponse();
+  process.env.GITHUB_REPOSITORY = "radostinvgeorgiev-commits/sunchron-backend";
+  process.env.GITHUB_API_URL = "https://github.test";
+  process.env.GITHUB_TOKEN = "test-token";
+  try {
+    await captureUpstreamFailure(() =>
+      createFile({
+        branch: "test-branch",
+        path: "test.txt",
+        content: "test",
+        message: "test",
+      }),
+    );
+  } finally {
+    global.fetch = originalFetch;
+    if (originalRepository === undefined) delete process.env.GITHUB_REPOSITORY;
+    else process.env.GITHUB_REPOSITORY = originalRepository;
+    if (originalApiUrl === undefined) delete process.env.GITHUB_API_URL;
+    else process.env.GITHUB_API_URL = originalApiUrl;
+    if (originalToken === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = originalToken;
+  }
+});


### PR DESCRIPTION
## What changed

- stopped logging failed upstream response bodies for OpenAI chat, web search, vision, GitHub read, and GitHub write
- retained provider labels and numeric HTTP status for operational diagnosis
- added behavioral regression tests with token, email, and prompt sentinel data

## Why

Provider error bodies can include user context or sensitive diagnostic values. They do not belong in DigitalOcean runtime logs.

## Impact

Public error codes, statuses, and user-facing messages are unchanged. No secrets, data, deployment configuration, or success path changed.

## Validation

- targeted adapter tests: 27/27
- full `npm test`: 418/418
- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities
- `git diff --check`
- published tree matches locally verified tree: `ee49985ef4912854797c9b5473a98c373be22071`

Closes #182