### PR TITLE
Show live capability summary in work center

### DIFF
--- a/public/accessibility.css
+++ b/public/accessibility.css
@@ -305,6 +305,17 @@
   white-space: normal;
 }
 
+:root[data-font-scale="max"] .work-center-capabilities-title {
+  font-size: var(--synchron-card-title);
+}
+
+:root[data-font-scale="max"] .work-center-capabilities-note,
+:root[data-font-scale="max"] .work-center-capability-heading,
+:root[data-font-scale="max"] .work-center-capability-group li {
+  font-size: var(--synchron-card-description);
+  line-height: 1.4;
+}
+
 :root[data-font-scale="max"] .work-center-close {
   min-height: 70px;
   font-size: var(--synchron-readable-text);

--- a/public/appshell.css
+++ b/public/appshell.css
@@ -70,6 +70,7 @@
 .work-center-status{width:fit-content;max-width:100%;margin-top:8px;padding:4px 8px;border-radius:999px;font-size:10px;font-weight:750;line-height:1.25}
 .work-center-action-label{margin-top:9px;color:#1d4ed8;font-size:12px;font-weight:800;line-height:1.3}
 .work-center-status.external{color:#7c4a03;background:#fff4d7}.work-center-status.internal{color:#137333;background:#e6f4ea}
+.work-center-capabilities{margin:0 0 14px;padding:14px;border:1px solid #dfe3e8;border-radius:14px;background:#f8f9fa}.work-center-capabilities-title{margin:0;font-size:17px;line-height:1.25}.work-center-capabilities-note{margin:5px 0 12px;color:#5f6368;font-size:12px;line-height:1.4}.work-center-capabilities-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px}.work-center-capability-group{min-width:0;padding:10px;border-radius:11px;background:#fff}.work-center-capability-group.working{border:1px solid #b7dfc1}.work-center-capability-group.action{border:1px solid #f1d28b}.work-center-capability-group.unavailable{border:1px solid #d4d7dc}.work-center-capability-heading{display:block;font-size:12px;line-height:1.3}.work-center-capability-group.working .work-center-capability-heading{color:#137333}.work-center-capability-group.action .work-center-capability-heading{color:#7c4a03}.work-center-capability-group.unavailable .work-center-capability-heading{color:#5f6368}.work-center-capability-group ul{margin:7px 0 0;padding-left:18px}.work-center-capability-group li{margin:4px 0;font-size:12px;line-height:1.35;overflow-wrap:anywhere}.work-center-capability-empty{color:#777}
 .work-center-arrow{color:#94a3b8}.featured .work-center-arrow{color:#fff}
 .work-center-close{width:100%;min-height:48px;margin-top:8px;border:1px solid #cbd5e1;border-radius:14px;color:#17212b;background:#fff;font:inherit;font-weight:750;cursor:pointer}
 .chatgpt-app-setup{margin-top:2px}.chatgpt-app-steps{margin:12px 0;padding-left:22px}.chatgpt-app-steps li{margin:8px 0}.chatgpt-app-label{display:block;margin-top:12px;font-size:12px;font-weight:800}.chatgpt-app-endpoint{display:block;margin-top:6px;padding:11px;border-radius:10px;color:#0f172a;background:#e8eef7;overflow-wrap:anywhere}.chatgpt-app-actions{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}.chatgpt-app-copy,.chatgpt-app-link{min-height:44px;padding:10px 13px;border:0;border-radius:10px;color:#fff;background:#1d4ed8;font:inherit;font-weight:800;text-decoration:none;cursor:pointer}.chatgpt-app-link.secondary{color:#17212b;background:#e2e8f0}
@@ -88,6 +89,7 @@
 }
 @media(max-width:520px){
   .data-drawer-header{min-height:68px;padding:14px 16px}.data-drawer-body{padding:14px}
+  .work-center-capabilities-grid{grid-template-columns:1fr}
   .permission-card,.tool-status-card{width:100%;min-width:0;flex-direction:column;align-items:stretch}
   .configuration-item{flex-direction:column}.configuration-item .permission-badge{align-self:flex-start}
   .permission-card>div,.tool-status-card>div{width:100%;min-width:0}

--- a/public/work-center.js
+++ b/public/work-center.js
@@ -165,6 +165,12 @@
     toolId,
     { connected = true, connectionName = "услугата" } = {},
   ) {
+    if (!Array.isArray(integrations?.tools)) {
+      return {
+        label: "Не е проверено",
+        className: "warning",
+      };
+    }
     const tool = integrations?.tools?.find((item) => item.id === toolId);
     if (!tool?.configured || !tool?.enabled || !tool?.executable) {
       return {
@@ -182,6 +188,150 @@
       label: toolId === "github-read" ? "GitHub Read: работи" : "Работи",
       className: "internal",
     };
+  }
+
+  function resolveCapabilityState(
+    integrations,
+    toolId,
+    { connected = true } = {},
+  ) {
+    if (!Array.isArray(integrations?.tools)) return "unavailable";
+    const tool = integrations.tools.find((item) => item.id === toolId);
+    if (!tool?.configured || !tool?.enabled || !tool?.executable) {
+      return "unavailable";
+    }
+    return connected ? "working" : "action";
+  }
+
+  function buildCurrentCapabilities(
+    readiness,
+    integrations,
+    sessions,
+    testerAuth,
+  ) {
+    const coreReady =
+      readiness?.status === "ready" &&
+      readiness?.checks?.chatAgent?.ready === true &&
+      readiness?.checks?.memory?.ready === true;
+    const bridge = readiness?.checks?.bridge;
+    const bridgeReady =
+      bridge?.configured === true &&
+      bridge?.responding === true &&
+      bridge?.tools >= 11 &&
+      bridge?.authentication?.chatgptOAuthReady === true;
+    const testerStatus = testerAuth
+      ? testerAuth.configured && testerAuth.registrationEnabled
+        ? "working"
+        : "action"
+      : "unavailable";
+
+    return [
+      {
+        label: "AI разговор и постоянна памет",
+        state: coreReady ? "working" : "unavailable",
+      },
+      {
+        label: "ChatGPT MCP мост",
+        state: bridgeReady ? "working" : "unavailable",
+      },
+      {
+        label: "GitHub Read",
+        state: resolveCapabilityState(integrations, "github-read"),
+      },
+      {
+        label: "GitHub запис с точно потвърждение",
+        state: resolveCapabilityState(integrations, "github-write", {
+          connected: Boolean(sessions.githubConnected),
+        }),
+      },
+      {
+        label: "Google Drive",
+        state: resolveCapabilityState(integrations, "google-drive-read", {
+          connected: Boolean(sessions.googleConnected),
+        }),
+      },
+      {
+        label: "Gmail",
+        state: resolveCapabilityState(integrations, "gmail-read", {
+          connected: Boolean(sessions.googleConnected),
+        }),
+      },
+      {
+        label: "Google Calendar",
+        state: resolveCapabilityState(integrations, "google-calendar-read", {
+          connected: Boolean(sessions.googleConnected),
+        }),
+      },
+      { label: "Тестови профили", state: testerStatus },
+    ];
+  }
+
+  function renderCurrentCapabilities(
+    readiness,
+    integrations,
+    sessions,
+    testerAuth,
+  ) {
+    const section = document.createElement("section");
+    section.className = "work-center-capabilities";
+    section.setAttribute("aria-labelledby", "currentCapabilitiesTitle");
+
+    const heading = addText(
+      section,
+      "h3",
+      "Какво мога в момента?",
+      "work-center-capabilities-title",
+    );
+    heading.id = "currentCapabilitiesTitle";
+    addText(
+      section,
+      "p",
+      "Показано е само потвърденото от живия статус на системата.",
+      "work-center-capabilities-note",
+    );
+
+    const capabilities = buildCurrentCapabilities(
+      readiness,
+      integrations,
+      sessions,
+      testerAuth,
+    );
+    const groups = [
+      { state: "working", title: "Работи сега" },
+      {
+        state: "action",
+        title: "Изисква свързване или потвърждение",
+      },
+      {
+        state: "unavailable",
+        title: "Не е проверено или недостъпно",
+      },
+    ];
+
+    const grid = document.createElement("div");
+    grid.className = "work-center-capabilities-grid";
+    groups.forEach(({ state, title: groupTitle }) => {
+      const items = capabilities.filter((item) => item.state === state);
+      const group = document.createElement("div");
+      group.className = `work-center-capability-group ${state}`;
+      group.dataset.capabilityGroup = state;
+      addText(
+        group,
+        "strong",
+        `${groupTitle} · ${items.length}`,
+        "work-center-capability-heading",
+      );
+      const list = document.createElement("ul");
+      if (items.length) {
+        items.forEach((item) => addText(list, "li", item.label));
+      } else {
+        addText(list, "li", "Няма", "work-center-capability-empty");
+      }
+      group.appendChild(list);
+      grid.appendChild(group);
+    });
+    section.appendChild(grid);
+    return section;
   }
 
   function resolveChatGptAppStatus(readiness) {
@@ -232,6 +382,14 @@
       "Свързаният разговор е вътре в SYNCHRON-X. Външните услуги не получават автоматично достъп до паметта и не дават нови права на агента.",
     );
     body.appendChild(intro);
+    body.appendChild(
+      renderCurrentCapabilities(
+        readiness,
+        integrations,
+        sessions,
+        testerAuth,
+      ),
+    );
 
     const grid = document.createElement("section");
     grid.className = "work-center-grid";

--- a/tests/workCenterUi.test.js
+++ b/tests/workCenterUi.test.js
@@ -13,6 +13,10 @@ const css = await readFile(
   new URL("../public/appshell.css", import.meta.url),
   "utf8",
 );
+const accessibilityCss = await readFile(
+  new URL("../public/accessibility.css", import.meta.url),
+  "utf8",
+);
 
 function createHarness({
   config,
@@ -443,6 +447,85 @@ test("one Google login marks Drive, Gmail, and Calendar as connected", async () 
   });
 });
 
+test("current capabilities summary uses only live verified status", async () => {
+  const harness = createHarness({
+    readiness: {
+      status: "ready",
+      checks: {
+        chatAgent: { ready: true },
+        memory: { ready: true, status: "green" },
+        bridge: {
+          configured: true,
+          responding: true,
+          tools: 11,
+          authentication: { chatgptOAuthReady: true },
+        },
+      },
+    },
+    integrations: {
+      tools: [
+        "github-read",
+        "github-write",
+        "google-drive-read",
+        "gmail-read",
+        "google-calendar-read",
+      ].map((id) => ({
+        id,
+        enabled: true,
+        executable: true,
+        configured: true,
+      })),
+    },
+    googleConnected: true,
+    githubConnected: true,
+    testerAuth: { configured: true, registrationEnabled: true },
+  });
+  await openCenter(harness);
+  const { document } = harness.dom.window;
+  const summary = document.querySelector(".work-center-capabilities");
+  const working = summary.querySelector('[data-capability-group="working"]');
+
+  assert.match(summary.textContent, /Какво мога в момента\?/u);
+  assert.match(working.textContent, /Работи сега · 8/u);
+  assert.match(working.textContent, /AI разговор и постоянна памет/u);
+  assert.match(working.textContent, /ChatGPT MCP мост/u);
+  assert.match(working.textContent, /GitHub Read/u);
+  assert.match(working.textContent, /Google Drive/u);
+  assert.match(working.textContent, /Gmail/u);
+  assert.match(working.textContent, /Google Calendar/u);
+  assert.match(working.textContent, /Тестови профили/u);
+});
+
+test("missing Google session is an action and never a working capability", async () => {
+  const harness = createHarness({ googleConnected: false });
+  await openCenter(harness);
+  const { document } = harness.dom.window;
+  const working = document.querySelector('[data-capability-group="working"]');
+  const action = document.querySelector('[data-capability-group="action"]');
+
+  assert.doesNotMatch(working.textContent, /Google Drive|Gmail|Google Calendar/u);
+  assert.match(action.textContent, /Google Drive/u);
+  assert.match(action.textContent, /Gmail/u);
+  assert.match(action.textContent, /Google Calendar/u);
+});
+
+test("unavailable runtime status is never presented as working", async () => {
+  const harness = createHarness({ fetchFails: true });
+  await openCenter(harness);
+  const { document } = harness.dom.window;
+  const summary = document.querySelector(".work-center-capabilities");
+  const working = summary.querySelector('[data-capability-group="working"]');
+  const unavailable = summary.querySelector(
+    '[data-capability-group="unavailable"]',
+  );
+
+  assert.match(working.textContent, /Работи сега · 0/u);
+  assert.match(unavailable.textContent, /AI разговор и постоянна памет/u);
+  assert.match(unavailable.textContent, /ChatGPT MCP мост/u);
+  assert.match(unavailable.textContent, /Google Drive/u);
+  assert.doesNotMatch(summary.textContent, /secret|token|password/iu);
+});
+
 test("mobile drawer cards use full width without horizontal overflow", () => {
   assert.doesNotMatch(css, /display:none\}\\\\n\.drawer-backdrop/u);
   assert.match(css, /@media\s*\(max-width:\s*520px\)/u);
@@ -452,4 +535,12 @@ test("mobile drawer cards use full width without horizontal overflow", () => {
   );
   assert.match(css, /\.data-drawer-body\s*\{[^}]*overflow-x:\s*hidden/u);
   assert.match(css, /\.work-center-card\s*\{\s*min-height:\s*104px/u);
+  assert.match(
+    css,
+    /@media\s*\(\s*max-width:\s*520px\s*\).*?\.work-center-capabilities-grid\s*\{[^}]*grid-template-columns:\s*1fr/su,
+  );
+  assert.match(
+    accessibilityCss,
+    /data-font-scale="max"[^}]*\.work-center-capabilities-title\s*\{[^}]*font-size:\s*var\(--synchron-card-title\)/su,
+  );
 });


### PR DESCRIPTION
## Какво променя

- добавя „Какво мога в момента?“ в началото на Работния център;
- разделя способностите на работещи, изискващи свързване/потвърждение и непроверени/недостъпни;
- използва само вече заредените live runtime и session статуси;
- никога не представя неуспешна status заявка като работеща услуга;
- запазва мобилния изглед и режима с много голям шрифт;
- не добавя endpoint, secret, външна услуга или допълнителна background заявка.

## Проверки

- Work Center UI: 18/18;
- пълен пакет: 436/436;
- full dependency audit: 0 уязвимости;
- production dependency audit: 0 уязвимости;
- remote tree съвпада точно с локалния: `5eaaee3516194c59b089326cee1f63c881c8ab80`.

Closes #192