### PR TITLE
Remove stale Copilot focus and honest image label

### DIFF
--- a/public/accessibility.css
+++ b/public/accessibility.css
@@ -262,16 +262,13 @@
 :root[data-font-scale="max"] .drawer-state,
 :root[data-font-scale="max"] .memory-card,
 :root[data-font-scale="max"] .permission-card,
-:root[data-font-scale="max"] .focus-card,
-:root[data-font-scale="max"] .focus-next,
 :root[data-font-scale="max"] .work-center-intro {
   font-size: var(--synchron-readable-text);
   line-height: 1.5;
 }
 
 :root[data-font-scale="max"] .memory-card p,
-:root[data-font-scale="max"] .permission-card p,
-:root[data-font-scale="max"] .focus-card p {
+:root[data-font-scale="max"] .permission-card p {
   font-size: inherit;
   line-height: inherit;
 }

--- a/public/app.js
+++ b/public/app.js
@@ -276,7 +276,6 @@ async function startApplication(user) {
   elements.sidebarBackdrop.addEventListener("click", closeSidebar);
   elements.imagesBtn.addEventListener("click", openImagePicker);
   elements.modulesBtn.addEventListener("click", openModulesDrawer);
-  elements.focusBtn.addEventListener("click", openFocusDrawer);
   elements.toolsBtn.addEventListener("click", openToolsDrawer);
   elements.systemConfigurationBtn.addEventListener(
     "click",
@@ -593,25 +592,6 @@ function openModulesDrawer() {
   document.dispatchEvent(new CustomEvent("synchron:modules-opened"));
 }
 
-function openFocusDrawer() {
-  openDataDrawer("Днешен фокус");
-  elements.dataDrawerBody.innerHTML = `
-    <section class="focus-card focus-primary">
-      <span class="focus-kicker">Текущ етап</span>
-      <h3>Стабилен разговор и постоянна памет</h3>
-      <p>Една задача трябва да се изпълнява веднъж, с ясен резултат и без повторения.</p>
-    </section>
-    <section class="focus-card">
-      <span class="focus-kicker">Текуща задача</span>
-      <h3>Свързване на GitHub Copilot</h3>
-      <p>AI Core води разговора, а потвърдените кодови задачи се предават на Copilot в отделен клон и Pull Request.</p>
-    </section>
-    <section class="focus-next">
-      <span>Следваща проверка</span>
-      <strong>Свържи GitHub еднократно, после изпълни една малка кодова задача с точно потвърждение.</strong>
-    </section>`;
-}
-
 function isGoogleTool(tool) {
   return (
     tool?.provider === "google" ||
@@ -738,7 +718,7 @@ async function openToolsDrawer() {
           <span class="permission-badge allow">Отвори</span>
         </button>
         <article class="permission-card tool-status-card">
-          <div><strong>Снимки и файлове</strong><p>Качване и анализ на изображение.</p></div>
+          <div><strong>Снимки</strong><p>JPEG, PNG и WebP до 5 MB.</p></div>
           <span class="permission-badge allow">Работи</span>
         </article>
         ${tools

--- a/public/appshell.css
+++ b/public/appshell.css
@@ -49,10 +49,6 @@
 .permission-default{margin-bottom:18px;padding:13px 14px;border-radius:12px;background:#f3f6f8;line-height:1.45}.permission-list{display:grid;gap:2px}
 .permission-card{align-items:center}.permission-card strong{font-size:13px}.permission-card p{margin-top:4px;color:#666;font-size:12px}.permission-badge{padding:5px 8px;flex:0 0 auto;border-radius:999px;font-size:11px;font-weight:700}
 .permission-badge.allow{color:#137333;background:#e6f4ea}.permission-badge.confirm{color:#8a4b00;background:#fff4df}.permission-badge.deny{color:#b42318;background:#feeceb}
-.focus-card{margin-bottom:12px;padding:18px;border:1px solid #e3e5e8;border-radius:16px;background:#fff}.focus-card.focus-primary{color:#fff;border-color:#111;background:#111}
-.focus-card h3{margin:6px 0 8px;font-size:18px;line-height:1.25}.focus-card p{margin:0;color:#666;line-height:1.5}.focus-card.focus-primary p{color:#d5d5d5}
-.focus-kicker{font-size:11px;font-weight:800;letter-spacing:.06em;text-transform:uppercase;color:#777}.focus-primary .focus-kicker{color:#a8c7fa}
-.focus-next{padding:15px;border-radius:14px;background:#eef5ff}.focus-next span,.focus-next strong{display:block}.focus-next span{margin-bottom:5px;color:#2765a5;font-size:11px;font-weight:800;text-transform:uppercase}.focus-next strong{line-height:1.45}
 .tool-status-card>div{min-width:0}.tool-status-card .permission-badge{max-width:132px;text-align:center}
 .work-center-intro{margin-bottom:16px;padding:14px 16px;border-radius:14px;color:#475569;background:#f3f6f8;line-height:1.5}
 .work-center-intro p{margin:0}

--- a/tests/dataControlsUi.test.js
+++ b/tests/dataControlsUi.test.js
@@ -26,8 +26,12 @@ test("application exposes working memory and permission controls", async () => {
   assert.match(script, /elements\.imageInput\.click\(\)/u);
   assert.match(script, /function closeSidebar\(\)/u);
   assert.match(script, /function openModulesDrawer\(\)/u);
-  assert.match(script, /function openFocusDrawer\(\)/u);
+  assert.match(html, /task-journal\.js/u);
+  assert.doesNotMatch(script, /function openFocusDrawer\(\)/u);
+  assert.doesNotMatch(script, /Свързване на GitHub Copilot/u);
   assert.match(script, /function openToolsDrawer\(\)/u);
+  assert.match(script, /<strong>Снимки<\/strong><p>JPEG, PNG и WebP до 5 MB\.<\/p>/u);
+  assert.doesNotMatch(script, /Снимки и файлове/u);
   assert.match(script, /fetch\(["']\/health\/integrations["']/u);
   assert.match(script, /Твоята лична AI операционна система/u);
   assert.match(script, /item\.readOnly/u);


### PR DESCRIPTION
## Какво поправя

- премахва недостижимия стар drawer „Днешен фокус“ с остаряла Copilot задача;
- оставя актуалния Дневник като единствен източник за „Задачи“;
- премахва неизползваните `.focus-*` стилове;
- променя подвеждащото „Снимки и файлове“ на „Снимки“;
- показва точната поддръжка: JPEG, PNG и WebP до 5 MB.

## Проверки

- целеви UI тестове: 26/26;
- пълен пакет: 438/438;
- full dependency audit: 0 уязвимости;
- production dependency audit: 0 уязвимости;
- remote tree съвпада точно с локалния: `9e7e3b9aab4f6692e977f23779eeeef3c6ad4519`.

Няма промяна на чат, памет, OpenSearch, permissions, upload поведението, тайни или услуги.

Closes #196