### PR TITLE
Sanitize remaining server error logs

### DIFF
--- a/src/config/opensearch.js
+++ b/src/config/opensearch.js
@@ -1,4 +1,5 @@
 import { Client } from "@opensearch-project/opensearch";
+import { logSafeError } from "../utils/safeLogging.js";
 
 let opensearchClient = null;
 
@@ -57,7 +58,7 @@ export function createOpenSearchClient() {
     console.log("✅ OpenSearch client initialized");
     return opensearchClient;
   } catch (error) {
-    console.error("❌ Failed to initialize OpenSearch client:", error.message);
+    logSafeError("[OpenSearch] Client initialization failed", error);
     return null;
   }
 }

--- a/src/routes/calendarRouter.js
+++ b/src/routes/calendarRouter.js
@@ -9,6 +9,7 @@ import {
   evaluatePermission,
   recordAuditEvent,
 } from "../services/permissionService.js";
+import { logSafeError, safeErrorCode } from "../utils/safeLogging.js";
 
 const router = express.Router();
 const AUDIT_TIMEOUT_MS = 2000;
@@ -24,10 +25,7 @@ async function auditAction(event) {
       new Promise((resolve) => setTimeout(resolve, AUDIT_TIMEOUT_MS)),
     ]);
   } catch (error) {
-    console.error(
-      "[Calendar audit] Write failure:",
-      error?.message || "unknown",
-    );
+    logSafeError("[Calendar audit] Write failure", error);
   }
 }
 
@@ -92,7 +90,7 @@ router.get("/events", async (req, res) => {
       decision: permission.decision,
       outcome: "failed",
       resource: "GET /calendar/events",
-      details: error?.code,
+      details: safeErrorCode(error, "CALENDAR_READ_FAILED"),
     });
     sendError(res, error);
   }

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -80,6 +80,7 @@ import {
   PROJECT_BASE_CONTEXT,
   PROJECT_DEFINITION,
 } from "../config/projectIdentity.js";
+import { logSafeError, safeErrorCode } from "../utils/safeLogging.js";
 
 const router = express.Router();
 const HEARTBEAT_INTERVAL_MS = 15000;
@@ -98,7 +99,7 @@ async function auditAction(event) {
   try {
     await recordAuditEvent(event);
   } catch (error) {
-    console.error("[Audit] Write failure:", error);
+    logSafeError("[Chat audit] Write failure", error);
   }
 }
 
@@ -112,7 +113,7 @@ async function saveConversationTurnBestEffort(
     await saveConversationTurn(sessionId, userText, replyText, ownerId);
     return true;
   } catch (error) {
-    console.error(`[ConversationMemory] Save failure for ${sessionId}:`, error);
+    logSafeError("[ConversationMemory] Save failure", error);
     return false;
   }
 }
@@ -842,10 +843,7 @@ router.post("/chat", async (req, res) => {
       listConversationMessages(cleanSessionId, undefined, ownerId),
     ]);
   } catch (error) {
-    console.error(
-      `[Memory] Failure for ${cleanSessionId}:`,
-      error?.code || error?.message || "unknown",
-    );
+    logSafeError("[Memory] Chat request failure", error);
     if (
       error instanceof MemoryDeleteConfirmationError ||
       isAuditSafetyError(error)
@@ -949,7 +947,7 @@ router.post("/chat", async (req, res) => {
         ...getConversationPersistenceMetadata(conversationPersisted),
       });
     } catch (error) {
-      console.error(`[Vision] Failure for ${cleanSessionId}:`, error);
+      logSafeError("[Vision] Chat request failure", error);
       sendEvent("error", {
         status: error instanceof ImageServiceError ? error.status : 502,
         message:
@@ -986,17 +984,14 @@ router.post("/chat", async (req, res) => {
         ...getConversationPersistenceMetadata(conversationPersisted),
       });
     } catch (error) {
-      console.error(
-        "[Memory write confirmation]",
-        error?.code || error?.message || "unknown",
-      );
+      logSafeError("[Memory write confirmation] Failure", error);
       if (!isAuditSafetyError(error)) {
         await auditAction({
           action: "memory.write",
           decision: "confirmed",
           outcome: "failed",
           resource: "profile-memory",
-          details: `chat:failed:${error?.code || "unknown"}`,
+          details: `chat:failed:${safeErrorCode(error, "MEMORY_WRITE_FAILED")}`,
           sessionId: cleanSessionId,
         });
       }
@@ -1052,13 +1047,13 @@ router.post("/chat", async (req, res) => {
         ...getConversationPersistenceMetadata(conversationPersisted),
       });
     } catch (error) {
-      console.error("[Calendar confirmation]", error);
+      logSafeError("[Calendar confirmation] Failure", error);
       await auditAction({
         action: "calendar.write",
         decision: "confirmed",
         outcome: "failed",
         resource: "primary-calendar",
-        details: error?.code || error?.message,
+        details: safeErrorCode(error, "CALENDAR_WRITE_FAILED"),
         sessionId: cleanSessionId,
       });
       sendEvent("error", {
@@ -1103,13 +1098,13 @@ router.post("/chat", async (req, res) => {
         ...getConversationPersistenceMetadata(conversationPersisted),
       });
     } catch (error) {
-      console.error("[Copilot confirmation]", error);
+      logSafeError("[Copilot confirmation] Failure", error);
       await auditAction({
         action: "github.write",
         decision: "confirmed",
         outcome: "failed",
         resource: "github-copilot",
-        details: error?.code || error?.message,
+        details: safeErrorCode(error, "COPILOT_TASK_FAILED"),
         sessionId: cleanSessionId,
       });
       sendEvent("error", {
@@ -1224,7 +1219,7 @@ router.post("/chat", async (req, res) => {
         `[AgentPlanner] Planned ${detectedCapabilityRequests.length} capability calls for ${cleanSessionId}.`,
       );
     } catch (error) {
-      console.error(`[AgentPlanner] Failure for ${cleanSessionId}:`, error);
+      logSafeError("[AgentPlanner] Failure", error);
       detectedCapabilityRequests = memoryAction
         ? []
         : fallbackCapabilityRequests;
@@ -1428,7 +1423,7 @@ router.post("/chat", async (req, res) => {
     );
   } catch (error) {
     if (abortController.signal.aborted && !timedOut) return;
-    console.error(`[AI Core] Failure for ${cleanSessionId}:`, error);
+    logSafeError("[AI Core] Failure", error);
     sendEvent("error", {
       status: timedOut ? 504 : 502,
       message: timedOut

--- a/src/routes/confirmedActionsRouter.js
+++ b/src/routes/confirmedActionsRouter.js
@@ -29,6 +29,7 @@ import {
   isAuditSafetyError,
   recordAuditEvent,
 } from "../services/permissionService.js";
+import { logSafeError, safeErrorCode } from "../utils/safeLogging.js";
 
 const router = express.Router();
 
@@ -36,7 +37,7 @@ async function auditAction(event) {
   try {
     await recordAuditEvent(event);
   } catch (error) {
-    console.error("[Audit] Write failure:", error);
+    logSafeError("[Confirmed action audit] Write failure", error);
   }
 }
 
@@ -80,7 +81,7 @@ router.post("/request", async (req, res) => {
       decision: "deny",
       outcome: "blocked",
       resource: resourceLabel(resource),
-      details: error.code || error.message,
+      details: safeErrorCode(error, "CONFIRMATION_REQUEST_BLOCKED"),
       sessionId: cleanSessionId,
     });
     const status = error.code === "UNKNOWN_ACTION" ? 400 : 422;
@@ -139,7 +140,7 @@ router.post("/confirm", async (req, res) => {
       action: "github.write",
       decision: "confirm",
       outcome: outcomeMap[error.code] || "denied",
-      details: error.code || "confirmation_denied",
+      details: safeErrorCode(error, "CONFIRMATION_DENIED"),
       sessionId: cleanSessionId,
     });
     const statusMap = {
@@ -176,7 +177,7 @@ router.post("/confirm", async (req, res) => {
         decision: "confirmed",
         outcome: "failed",
         resource: resourceLabel(confirmation.resource),
-        details: error.code || "EXECUTION_ERROR",
+        details: safeErrorCode(error, "EXECUTION_ERROR"),
         sessionId: cleanSessionId,
       });
     }

--- a/src/routes/githubRouter.js
+++ b/src/routes/githubRouter.js
@@ -11,6 +11,7 @@ import {
   evaluatePermission,
   recordAuditEvent,
 } from "../services/permissionService.js";
+import { logSafeError, safeErrorCode } from "../utils/safeLogging.js";
 
 const router = express.Router();
 
@@ -36,19 +37,19 @@ async function audit(req, outcome, details = null) {
       details,
     });
   } catch (error) {
-    console.error("[Audit] Write failure:", error);
+    logSafeError("[GitHub audit] Write failure", error);
   }
 }
 
 async function sendError(req, res, error) {
-  await audit(req, "failed", error?.code || error?.message);
+  await audit(req, "failed", safeErrorCode(error, "GITHUB_READ_FAILED"));
   if (error instanceof GitHubServiceError) {
     return res.status(error.status).json({
       error: error.message,
       code: error.code,
     });
   }
-  console.error("[GitHub] Unexpected failure:", error);
+  logSafeError("[GitHub] Unexpected failure", error);
   return res.status(500).json({
     error: "Неочаквана грешка в GitHub модула.",
     code: "INTERNAL_ERROR",

--- a/src/routes/memoryRouter.js
+++ b/src/routes/memoryRouter.js
@@ -21,6 +21,7 @@ import {
   MemoryDeleteConfirmationError,
   prepareMemoryDelete,
 } from "../services/memoryDeleteConfirmationService.js";
+import { logSafeError, safeErrorCode } from "../utils/safeLogging.js";
 
 const router = express.Router();
 
@@ -28,13 +29,13 @@ async function auditMemoryAction(event) {
   try {
     await recordAuditEvent(event);
   } catch (error) {
-    console.error("[Audit] Memory API write failure:", error);
+    logSafeError("[Memory audit] Write failure", error);
   }
 }
 
 function sendMemoryError(res, error) {
   const status = error?.code === "INVALID_MEMORY" ? 400 : error?.status || 503;
-  console.error("[Memory]", error?.message || error);
+  logSafeError("[Memory] Request failure", error);
   if (
     error instanceof MemoryWriteConfirmationError ||
     error instanceof MemoryDeleteConfirmationError ||
@@ -117,7 +118,7 @@ async function runProtectedMemoryDelete({
         decision: confirmationId ? "confirmed" : "confirm",
         outcome: "failed",
         resource: "profile-memory",
-        details: `api:${target.kind}:failed:${error?.code || "unknown"}`,
+        details: `api:${target.kind}:failed:${safeErrorCode(error, "MEMORY_DELETE_FAILED")}`,
         sessionId,
       });
     }
@@ -232,7 +233,7 @@ export function createProfileMemoryWriteHandler({
           decision: "confirmed",
           outcome: "failed",
           resource: "profile-memory",
-          details: `api:failed:${error?.code || "unknown"}`,
+          details: `api:failed:${safeErrorCode(error, "MEMORY_WRITE_FAILED")}`,
           sessionId,
         });
       }

--- a/src/routes/permissionsRouter.js
+++ b/src/routes/permissionsRouter.js
@@ -4,6 +4,7 @@ import {
   listAuditEvents,
   listPermissions,
 } from "../services/permissionService.js";
+import { logSafeError } from "../utils/safeLogging.js";
 
 const router = express.Router();
 
@@ -23,7 +24,7 @@ router.get("/audit", async (req, res) => {
     const events = await listAuditEvents(req.query.limit);
     res.json({ events });
   } catch (error) {
-    console.error("[Audit] Read failure:", error);
+    logSafeError("[Audit] Read failure", error);
     res.status(503).json({
       error: "Дневникът на действията временно не е достъпен.",
       code: "AUDIT_UNAVAILABLE",

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -1,5 +1,6 @@
 import express from "express";
 import { getOpenSearchClient } from "../config/opensearch.js";
+import { logSafeError } from "../utils/safeLogging.js";
 
 const router = express.Router();
 const INDEX_NAME = "projects";
@@ -29,7 +30,7 @@ router.get("/", async (req, res) => {
     if (error.meta && error.meta.statusCode === 404) {
         return res.json([]);
     }
-    console.error("OpenSearch Search Error:", error);
+    logSafeError("[Projects] OpenSearch search failed", error);
     res.status(500).json({ error: "Failed to fetch projects" });
   }
 });
@@ -57,7 +58,7 @@ router.post("/", async (req, res) => {
 
     res.status(201).json({ id: response.body._id, ...project });
   } catch (error) {
-    console.error("OpenSearch Index Error:", error);
+    logSafeError("[Projects] OpenSearch index failed", error);
     res.status(500).json({ error: "Failed to create project" });
   }
 });
@@ -80,7 +81,7 @@ router.get("/:id", async (req, res) => {
     if (error.meta && error.meta.statusCode === 404) {
       return res.status(404).json({ error: "Project not found" });
     }
-    console.error("OpenSearch Get Error:", error);
+    logSafeError("[Projects] OpenSearch get failed", error);
     res.status(500).json({ error: "Failed to fetch project" });
   }
 });
@@ -104,7 +105,7 @@ router.delete("/:id", async (req, res) => {
     if (error.meta && error.meta.statusCode === 404) {
       return res.status(404).json({ error: "Project not found" });
     }
-    console.error("OpenSearch Delete Error:", error);
+    logSafeError("[Projects] OpenSearch delete failed", error);
     res.status(500).json({ error: "Failed to delete project" });
   }
 });

--- a/src/routes/testerAuthAdminRouter.js
+++ b/src/routes/testerAuthAdminRouter.js
@@ -18,6 +18,7 @@ import {
   isTesterRegistrationEnabled,
   isUserAuthConfigured,
 } from "../services/userAuthService.js";
+import { logSafeError, safeErrorCode } from "../utils/safeLogging.js";
 
 const ACTION = "infrastructure.digitalocean:activate_tester_auth";
 
@@ -25,10 +26,7 @@ async function safeAudit(audit, event) {
   try {
     await audit(event);
   } catch (error) {
-    console.error(
-      "[Tester auth audit]",
-      error?.message || "Audit storage unavailable.",
-    );
+    logSafeError("[Tester auth audit] Write failure", error);
   }
 }
 
@@ -201,7 +199,7 @@ export function createTesterAuthAdminRouter({
         decision: "confirmed",
         outcome: "failed",
         resource: "tester-auth",
-        details: error?.code || "TESTER_AUTH_ACTIVATION_FAILED",
+        details: safeErrorCode(error, "TESTER_AUTH_ACTIVATION_FAILED"),
       });
       const response = safeError(error);
       return res.status(response.status).json(response.body);

--- a/src/routes/webSearchRouter.js
+++ b/src/routes/webSearchRouter.js
@@ -4,6 +4,7 @@ import {
   searchWeb,
   WebSearchError,
 } from "../services/webSearchService.js";
+import { logSafeError } from "../utils/safeLogging.js";
 
 const router = express.Router();
 
@@ -13,7 +14,7 @@ router.post("/ai", async (req, res) => {
   try {
     return res.json(await searchWeb(query));
   } catch (error) {
-    console.error("[Web search] Failure:", error);
+    logSafeError("[Web search] Failure", error);
     const status = error instanceof WebSearchError ? error.status : 502;
     return res.status(status).json({
       error:

--- a/src/services/confirmationService.js
+++ b/src/services/confirmationService.js
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { getOpenSearchClient } from "../config/opensearch.js";
+import { logSafeError } from "../utils/safeLogging.js";
 import {
   decryptGitHubSession,
   encryptGitHubSession,
@@ -181,10 +182,7 @@ export async function createDurableConfirmation(options) {
       pendingConfirmations.delete(confirmation.id);
       throw persistenceError();
     }
-    console.error(
-      "[Confirmation] Persistence failure:",
-      error?.message || "unknown",
-    );
+    logSafeError("[Confirmation] Persistence failure", error);
   }
 
   if (!persisted && requiresPersistentConfirmations()) {
@@ -247,10 +245,7 @@ export async function markDurableConfirmationUsed(confirmationId) {
     try {
       await removeStoredConfirmation(confirmationId);
     } catch (error) {
-      console.error(
-        "[Confirmation] Delete failure:",
-        error?.message || "unknown",
-      );
+      logSafeError("[Confirmation] Delete failure", error);
     }
   }
   markConfirmationUsed(confirmationId);

--- a/src/services/taskExecutionService.js
+++ b/src/services/taskExecutionService.js
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { logSafeError, safeErrorCode } from "../utils/safeLogging.js";
 
 const TERMINAL_STATUSES = new Set([
   "completed",
@@ -12,7 +13,7 @@ function safeNotify(notify, event) {
   try {
     notify(Object.freeze({ ...event }));
   } catch (error) {
-    console.error("[TaskExecution] Status notification failed:", error);
+    logSafeError("[TaskExecution] Status notification failed", error);
   }
 }
 
@@ -21,7 +22,7 @@ async function safeAudit(audit, event) {
   try {
     await audit(event);
   } catch (error) {
-    console.error("[TaskExecution] Audit write failed:", error);
+    logSafeError("[TaskExecution] Audit write failed", error);
   }
 }
 
@@ -115,7 +116,7 @@ export async function executeTaskPlan({
         decision: "deny",
         outcome: "failed",
         resource: request.capability,
-        details: error?.code || error?.message || "unknown_error",
+        details: safeErrorCode(error, "TASK_EXECUTION_FAILED"),
         sessionId: capabilityInputContext.sessionId,
       });
     }

--- a/src/utils/safeLogging.js
+++ b/src/utils/safeLogging.js
@@ -28,6 +28,13 @@ export function safeErrorMetadata(error) {
   return Object.freeze(metadata);
 }
 
+export function safeErrorCode(error, fallback = "UNCLASSIFIED_ERROR") {
+  return (
+    safeIdentifier(error?.code, SAFE_ERROR_CODE) ||
+    safeIdentifier(fallback, SAFE_ERROR_CODE, "UNCLASSIFIED_ERROR")
+  );
+}
+
 export function logSafeError(context, error) {
   console.error(context, safeErrorMetadata(error));
 }

--- a/tests/safeLogging.test.js
+++ b/tests/safeLogging.test.js
@@ -1,9 +1,28 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
-import { logSafeError, safeErrorMetadata } from "../src/utils/safeLogging.js";
+import {
+  logSafeError,
+  safeErrorCode,
+  safeErrorMetadata,
+} from "../src/utils/safeLogging.js";
 
 const SENTINEL = "Bearer private-token personal@example.com private-prompt";
+const SAFE_LOGGING_CALLERS = [
+  "../src/config/opensearch.js",
+  "../src/routes/calendarRouter.js",
+  "../src/routes/chat.js",
+  "../src/routes/confirmedActionsRouter.js",
+  "../src/routes/githubRouter.js",
+  "../src/routes/memoryRouter.js",
+  "../src/routes/permissionsRouter.js",
+  "../src/routes/projects.js",
+  "../src/routes/testerAuthAdminRouter.js",
+  "../src/routes/webSearchRouter.js",
+  "../src/services/confirmationService.js",
+  "../src/services/taskExecutionService.js",
+];
 
 function sensitiveError() {
   const error = new Error(SENTINEL, {
@@ -37,6 +56,18 @@ test("unsafe error codes cannot inject arbitrary text into logs", () => {
   });
 });
 
+test("safe error codes use only validated codes or fixed fallbacks", () => {
+  assert.equal(safeErrorCode(sensitiveError()), "SESSION_PERSISTENCE_FAILED");
+
+  const error = sensitiveError();
+  error.code = SENTINEL;
+  assert.equal(
+    safeErrorCode(error, "PROVIDER_REQUEST_FAILED"),
+    "PROVIDER_REQUEST_FAILED",
+  );
+  assert.equal(safeErrorCode(error, SENTINEL), "UNCLASSIFIED_ERROR");
+});
+
 test("safe logger emits only the fixed context and safe metadata", () => {
   const originalConsoleError = console.error;
   const calls = [];
@@ -54,4 +85,21 @@ test("safe logger emits only the fixed context and safe metadata", () => {
     status: 503,
   });
   assert.doesNotMatch(JSON.stringify(calls), new RegExp(SENTINEL, "u"));
+});
+
+test("server failure paths keep direct errors out of logs and audit details", () => {
+  for (const relativePath of SAFE_LOGGING_CALLERS) {
+    const source = readFileSync(new URL(relativePath, import.meta.url), "utf8");
+    assert.doesNotMatch(source, /console\.error\s*\(/u, relativePath);
+    assert.doesNotMatch(
+      source,
+      /details\s*:\s*error(?:\?\.|\.)/u,
+      relativePath,
+    );
+    assert.doesNotMatch(
+      source,
+      /details\s*:[^\n]*error\.message/u,
+      relativePath,
+    );
+  }
 });


### PR DESCRIPTION
## Какво променя
- прилага общия safe logger към останалите chat, memory, GitHub, projects, calendar, permissions и execution failure paths;
- премахва session id, `error.message`, stack/cause и provider payload от тези server логове;
- валидира кодовете, записвани в трайните audit details, с фиксирани fallback стойности;
- добавя регресионен тест срещу връщане на директно dynamic error logging.

## Проверки
- целеви тестове: 110/110;
- пълен пакет: 423/423;
- `npm audit`: 0 уязвимости;
- `npm audit --omit=dev`: 0 уязвимости;
- публикуваният GitHub tree е точен с локалния: `d00ad121600950700b12daef053660596a160b4b`.

Closes #186