### PR TITLE
Sanitize OAuth and session error logs

### DIFF
--- a/src/middleware/ownerAuth.js
+++ b/src/middleware/ownerAuth.js
@@ -8,6 +8,7 @@ import {
   resolveUserSession,
   userSessionCookie,
 } from "../services/userAuthService.js";
+import { logSafeError } from "../utils/safeLogging.js";
 
 export function resolveMemoryOwnerId(login, env = process.env) {
   const normalizedLogin =
@@ -92,7 +93,7 @@ export function createRequireOwnerSession({
       req.owner = identity;
       return next();
     } catch (error) {
-      console.error("[Owner auth]", error);
+      logSafeError("[Owner auth]", error);
       return res.status(503).json({
         error: "Проверката на собственика временно не е достъпна.",
         code: "OWNER_AUTH_UNAVAILABLE",

--- a/src/routes/githubOAuthRouter.js
+++ b/src/routes/githubOAuthRouter.js
@@ -11,6 +11,7 @@ import {
   isGitHubOAuthConfigured,
   parseGitHubCookies,
 } from "../services/githubOAuthService.js";
+import { logSafeError } from "../utils/safeLogging.js";
 
 const router = express.Router();
 const COOKIE_OPTIONS =
@@ -74,7 +75,7 @@ router.get("/callback", async (req, res) => {
     ]);
     res.redirect("/?github=connected");
   } catch (error) {
-    console.error("[GitHub OAuth callback]", error);
+    logSafeError("[GitHub OAuth callback]", error);
     res.redirect("/?github=error");
   }
 });

--- a/src/routes/googleDriveRouter.js
+++ b/src/routes/googleDriveRouter.js
@@ -14,6 +14,7 @@ import {
   listDriveFiles,
   parseCookies,
 } from "../services/googleDriveService.js";
+import { logSafeError } from "../utils/safeLogging.js";
 
 const router = express.Router();
 const COOKIE_OPTIONS =
@@ -68,7 +69,7 @@ router.get("/callback", async (req, res) => {
     ]);
     res.redirect("/?google=connected");
   } catch (error) {
-    console.error("[Google OAuth callback]", error);
+    logSafeError("[Google OAuth callback]", error);
     res.redirect("/?google=error");
   }
 });

--- a/src/routes/userAuthRouter.js
+++ b/src/routes/userAuthRouter.js
@@ -15,6 +15,7 @@ import {
   parseGitHubCookies,
 } from "../services/githubOAuthService.js";
 import { resolveRequestIdentity } from "../middleware/ownerAuth.js";
+import { logSafeError } from "../utils/safeLogging.js";
 
 const router = express.Router();
 
@@ -92,7 +93,7 @@ router.post("/logout", async (req, res) => {
     const githubCookies = parseGitHubCookies(req.headers.cookie);
     await disconnectGitHubSession(githubCookies.synchron_github_session);
   } catch (error) {
-    console.error("[User logout]", error);
+    logSafeError("[User logout]", error);
   }
   res.setHeader("Set-Cookie", [
     clearUserSessionCookie(),

--- a/src/services/githubOAuthService.js
+++ b/src/services/githubOAuthService.js
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { getOpenSearchClient } from "../config/opensearch.js";
+import { logSafeError } from "../utils/safeLogging.js";
 
 const GITHUB_AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
@@ -249,7 +250,7 @@ async function loadSession(id) {
   } catch (error) {
     const status = error?.statusCode || error?.meta?.statusCode;
     if (status !== 404) {
-      console.error("[GitHub session] Restore failure:", error);
+      logSafeError("[GitHub session] Restore failure", error);
     }
     return null;
   }
@@ -274,7 +275,7 @@ export async function createGitHubSession(tokens, fetchImpl = fetch) {
     await persistSession(id, session);
   } catch (error) {
     sessions.delete(id);
-    console.error("[GitHub session] Persistence failure:", error);
+    logSafeError("[GitHub session] Persistence failure", error);
     throw new GitHubOAuthError(
       "GitHub връзката не можа да бъде запазена защитено.",
       503,

--- a/src/services/googleDriveService.js
+++ b/src/services/googleDriveService.js
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { getOpenSearchClient } from "../config/opensearch.js";
+import { logSafeError } from "../utils/safeLogging.js";
 
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -120,7 +121,7 @@ async function loadSession(id) {
   } catch (error) {
     const status = error?.statusCode || error?.meta?.statusCode;
     if (status !== 404) {
-      console.error("[Google session] Restore failure:", error);
+      logSafeError("[Google session] Restore failure", error);
     }
     return null;
   }
@@ -227,10 +228,7 @@ export async function createSession(tokens) {
   try {
     persisted = await persistSession(id, session);
   } catch (error) {
-    console.error(
-      "[Google session] Persistence failure:",
-      error?.message || "unknown",
-    );
+    logSafeError("[Google session] Persistence failure", error);
   }
 
   if (!persisted && requiresPersistentGoogleSessions()) {
@@ -258,7 +256,7 @@ export async function disconnectSession(id) {
   } catch (error) {
     const status = error?.statusCode || error?.meta?.statusCode;
     if (status !== 404) {
-      console.error("[Google session] Delete failure:", error);
+      logSafeError("[Google session] Delete failure", error);
     }
   }
 }
@@ -307,7 +305,7 @@ async function refreshSession(id, fetchImpl = fetch) {
   try {
     await persistSession(id, session);
   } catch (error) {
-    console.error("[Google session] Refresh persistence failure:", error);
+    logSafeError("[Google session] Refresh persistence failure", error);
   }
   return session.access_token;
 }
@@ -533,9 +531,7 @@ export async function analyzeDriveFile({
   const data = await response.json();
   if (!response.ok) {
     console.error(
-      "[Google Drive file]",
-      response.status,
-      data?.error?.message || "unknown error",
+      `[Google Drive file] Upstream request failed: ${response.status}`,
     );
     throw new GoogleDriveError(
       "Анализът на файла не успя.",

--- a/src/utils/safeLogging.js
+++ b/src/utils/safeLogging.js
@@ -1,0 +1,33 @@
+const SAFE_ERROR_NAME = /^(?:Error|[A-Za-z][A-Za-z0-9]{0,47}Error)$/u;
+const SAFE_ERROR_CODE = /^[A-Z][A-Z0-9_]{1,63}$/u;
+
+function safeIdentifier(value, pattern, fallback = null) {
+  return typeof value === "string" && pattern.test(value) ? value : fallback;
+}
+
+function safeStatus(error) {
+  const candidates = [
+    error?.status,
+    error?.statusCode,
+    error?.meta?.statusCode,
+    error?.response?.status,
+  ];
+  return candidates.find(
+    (value) => Number.isInteger(value) && value >= 100 && value <= 599,
+  );
+}
+
+export function safeErrorMetadata(error) {
+  const metadata = {
+    name: safeIdentifier(error?.name, SAFE_ERROR_NAME, "Error"),
+  };
+  const code = safeIdentifier(error?.code, SAFE_ERROR_CODE);
+  const status = safeStatus(error);
+  if (code) metadata.code = code;
+  if (status) metadata.status = status;
+  return Object.freeze(metadata);
+}
+
+export function logSafeError(context, error) {
+  console.error(context, safeErrorMetadata(error));
+}

--- a/tests/safeLogging.test.js
+++ b/tests/safeLogging.test.js
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { logSafeError, safeErrorMetadata } from "../src/utils/safeLogging.js";
+
+const SENTINEL = "Bearer private-token personal@example.com private-prompt";
+
+function sensitiveError() {
+  const error = new Error(SENTINEL, {
+    cause: new Error(`cause-${SENTINEL}`),
+  });
+  error.name = "OAuthSessionError";
+  error.code = "SESSION_PERSISTENCE_FAILED";
+  error.status = 503;
+  error.stack = `stack-${SENTINEL}`;
+  error.request = { headers: { authorization: SENTINEL } };
+  error.response = { status: 502, data: SENTINEL };
+  return error;
+}
+
+test("safe error metadata excludes messages, stacks, causes, and provider data", () => {
+  const metadata = safeErrorMetadata(sensitiveError());
+  assert.deepEqual(metadata, {
+    name: "OAuthSessionError",
+    code: "SESSION_PERSISTENCE_FAILED",
+    status: 503,
+  });
+  assert.doesNotMatch(JSON.stringify(metadata), new RegExp(SENTINEL, "u"));
+});
+
+test("unsafe error codes cannot inject arbitrary text into logs", () => {
+  const error = sensitiveError();
+  error.code = "PrivateTokenAbCd123";
+  assert.deepEqual(safeErrorMetadata(error), {
+    name: "OAuthSessionError",
+    status: 503,
+  });
+});
+
+test("safe logger emits only the fixed context and safe metadata", () => {
+  const originalConsoleError = console.error;
+  const calls = [];
+  console.error = (...values) => calls.push(values);
+  try {
+    logSafeError("[OAuth test]", sensitiveError());
+  } finally {
+    console.error = originalConsoleError;
+  }
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][0], "[OAuth test]");
+  assert.deepEqual(calls[0][1], {
+    name: "OAuthSessionError",
+    code: "SESSION_PERSISTENCE_FAILED",
+    status: 503,
+  });
+  assert.doesNotMatch(JSON.stringify(calls), new RegExp(SENTINEL, "u"));
+});


### PR DESCRIPTION
## What changed

- added a shared safe error logger that emits only a constrained error name, uppercase code, and numeric status
- removed raw `Error`, message, stack, cause, request/response, and provider payload logging from owner auth, GitHub OAuth/session, Google OAuth/session, and logout paths
- removed the remaining Google Drive upstream error message from runtime logs
- added sentinel regression tests covering token, email, prompt, stack, cause, headers, response data, and code injection

## Why

OAuth and persistence errors can carry credentials or personal provider context inside nested error objects. Full objects must not reach DigitalOcean runtime logs.

## Impact

OAuth scopes, cookies, session storage, API responses, and error codes are unchanged. Operational logs retain the stable context plus safe `name`, `code`, and `status` metadata.

## Validation

- affected tests: 50/50
- full `npm test`: 421/421
- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities
- Prettier and `git diff --check`
- published tree matches locally verified tree: `379974d03694e3c292a71a7acd1b5bd92aee56fa`

Closes #184