### PR TITLE
Изключи Copilot автоматизацията при липса на кредити

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -79,6 +79,9 @@ services:
       - key: SYNCHRON_TEST_INVITE_CODE
         scope: RUN_TIME
         type: SECRET
+      - key: COPILOT_AUTOMATION_ENABLED
+        value: "false"
+        scope: RUN_TIME
       - key: GITHUB_CLIENT_ID
         scope: RUN_TIME
         type: SECRET

--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,8 @@ OPENAI_API_URL=
 OPENAI_TIMEOUT_MS=30000
 OPENAI_PLANNER_TIMEOUT_MS=30000
 
-# GitHub OAuth App (Required for confirmed Copilot coding tasks)
+# GitHub OAuth App. Copilot automation stays off unless explicitly enabled.
+COPILOT_AUTOMATION_ENABLED=false
 GITHUB_CLIENT_ID=your-github-app-client-id
 GITHUB_CLIENT_SECRET=your-github-app-client-secret
 # Optional overrides. Production defaults to synchron.foundation and derives

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -130,6 +130,23 @@ write adapter, спри и поискай изрично разрешение.
 - При MCP OAuth миграция запази `MCP_ACCESS_TOKEN`, докато dedicated flow и
   refresh периодът не са доказани. Следвай `BRIDGE_AND_DIAGNOSTICS.md`.
 
+## Режим без Copilot
+
+Production работи безопасно с `COPILOT_AUTOMATION_ENABLED=false`. В този режим
+GitHub Read остава активен, а `code.write`, `code.branch` и
+`code.pull-request` спират преди потвърждение, OAuth или външно Copilot
+извикване. `/health/integrations` трябва да връща за `github-write`:
+
+- `enabled=false`;
+- `executable=false`;
+- `healthStatus=unavailable`;
+- `availabilityCode=COPILOT_AUTOMATION_DISABLED`.
+
+Не променяй настройката само защото GitHub OAuth работи. Стойност `true` се
+добавя едва след потвърдени Copilot кредити и отделно разрешение за production
+конфигурацията; защитите за собственическа сесия и точно потвърждение остават
+задължителни.
+
 ## Кога инцидентът е затворен
 
 Инцидентът е приключил само когато:

--- a/public/app.js
+++ b/public/app.js
@@ -1,809 +1,34 @@
-const state = {
-  sessionId: getOrCreateSessionId(),
-  serverOnline: false,
-  opensearchStatus: "unknown",
-  opensearchFailures: 0,
-  lastMemorySuccessAt: 0,
-  lastActions: [],
-  chatBusy: false,
-  speakingButton: null,
-  pendingImage: null,
-  conversations: [],
-  conversationLoadError: "",
-  memoryItems: [],
-  recognition: null,
-  listening: false,
-  authenticatedUser: null,
-  registrationEnabled: false,
-  applicationStarted: false,
-};
-
-const elements = {
-  authGate: document.getElementById("authGate"),
-  appShell: document.getElementById("appShell"),
-  loginForm: document.getElementById("loginForm"),
-  loginEmail: document.getElementById("loginEmail"),
-  loginPassword: document.getElementById("loginPassword"),
-  loginBtn: document.getElementById("loginBtn"),
-  showRegisterBtn: document.getElementById("showRegisterBtn"),
-  registerForm: document.getElementById("registerForm"),
-  registerName: document.getElementById("registerName"),
-  registerEmail: document.getElementById("registerEmail"),
-  registerPassword: document.getElementById("registerPassword"),
-  registerInviteCode: document.getElementById("registerInviteCode"),
-  registerBtn: document.getElementById("registerBtn"),
-  backToLoginBtn: document.getElementById("backToLoginBtn"),
-  authMessage: document.getElementById("authMessage"),
-  chatMessages: document.getElementById("chatMessages"),
-  chatInput: document.getElementById("chatInput"),
-  sendBtn: document.getElementById("sendBtn"),
-  attachBtn: document.getElementById("attachBtn"),
-  imageInput: document.getElementById("imageInput"),
-  attachmentPreview: document.getElementById("attachmentPreview"),
-  attachmentImage: document.getElementById("attachmentImage"),
-  attachmentName: document.getElementById("attachmentName"),
-  removeAttachmentBtn: document.getElementById("removeAttachmentBtn"),
-  newChatBtn: document.getElementById("newChatBtn"),
-  toggleStatusBtn: document.getElementById("toggleStatusBtn"),
-  closeContextBtn: document.getElementById("closeContextBtn"),
-  statusPanel: document.getElementById("statusPanel"),
-  agentStatusDot: document.getElementById("agentStatusDot"),
-  agentStatusText: document.getElementById("agentStatusText"),
-  sessionIdDisplay: document.getElementById("sessionIdDisplay"),
-  serverStatusDisplay: document.getElementById("serverStatusDisplay"),
-  opensearchStatusDisplay: document.getElementById("opensearchStatusDisplay"),
-  actionsLog: document.getElementById("actionsLog"),
-  conversationList: document.getElementById("conversationList"),
-  conversationSearch: document.getElementById("conversationSearch"),
-  searchChatsBtn: document.getElementById("searchChatsBtn"),
-  mobileMenuBtn: document.getElementById("mobileMenuBtn"),
-  sidebar: document.getElementById("sidebar"),
-  sidebarBackdrop: document.getElementById("sidebarBackdrop"),
-  imagesBtn: document.getElementById("imagesBtn"),
-  modulesBtn: document.getElementById("modulesBtn"),
-  systemConfigurationBtn: document.getElementById("systemConfigurationBtn"),
-  focusBtn: document.getElementById("focusBtn"),
-  toolsBtn: document.getElementById("toolsBtn"),
-  memoryBtn: document.getElementById("memoryBtn"),
-  permissionsBtn: document.getElementById("permissionsBtn"),
-  dataDrawer: document.getElementById("dataDrawer"),
-  dataDrawerTitle: document.getElementById("dataDrawerTitle"),
-  dataDrawerBody: document.getElementById("dataDrawerBody"),
-  drawerBackdrop: document.getElementById("drawerBackdrop"),
-  closeDataDrawerBtn: document.getElementById("closeDataDrawerBtn"),
-  voiceBtn: document.getElementById("voiceBtn"),
-  profileAvatar: document.getElementById("profileAvatar"),
-  profileName: document.getElementById("profileName"),
-  profileRole: document.getElementById("profileRole"),
-  logoutBtn: document.getElementById("logoutBtn"),
-};
-
-function createSessionId() {
-  if (globalThis.crypto?.randomUUID) {
-    return "sess-" + globalThis.crypto.randomUUID();
-  }
-  return (
-    "sess-" + Math.random().toString(36).slice(2) + Date.now().toString(36)
-  );
-}
-
-function getOrCreateSessionId() {
-  const stored = localStorage.getItem("synchronSessionId");
-  if (stored?.startsWith("sess-")) return stored;
-  const sessionId = createSessionId();
-  localStorage.setItem("synchronSessionId", sessionId);
-  return sessionId;
-}
-
-function setAuthMessage(message = "", success = false) {
-  elements.authMessage.textContent = message;
-  elements.authMessage.classList.toggle("success", success);
-}
-
-function setAuthBusy(isBusy) {
-  elements.loginBtn.disabled = isBusy;
-  elements.registerBtn.disabled = isBusy;
-}
-
-function showLoginForm() {
-  elements.loginForm.hidden = false;
-  elements.registerForm.hidden = true;
-  elements.showRegisterBtn.hidden = !state.registrationEnabled;
-  setAuthMessage();
-  elements.loginEmail.focus();
-}
-
-function showRegisterForm() {
-  elements.loginForm.hidden = true;
-  elements.registerForm.hidden = false;
-  elements.showRegisterBtn.hidden = true;
-  setAuthMessage();
-  elements.registerName.focus();
-}
-
-async function readAuthSession() {
-  const response = await fetch("/api/auth/session", { cache: "no-store" });
-  if (!response.ok) {
-    throw new Error("Ð’Ñ…Ð¾Ð´ÑŠÑ‚ Ð²Ñ€ÐµÐ¼ÐµÐ½Ð½Ð¾ Ð½Ðµ Ðµ Ð´Ð¾ÑÑ‚ÑŠÐ¿ÐµÐ½.");
-  }
-  return response.json();
-}
-
-async function submitAuth(path, body) {
-  const response = await fetch(path, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  const data = await response.json().catch(() => null);
-  if (!response.ok) {
-    throw new Error(data?.error || "Ð’Ñ…Ð¾Ð´ÑŠÑ‚ Ð½Ðµ Ð±ÐµÑˆÐµ ÑƒÑÐ¿ÐµÑˆÐµÐ½.");
-  }
-  return data;
-}
-
-async function handleLogin(event) {
-  event.preventDefault();
-  setAuthBusy(true);
-  setAuthMessage();
-  try {
-    await submitAuth("/api/auth/login", {
-      email: elements.loginEmail.value,
-      password: elements.loginPassword.value,
-    });
-    elements.loginPassword.value = "";
-    const session = await readAuthSession();
-    if (!session.authenticated) throw new Error("Ð¡ÐµÑÐ¸ÑÑ‚Ð° Ð½Ðµ Ð±ÐµÑˆÐµ ÑÑŠÐ·Ð´Ð°Ð´ÐµÐ½Ð°.");
-    await startApplication(session.user);
-  } catch (error) {
-    setAuthMessage(error.message);
-  } finally {
-    setAuthBusy(false);
-  }
-}
-
-async function handleRegistration(event) {
-  event.preventDefault();
-  setAuthBusy(true);
-  setAuthMessage();
-  try {
-    const result = await submitAuth("/api/auth/register", {
-      displayName: elements.registerName.value,
-      email: elements.registerEmail.value,
-      password: elements.registerPassword.value,
-      inviteCode: elements.registerInviteCode.value,
-    });
-    elements.registerPassword.value = "";
-    elements.registerInviteCode.value = "";
-    if (result.confirmationRequired) {
-      showLoginForm();
-      elements.loginEmail.value = result.user?.email || "";
-      setAuthMessage(
-        "ÐŸÑ€Ð¾Ñ„Ð¸Ð»ÑŠÑ‚ Ðµ ÑÑŠÐ·Ð´Ð°Ð´ÐµÐ½. ÐŸÐ¾Ñ‚Ð²ÑŠÑ€Ð´Ð¸ Ð¸Ð¼ÐµÐ¹Ð»Ð° ÑÐ¸ Ð¸ Ð¿Ð¾ÑÐ»Ðµ Ð²Ð»ÐµÐ·.",
-        true,
-      );
-      return;
-    }
-    const session = await readAuthSession();
-    if (!session.authenticated) throw new Error("Ð¡ÐµÑÐ¸ÑÑ‚Ð° Ð½Ðµ Ð±ÐµÑˆÐµ ÑÑŠÐ·Ð´Ð°Ð´ÐµÐ½Ð°.");
-    await startApplication(session.user);
-  } catch (error) {
-    setAuthMessage(error.message);
-  } finally {
-    setAuthBusy(false);
-  }
-}
-
-async function handleLogout() {
-  elements.logoutBtn.disabled = true;
-  try {
-    await fetch("/api/auth/logout", { method: "POST" });
-  } finally {
-    globalThis.location.href = "/";
-  }
-}
-
-function applyAuthenticatedUser(user) {
-  state.authenticatedUser = user;
-  const displayName = user?.displayName || "ÐŸÐ¾Ñ‚Ñ€ÐµÐ±Ð¸Ñ‚ÐµÐ»";
-  const isOwner = user?.role === "owner";
-  elements.profileName.textContent = displayName;
-  elements.profileAvatar.textContent =
-    displayName.trim().charAt(0).toLocaleUpperCase("bg-BG") || "ÐŸ";
-  elements.profileRole.textContent = isOwner
-    ? "Ð¡Ð¾Ð±ÑÑ‚Ð²ÐµÐ½Ð¸Ðº Â· Ð½Ð°ÑÑ‚Ñ€Ð¾Ð¹ÐºÐ¸"
-    : "Ð¢ÐµÑÑ‚Ð¾Ð² Ð¿Ñ€Ð¾Ñ„Ð¸Ð»";
-  document.body.dataset.userRole = isOwner ? "owner" : "tester";
-  for (const item of document.querySelectorAll("[data-owner-only]")) {
-    item.hidden = !isOwner;
-  }
-}
-
-async function init() {
-  elements.loginForm.addEventListener("submit", handleLogin);
-  elements.registerForm.addEventListener("submit", handleRegistration);
-  elements.showRegisterBtn.addEventListener("click", showRegisterForm);
-  elements.backToLoginBtn.addEventListener("click", showLoginForm);
-
-  try {
-    const session = await readAuthSession();
-    state.registrationEnabled = Boolean(session.registrationEnabled);
-    elements.showRegisterBtn.hidden = !state.registrationEnabled;
-    if (session.authenticated) {
-      await startApplication(session.user);
-      return;
-    }
-    elements.authGate.hidden = false;
-    elements.appShell.hidden = true;
-    if (!session.configured) {
-      setAuthMessage(
-        "Ð’Ñ…Ð¾Ð´ÑŠÑ‚ Ð·Ð° Ñ‚ÐµÑÑ‚Ð¾Ð²Ð¸ Ð¿Ñ€Ð¾Ñ„Ð¸Ð»Ð¸ Ð¾Ñ‰Ðµ Ð½Ðµ Ðµ Ð°ÐºÑ‚Ð¸Ð²Ð¸Ñ€Ð°Ð½. Ð¡Ð¾Ð±ÑÑ‚Ð²ÐµÐ½Ð¸ÐºÑŠÑ‚ Ð¼Ð¾Ð¶Ðµ Ð´Ð° Ð²Ð»ÐµÐ·Ðµ Ñ GitHub.",
-      );
-    }
-  } catch (error) {
-    setAuthMessage(error.message);
-  }
-}
-
-async function startApplication(user) {
-  if (state.applicationStarted) return;
-  state.applicationStarted = true;
-  applyAuthenticatedUser(user);
-  elements.authGate.hidden = true;
-  elements.appShell.hidden = false;
-  updateSessionDisplay();
-
-  elements.sendBtn.addEventListener("click", sendMessage);
-  elements.attachBtn.addEventListener("click", () =>
-    elements.imageInput.click(),
-  );
-  elements.imageInput.addEventListener("change", handleImageSelection);
-  elements.removeAttachmentBtn.addEventListener("click", clearPendingImage);
-  elements.chatInput.addEventListener("keydown", (event) => {
-    if (event.key === "Enter" && !event.shiftKey) {
-      event.preventDefault();
-      sendMessage();
-    }
-  });
-  elements.newChatBtn.addEventListener("click", startNewChat);
-  elements.toggleStatusBtn.addEventListener("click", openStatus);
-  elements.closeContextBtn.addEventListener("click", closeStatus);
-  elements.chatMessages.addEventListener("click", handleMessageAction);
-  elements.conversationList.addEventListener("click", handleConversationClick);
-  elements.conversationSearch.addEventListener("input", renderConversationList);
-  elements.searchChatsBtn.addEventListener("click", toggleConversationSearch);
-  elements.mobileMenuBtn.addEventListener("click", toggleSidebar);
-  elements.sidebarBackdrop.addEventListener("click", closeSidebar);
-  elements.imagesBtn.addEventListener("click", openImagePicker);
-  elements.modulesBtn.addEventListener("click", openModulesDrawer);
-  elements.toolsBtn.addEventListener("click", openToolsDrawer);
-  elements.systemConfigurationBtn.addEventListener(
-    "click",
-    openSystemConfigurationDrawer,
-  );
-  elements.memoryBtn.addEventListener("click", openMemoryDrawer);
-  elements.permissionsBtn.addEventListener("click", openPermissionsDrawer);
-  elements.closeDataDrawerBtn.addEventListener("click", closeDataDrawer);
-  elements.drawerBackdrop.addEventListener("click", closeDataDrawer);
-  elements.dataDrawerBody.addEventListener("click", handleDataDrawerAction);
-  elements.voiceBtn.addEventListener("click", toggleVoiceInput);
-  elements.logoutBtn.addEventListener("click", handleLogout);
-  document.addEventListener("keydown", handleGlobalKeydown);
-  prepareVoiceInput();
-
-  checkHealth();
-  checkOpenSearch();
-  setInterval(checkHealth, 10000);
-  setInterval(checkOpenSearch, 20000);
-
-  await restoreConversation();
-  await loadConversations();
-}
-
-function updateSessionDisplay() {
-  elements.sessionIdDisplay.textContent = state.sessionId;
-}
-
-async function showWelcomeMessage() {
-  appendMessage(
-    "agent",
-    [
-      "## SYNCHRON-X",
-      "**Ð¢Ð²Ð¾ÑÑ‚Ð° Ð»Ð¸Ñ‡Ð½Ð° AI Ð¾Ð¿ÐµÑ€Ð°Ñ†Ð¸Ð¾Ð½Ð½Ð° ÑÐ¸ÑÑ‚ÐµÐ¼Ð°.**",
-      "",
-      "Ð•Ð´Ð½Ð¾ AI ÑÐ´Ñ€Ð¾, Ð¿Ð¾ÑÑ‚Ð¾ÑÐ½Ð½Ð° ÐºÐ¾Ð½Ñ‚Ñ€Ð¾Ð»Ð¸Ñ€Ð°Ð½Ð° Ð¿Ð°Ð¼ÐµÑ‚ Ð¸ Ñ€Ð°Ð·Ñ€ÐµÑˆÐµÐ½Ð¸ Ð¸Ð½ÑÑ‚Ñ€ÑƒÐ¼ÐµÐ½Ñ‚Ð¸ Ð·Ð° Ñ€ÐµÐ°Ð»Ð½Ð¸ Ð·Ð°Ð´Ð°Ñ‡Ð¸.",
-      "",
-      "AI Ð°Ð²Ð°Ñ‚Ð°Ñ€ÑŠÑ‚ Ðµ Ð¼Ð¾ÑÑ‚ Ð½Ð°Ñ‡Ð¸Ð½ Ð½Ð° Ð¾Ð±Ñ‰ÑƒÐ²Ð°Ð½Ðµ. Ð¢Ð¸ ÐºÐ¾Ð½Ñ‚Ñ€Ð¾Ð»Ð¸Ñ€Ð°Ñˆ Ð´Ð°Ð½Ð½Ð¸Ñ‚Ðµ, Ð¿Ð°Ð¼ÐµÑ‚Ñ‚Ð° Ð¸ Ñ€Ð¸ÑÐºÐ¾Ð²Ð¸Ñ‚Ðµ Ð´ÐµÐ¹ÑÑ‚Ð²Ð¸Ñ.",
-    ].join("\n"),
-  );
-}
-
-async function restoreConversation() {
-  try {
-    const response = await fetch(
-      "/memory/conversation/" + encodeURIComponent(state.sessionId),
-      { cache: "no-store" },
-    );
-    if (!response.ok) throw new Error("Ð˜ÑÑ‚Ð¾Ñ€Ð¸ÑÑ‚Ð° Ð½Ðµ Ðµ Ð´Ð¾ÑÑ‚ÑŠÐ¿Ð½Ð°.");
-    const data = await response.json();
-    markMemoryOperational();
-    const items = Array.isArray(data.items) ? data.items : [];
-    if (items.length === 0) {
-      await showWelcomeMessage();
-      return;
-    }
-    for (const item of items) {
-      if (
-        (item.role === "user" || item.role === "assistant") &&
-        typeof item.content === "string"
-      ) {
-        appendMessage(
-          item.role === "assistant" ? "agent" : "user",
-          item.content,
-        );
-      }
-    }
-    logAction("Ð’ÑŠÐ·ÑÑ‚Ð°Ð½Ð¾Ð²ÐµÐ½Ð° Ðµ Ð¸ÑÑ‚Ð¾Ñ€Ð¸ÑÑ‚Ð° Ð½Ð° Ñ€Ð°Ð·Ð³Ð¾Ð²Ð¾Ñ€Ð°");
-  } catch (error) {
-    console.error(error);
-    await showWelcomeMessage();
-    logAction("Ð˜ÑÑ‚Ð¾Ñ€Ð¸ÑÑ‚Ð° Ð½Ðµ Ð¼Ð¾Ð¶Ð° Ð´Ð° Ð±ÑŠÐ´Ðµ Ð²ÑŠÐ·ÑÑ‚Ð°Ð½Ð¾Ð²ÐµÐ½Ð°");
-  }
-}
-
-async function startNewChat() {
-  if (state.chatBusy) return;
-  closeSidebar();
-  clearPendingImage();
-  state.sessionId = createSessionId();
-  localStorage.setItem("synchronSessionId", state.sessionId);
-  state.lastActions = [];
-  elements.chatMessages.replaceChildren();
-  updateSessionDisplay();
-  renderActionsLog();
-  await showWelcomeMessage();
-  logAction("Ð—Ð°Ð¿Ð¾Ñ‡Ð½Ð°Ñ‚ Ðµ Ð½Ð¾Ð² Ñ€Ð°Ð·Ð³Ð¾Ð²Ð¾Ñ€");
-  renderConversationList();
-  elements.chatInput.focus();
-}
-
-async function loadConversations() {
-  try {
-    const response = await fetch("/memory/conversations", {
-      cache: "no-store",
-    });
-    if (!response.ok) throw new Error("Ð¡Ð¿Ð¸ÑÑŠÐºÑŠÑ‚ Ð½Ðµ Ðµ Ð´Ð¾ÑÑ‚ÑŠÐ¿ÐµÐ½.");
-    const data = await response.json();
-    state.conversations = Array.isArray(data.items) ? data.items : [];
-    state.conversationLoadError = "";
-    renderConversationList();
-  } catch (error) {
-    console.error(error);
-    state.conversations = [];
-    state.conversationLoadError =
-      "Ð˜ÑÑ‚Ð¾Ñ€Ð¸ÑÑ‚Ð° Ð²Ñ€ÐµÐ¼ÐµÐ½Ð½Ð¾ Ð½Ðµ Ðµ Ð´Ð¾ÑÑ‚ÑŠÐ¿Ð½Ð°. ÐžÐ¿Ð¸Ñ‚Ð°Ð¹ Ð¾Ñ‚Ð½Ð¾Ð²Ð¾.";
-    renderConversationList();
-  }
-}
-
-function renderConversationList() {
-  const query = elements.conversationSearch.value
-    .trim()
-    .toLocaleLowerCase("bg-BG");
-  const conversations = state.conversations.filter(
-    (item) => !query || item.title.toLocaleLowerCase("bg-BG").includes(query),
-  );
-  elements.conversationList.replaceChildren();
-
-  if (state.conversationLoadError) {
-    const error = document.createElement("p");
-    error.className = "conversation-state conversation-state-error";
-    error.textContent = state.conversationLoadError;
-    elements.conversationList.appendChild(error);
-    return;
-  }
-
-  if (conversations.length === 0) {
-    const empty = document.createElement("p");
-    empty.className = "conversation-state";
-    empty.textContent = query
-      ? "ÐÑÐ¼Ð° Ð½Ð°Ð¼ÐµÑ€ÐµÐ½Ð¸ Ñ€Ð°Ð·Ð³Ð¾Ð²Ð¾Ñ€Ð¸."
-      : "Ð’ÑÐµ Ð¾Ñ‰Ðµ Ð½ÑÐ¼Ð° Ð·Ð°Ð¿Ð°Ð·ÐµÐ½Ð¸ Ñ€Ð°Ð·Ð³Ð¾Ð²Ð¾Ñ€Ð¸.";
-    elements.conversationList.appendChild(empty);
-    return;
-  }
-
-  for (const item of conversations) {
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = "conversation";
-    if (item.sessionId === state.sessionId) button.classList.add("active");
-    button.dataset.sessionId = item.sessionId;
-    button.textContent = item.title;
-    elements.conversationList.appendChild(button);
-  }
-}
-
-async function handleConversationClick(event) {
-  const button = event.target.closest("button[data-session-id]");
-  if (!button || state.chatBusy || button.dataset.sessionId === state.sessionId)
-    return;
-  state.sessionId = button.dataset.sessionId;
-  localStorage.setItem("synchronSessionId", state.sessionId);
-  elements.chatMessages.replaceChildren();
-  updateSessionDisplay();
-  renderConversationList();
-  await restoreConversation();
-  closeSidebar();
-}
-
-function toggleSidebar() {
-  const isOpen = elements.sidebar.classList.toggle("mobile-visible");
-  elements.sidebarBackdrop.hidden = !isOpen;
-  elements.mobileMenuBtn.setAttribute("aria-expanded", String(isOpen));
-}
-
-function closeSidebar() {
-  elements.sidebar.classList.remove("mobile-visible");
-  elements.sidebarBackdrop.hidden = true;
-  elements.mobileMenuBtn.setAttribute("aria-expanded", "false");
-}
-
-function openImagePicker() {
-  closeSidebar();
-  elements.imageInput.click();
-}
-
-function handleGlobalKeydown(event) {
-  if (event.key !== "Escape") return;
-  closeSidebar();
-  closeStatus();
-  closeDataDrawer();
-}
-
-function toggleConversationSearch() {
-  elements.conversationSearch.hidden = false;
-  elements.conversationList
-    .closest(".sidebar-section")
-    ?.scrollIntoView({ block: "start", behavior: "smooth" });
-  elements.conversationSearch.focus({ preventScroll: true });
-}
-
-function handleImageSelection(event) {
-  const file = event.target.files?.[0];
-  if (!file) return;
-
-  const allowedTypes = ["image/jpeg", "image/png", "image/webp"];
-  if (!allowedTypes.includes(file.type)) {
-    appendMessage("agent", "âŒ ÐŸÐ¾Ð´Ð´ÑŠÑ€Ð¶Ð°Ñ‚ ÑÐµ ÑÐ°Ð¼Ð¾ JPEG, PNG Ð¸ WebP ÑÐ½Ð¸Ð¼ÐºÐ¸.");
-    clearPendingImage();
-    return;
-  }
-
-  if (file.size > 5 * 1024 * 1024) {
-    appendMessage("agent", "âŒ Ð¡Ð½Ð¸Ð¼ÐºÐ°Ñ‚Ð° Ñ‚Ñ€ÑÐ±Ð²Ð° Ð´Ð° Ð±ÑŠÐ´Ðµ Ð´Ð¾ 5 MB.");
-    clearPendingImage();
-    return;
-  }
-
-  const reader = new FileReader();
-  reader.onload = () => {
-    state.pendingImage = {
-      dataUrl: reader.result,
-      mimeType: file.type,
-      name: file.name,
-    };
-    elements.attachmentImage.src = reader.result;
-    elements.attachmentName.textContent = file.name;
-    elements.attachmentPreview.hidden = false;
-    elements.chatInput.focus();
-  };
-  reader.onerror = () => {
-    appendMessage("agent", "âŒ Ð¡Ð½Ð¸Ð¼ÐºÐ°Ñ‚Ð° Ð½Ðµ Ð¼Ð¾Ð¶Ð° Ð´Ð° Ð±ÑŠÐ´Ðµ Ð¿Ñ€Ð¾Ñ‡ÐµÑ‚ÐµÐ½Ð°.");
-    clearPendingImage();
-  };
-  reader.readAsDataURL(file);
-}
-
-function clearPendingImage() {
-  state.pendingImage = null;
-  elements.imageInput.value = "";
-  elements.attachmentImage.removeAttribute("src");
-  elements.attachmentName.textContent = "";
-  elements.attachmentPreview.hidden = true;
-}
-
-function openStatus() {
-  closeSidebar();
-  elements.statusPanel.classList.add("mobile-visible");
-}
-
-function closeStatus() {
-  elements.statusPanel.classList.remove("mobile-visible");
-}
-
-function prepareVoiceInput() {
-  const SpeechRecognition =
-    window.SpeechRecognition || window.webkitSpeechRecognition;
-  if (!SpeechRecognition) {
-    elements.voiceBtn.hidden = true;
-    return;
-  }
-
-  const recognition = new SpeechRecognition();
-  recognition.lang = "bg-BG";
-  recognition.continuous = false;
-  recognition.interimResults = true;
-
-  recognition.onstart = () => setListening(true);
-  recognition.onend = () => setListening(false);
-  recognition.onerror = (event) => {
-    setListening(false);
-    if (event.error !== "aborted" && event.error !== "no-speech") {
-      appendMessage(
-        "agent",
-        "Ð“Ð»Ð°ÑÐ¾Ð²Ð¾Ñ‚Ð¾ Ð²ÑŠÐ²ÐµÐ¶Ð´Ð°Ð½Ðµ Ð½Ðµ Ð¼Ð¾Ð¶Ð° Ð´Ð° ÑÑ‚Ð°Ñ€Ñ‚Ð¸Ñ€Ð°. ÐŸÑ€Ð¾Ð²ÐµÑ€Ð¸ Ð´Ð¾ÑÑ‚ÑŠÐ¿Ð° Ð´Ð¾ Ð¼Ð¸ÐºÑ€Ð¾Ñ„Ð¾Ð½Ð°.",
-      );
-    }
-  };
-  recognition.onresult = (event) => {
-    let transcript = "";
-    for (
-      let index = event.resultIndex;
-      index < event.results.length;
-      index += 1
-    ) {
-      transcript += event.results[index][0].transcript;
-    }
-    elements.chatInput.value = transcript.trim();
-    const lastResult = event.results[event.results.length - 1];
-    if (lastResult?.isFinal) elements.chatInput.focus();
-  };
-  state.recognition = recognition;
-}
-
-function setListening(isListening) {
-  state.listening = isListening;
-  elements.voiceBtn.classList.toggle("listening", isListening);
-  elements.voiceBtn.setAttribute("aria-pressed", String(isListening));
-  elements.voiceBtn.title = isListening
-    ? "Ð¡Ð¿Ñ€Ð¸ ÑÐ»ÑƒÑˆÐ°Ð½ÐµÑ‚Ð¾"
-    : "Ð“Ð»Ð°ÑÐ¾Ð²Ð¾ Ð²ÑŠÐ²ÐµÐ¶Ð´Ð°Ð½Ðµ";
-}
-
-function toggleVoiceInput() {
-  if (!state.recognition || state.chatBusy) return;
-  if (state.listening) {
-    state.recognition.stop();
-  } else {
-    state.recognition.start();
-  }
-}
-
-function openModulesDrawer() {
-  openDataDrawer("Ð Ð°Ð±Ð¾Ñ‚Ð½Ð¸ Ð¾Ð±Ð»Ð°ÑÑ‚Ð¸");
-  elements.dataDrawerBody.innerHTML = `
-        <div class="module-summary">
-            Ð¢Ð¾Ð²Ð° ÑÐ° Ð¾Ð±Ð»Ð°ÑÑ‚Ð¸, Ð² ÐºÐ¾Ð¸Ñ‚Ð¾ Ð»Ð¸Ñ‡Ð½Ð°Ñ‚Ð° AI Ð¾Ð¿ÐµÑ€Ð°Ñ†Ð¸Ð¾Ð½Ð½Ð° ÑÐ¸ÑÑ‚ÐµÐ¼Ð° Ð¸Ð·Ð¿Ð¾Ð»Ð·Ð²Ð° Ñ€Ð°Ð·Ð³Ð¾Ð²Ð¾Ñ€Ð°,
-            Ð¿Ð°Ð¼ÐµÑ‚Ñ‚Ð° Ð¸ Ñ€Ð°Ð·Ñ€ÐµÑˆÐµÐ½Ð¸Ñ‚Ðµ Ð¸Ð½ÑÑ‚Ñ€ÑƒÐ¼ÐµÐ½Ñ‚Ð¸. ÐžÐ±Ð»Ð°ÑÑ‚Ñ‚Ð° ÑÐ°Ð¼Ð° Ð¿Ð¾ ÑÐµÐ±Ðµ ÑÐ¸ Ð½Ðµ
-            Ð¾Ð·Ð½Ð°Ñ‡Ð°Ð²Ð°, Ñ‡Ðµ Ð²ÑŠÐ½ÑˆÐ½Ð° ÑƒÑÐ»ÑƒÐ³Ð° Ðµ ÑÐ²ÑŠÑ€Ð·Ð°Ð½Ð°.
-        </div>
-        <section class="drawer-section permission-list module-list" data-module-list></section>`;
-  document.dispatchEvent(new CustomEvent("synchron:modules-opened"));
-}
-
-function isGoogleTool(tool) {
-  return (
-    tool?.provider === "google" ||
-    tool?.id?.startsWith("google-") ||
-    tool?.id === "gmail-read"
-  );
-}
-
-function toolState(tool, googleConnected, githubConnected) {
-  if (!tool.enabled || !tool.executable) {
-    return { label: "ÐÐµ Ðµ ÑÐ²ÑŠÑ€Ð·Ð°Ð½", className: "deny" };
-  }
-  if (!tool.configured) {
-    return { label: "ÐÐµ Ðµ ÐºÐ¾Ð½Ñ„Ð¸Ð³ÑƒÑ€Ð¸Ñ€Ð°Ð½", className: "deny" };
-  }
-  if (isGoogleTool(tool) && !googleConnected) {
-    return { label: "Ð˜ÑÐºÐ° ÑÐ²ÑŠÑ€Ð·Ð²Ð°Ð½Ðµ", className: "confirm" };
-  }
-  if (tool.id === "github-write" && !githubConnected) {
-    return { label: "Ð˜ÑÐºÐ° ÑÐ²ÑŠÑ€Ð·Ð²Ð°Ð½Ðµ", className: "confirm" };
-  }
-  return { label: "Ð Ð°Ð±Ð¾Ñ‚Ð¸", className: "allow" };
-}
-
-function toolStatusActions(tool, status, googleConnected, githubConnected) {
-  let action = "";
-  if (isGoogleTool(tool) && !googleConnected && tool.configured) {
-    action =
-      '<button type="button" class="tool-connect-btn" data-connect-service="google">Ð¡Ð²ÑŠÑ€Ð¶Ð¸ Google</button>';
-  } else if (
-    tool.id === "github-write" &&
-    tool.configured &&
-    !githubConnected
-  ) {
-    action =
-      '<button type="button" class="tool-connect-btn" data-connect-service="github">Ð¡Ð²ÑŠÑ€Ð¶Ð¸ GitHub</button>';
-  } else if (tool.id === "github-write" && !tool.configured) {
-    action =
-      '<button type="button" class="tool-connect-btn" data-github-setup>ÐÐ°ÑÑ‚Ñ€Ð¾Ð¹ GitHub</button>';
-  }
-
-  return `
-    <div class="tool-status-actions">
-      <span class="permission-badge ${status.className}">${status.label}</span>
-      ${action}
-    </div>`;
-}
-
-function permissionAction(item, toolMap, googleConnected, githubConnected) {
-  const googlePermissions = new Set([
-    "calendar.read",
-    "calendar.write",
-    "drive.read",
-    "mail.read",
-  ]);
-  if (googlePermissions.has(item.action) && !googleConnected) {
-    return '<button type="button" class="tool-connect-btn" data-connect-service="google">Ð¡Ð²ÑŠÑ€Ð¶Ð¸ Google</button>';
-  }
-
-  const githubWrite = toolMap.get("github-write");
-  if (
-    item.action === "github.write" &&
-    githubWrite?.configured &&
-    githubWrite?.executable &&
-    !githubConnected
-  ) {
-    return '<button type="button" class="tool-connect-btn" data-connect-service="github">Ð¡Ð²ÑŠÑ€Ð¶Ð¸ GitHub</button>';
-  }
-  if (
-    item.action === "github.write" &&
-    (!githubWrite?.configured || !githubWrite?.executable)
-  ) {
-    return '<button type="button" class="tool-connect-btn" data-github-setup>ÐÐ°ÑÑ‚Ñ€Ð¾Ð¹ GitHub</button>';
-  }
-
-  if (item.decision === "confirm") {
-    return `<button type="button" class="permission-info-btn" data-permission-info="${escapeHtml(item.action)}">ÐšÐ°Ðº Ñ€Ð°Ð±Ð¾Ñ‚Ð¸</button>`;
-  }
-  return "";
-}
-
-async function openToolsDrawer() {
-  openDataDrawer("Ð˜Ð½ÑÑ‚Ñ€ÑƒÐ¼ÐµÐ½Ñ‚Ð¸");
-  renderDrawerLoading();
-  try {
-    const [healthResponse, googleResponse, githubResponse] = await Promise.all([
-      fetch("/health/integrations", { cache: "no-store" }),
-      fetch("/api/google/status", { cache: "no-store" }).catch(() => null),
-      fetch("/api/github/status", { cache: "no-store" }).catch(() => null),
-    ]);
-    if (!healthResponse.ok) {
-      throw new Error("Ð¡ÑŠÑÑ‚Ð¾ÑÐ½Ð¸ÐµÑ‚Ð¾ Ð½Ð° Ð¸Ð½ÑÑ‚Ñ€ÑƒÐ¼ÐµÐ½Ñ‚Ð¸Ñ‚Ðµ Ð½Ðµ Ðµ Ð´Ð¾ÑÑ‚ÑŠÐ¿Ð½Ð¾.");
-    }
-    const data = await healthResponse.json();
-    const googleData = googleResponse?.ok
-      ? await googleResponse.json().catch(() => ({}))
-      : {};
-    const githubData = githubResponse?.ok
-      ? await githubResponse.json().catch(() => ({}))
-      : {};
-    const tools = Array.isArray(data.tools) ? data.tools : [];
-    const descriptions = {
-      "github-read": "ÐŸÑ€Ð¾Ð²ÐµÑ€ÑÐ²Ð° commit-Ð¸ Ð¸ Ñ„Ð°Ð¹Ð»Ð¾Ð²Ðµ. Ð¡Ð°Ð¼Ð¾ Ð·Ð° Ñ‡ÐµÑ‚ÐµÐ½Ðµ.",
-      "github-write":
-        "Copilot Ð¼Ð¾ÑÑ‚: Ð¾Ñ‚Ð´ÐµÐ»ÐµÐ½ ÐºÐ»Ð¾Ð½, commit-Ð¸ Ð¸ Pull Request ÑÐ»ÐµÐ´ Ñ‚Ð¾Ñ‡Ð½Ð¾ Ð¿Ð¾Ñ‚Ð²ÑŠÑ€Ð¶Ð´ÐµÐ½Ð¸Ðµ. Ð‘ÐµÐ· Ð°Ð²Ñ‚Ð¾Ð¼Ð°Ñ‚Ð¸Ñ‡Ð½Ð¾ ÑÐ»Ð¸Ð²Ð°Ð½Ðµ.",
-      "google-drive-read": "Ð§ÐµÑ‚Ðµ Ñ€Ð°Ð·Ñ€ÐµÑˆÐµÐ½Ð¸ Ñ„Ð°Ð¹Ð»Ð¾Ð²Ðµ Ð¾Ñ‚ Google Drive.",
-      "google-calendar-read": "ÐŸÐ¾ÐºÐ°Ð·Ð²Ð° ÑÑŠÐ±Ð¸Ñ‚Ð¸Ñ Ð¾Ñ‚ Google Calendar.",
-      "gmail-read": "ÐŸÐ¾ÐºÐ°Ð·Ð²Ð° Ñ€Ð°Ð·Ñ€ÐµÑˆÐµÐ½Ð¸ Ð¸Ð¼ÐµÐ¹Ð»Ð¸. ÐÐµ Ð¸Ð·Ð¿Ñ€Ð°Ñ‰Ð°.",
-      "openai-web-search": "Ð¢ÑŠÑ€ÑÐ¸ Ð°ÐºÑ‚ÑƒÐ°Ð»Ð½Ð° Ð¸Ð½Ñ„Ð¾Ñ€Ð¼Ð°Ñ†Ð¸Ñ Ð² Ð¸Ð½Ñ‚ÐµÑ€Ð½ÐµÑ‚.",
-      "opensearch-memory": "ÐŸÐ°Ð·Ð¸ Ð»Ð¸Ñ‡Ð½Ð° Ð¸ Ð¿Ñ€Ð¾ÐµÐºÑ‚Ð½Ð° Ð¿Ð°Ð¼ÐµÑ‚ Ð¿Ð¾Ð´ Ñ‚Ð²Ð¾Ð¹ ÐºÐ¾Ð½Ñ‚Ñ€Ð¾Ð».",
-      "synchron-system-inspector":
-        "ÐŸÑ€Ð¾Ð²ÐµÑ€ÑÐ²Ð° ÑÐ´Ñ€Ð¾Ñ‚Ð¾ Ð¸ Ð²ÑÐ¸Ñ‡ÐºÐ¸ runtime/DigitalOcean Ð½Ð°ÑÑ‚Ñ€Ð¾Ð¹ÐºÐ¸ Ð±ÐµÐ· Ñ‚ÐµÑ…Ð½Ð¸Ñ‚Ðµ ÑÑ‚Ð¾Ð¹Ð½Ð¾ÑÑ‚Ð¸.",
-    };
-    elements.dataDrawerBody.innerHTML = `
-      <div class="permission-default">
-        ÐŸÐ¾ÐºÐ°Ð·Ð°Ð½Ð¾ Ðµ Ñ€ÐµÐ°Ð»Ð½Ð¾Ñ‚Ð¾ ÑÑŠÑÑ‚Ð¾ÑÐ½Ð¸Ðµ. â€žÐ ÐµÐ³Ð¸ÑÑ‚Ñ€Ð¸Ñ€Ð°Ð½â€œ Ð½Ðµ Ð¾Ð·Ð½Ð°Ñ‡Ð°Ð²Ð° Ð°Ð²Ñ‚Ð¾Ð¼Ð°Ñ‚Ð¸Ñ‡Ð½Ð¾ â€žÑ€Ð°Ð±Ð¾Ñ‚Ð¸â€œ.
-      </div>
-      <section class="drawer-section permission-list">
-        <button type="button" class="permission-card tool-status-card system-control-link" data-system-configuration>
-          <div>
-            <strong>Ð¡Ð¸ÑÑ‚ÐµÐ¼ÐµÐ½ ÐºÐ¾Ð½Ñ‚Ñ€Ð¾Ð»</strong>
-            <p>Ð¯Ð´Ñ€Ð¾, Ð¸Ð½ÑÑ‚Ñ€ÑƒÐ¼ÐµÐ½Ñ‚Ð¸ Ð¸ Ð²ÑÐ¸Ñ‡ÐºÐ¸ Ð¿Ñ€Ð¾Ð¼ÐµÐ½Ð»Ð¸Ð²Ð¸ Ð±ÐµÐ· Ð¿Ð¾ÐºÐ°Ð·Ð²Ð°Ð½Ðµ Ð½Ð° Ñ‚Ð°Ð¹Ð½Ð¸Ñ‚Ðµ Ð¸Ð¼ ÑÑ‚Ð¾Ð¹Ð½Ð¾ÑÑ‚Ð¸.</p>
-          </div>
-          <span class="permission-badge allow">ÐžÑ‚Ð²Ð¾Ñ€Ð¸</span>
-        </button>
-        <article class="permission-card tool-status-card">
-          <div><strong>Ð¡Ð½Ð¸Ð¼ÐºÐ¸</strong><p>JPEG, PNG Ð¸ WebP Ð´Ð¾ 5 MB.</p></div>
-          <span class="permission-badge allow">Ð Ð°Ð±Ð¾Ñ‚Ð¸</span>
-        </article>
-        ${tools
-          .map((tool) => {
-            const status = toolState(
-              tool,
-              Boolean(googleData.connected),
-              Boolean(githubData.connected),
-            );
-            return `
-              <article class="permission-card tool-status-card">
-                <div>
-                  <strong>${escapeHtml(tool.name)}</strong>
-                  <p>${escapeHtml(descriptions[tool.id] || "Ð˜Ð½ÑÑ‚Ñ€ÑƒÐ¼ÐµÐ½Ñ‚ Ð½Ð° SYNCHRON-X.")}</p>
-                </div>
-                ${toolStatusActions(
-                  tool,
-                  status,
-                  Boolean(googleData.connected),
-                  Boolean(githubData.connected),
-                )}
-              </article>`;
-          })
-          .join("")}
-      </section>`;
-  } catch (error) {
-    renderDrawerError(error.message);
-  }
-}
-
-function configurationStatus(item) {
-  const labels = {
-    configured: ["ÐÐ°ÑÑ‚Ñ€Ð¾ÐµÐ½Ð°", "allow"],
-    defaulted: ["ÐŸÐ¾ Ð¿Ð¾Ð´Ñ€Ð°Ð·Ð±Ð¸Ñ€Ð°Ð½Ðµ", "allow"],
-    "missing-required": ["Ð›Ð¸Ð¿ÑÐ²Ð°", "deny"],
-    "optional-missing": ["ÐÐµÐ·Ð°Ð´ÑŠÐ»Ð¶Ð¸Ñ‚ÐµÐ»Ð½Ð°", "confirm"],
-    compatibility: ["Ð¡Ñ‚Ð°Ñ€ Ñ€ÐµÐ·ÐµÑ€Ð²ÐµÐ½ Ð¿ÑŠÑ‚", "confirm"],
-    "not-needed": ["ÐÐµ Ðµ Ð½ÑƒÐ¶Ð½Ð°", "allow"],
-    unused: ["ÐÐµ ÑÐµ Ð¸Ð·Ð¿Ð¾Ð»Ð·Ð²Ð°", "deny"],
-  };
-  const [label, className] = labels[item.status] || [item.status, "confirm"];
-  return { label, className };
-}
-
-function renderEnvironmentGroup(area, items) {
-  return `
-    <details class="configuration-group" ${items.some((item) => item.status === "missing-required") ? "open" : ""}>
-      <summary>${escapeHtml(area)} <span>${items.length}</span></summary>
-      <div class="configuration-list">
-        ${items
-          .map((item) => {
-            const status = configurationStatus(item);
-            return `
-              <article class="configuration-item">
-                <div>
-                  <code>${escapeHtml(item.key)}</code>
-                  <p>${escapeHtml(item.purpose)}</p>
-                  <small>
-                    ${item.sensitivity === "secret" ? "Ð¢Ð°Ð¹Ð½Ð° ÑÑ‚Ð¾Ð¹Ð½Ð¾ÑÑ‚ Â· Ð½Ð¸ÐºÐ¾Ð³Ð° Ð½Ðµ ÑÐµ Ð¿Ð¾ÐºÐ°Ð·Ð²Ð°" : "ÐžÐ±Ñ‰Ð° Ð½Ð°ÑÑ‚Ñ€Ð¾Ð¹ÐºÐ°"}
-                    Â· DigitalOcean: ${item.digitalOceanDeclared ? "Ð´ÐµÐºÐ»Ð°Ñ€Ð¸Ñ€Ð°Ð½Ð°" : "Ð½Ðµ Ðµ Ð´ÐµÐºÐ»Ð°Ñ€Ð¸Ñ€Ð°Ð½Ð°"}
-                  </small>
-                </div>
-                <span class="permission-badge ${status.className}">${status.label}</span>
-              </article>`;
-          })
-          .join("")}
-      </div>
-    </details>`;
-}
-
-async function openSystemConfigurationDrawer() {
-  openDataDrawer("Ð¡Ð¸ÑÑ‚ÐµÐ¼ÐµÐ½ ÐºÐ¾Ð½Ñ‚Ñ€Ð¾Ð»");
-  renderDrawerLoading();
-  try {
-    const [configurationResponse, integrationsResponse, readinessResponse] =
-      await Promise.all([
-        fetch("/api/system/configuration", { cache: "no-store" }),
-        fetch("/health/integrations", { cache: "no-store" }),
-        fetch("/health/ready", { cache: "no-store" }),
-      ]);
-    if (!configurationResponse.ok || !integrationsResponse.ok) {
-      throw new Error("Ð¡Ð¸ÑÑ‚ÐµÐ¼Ð½Ð°Ñ‚Ð° Ð¿Ñ€Ð¾Ð²ÐµÑ€ÐºÐ° Ð²Ñ€ÐµÐ¼ÐµÐ½Ð½Ð¾ Ð½Ðµ Ðµ Ð´Ð¾ÑÑ‚ÑŠÐ¿Ð½Ð°.");
-    }
-    const configuration = await configurationResponse.json();
-    const integrations = await integrationsResponse.json();
+YªçŠx-®éÜj×¢ëiºÚ+Š§j[h‘éÜ¢éíÛMwÑ:-jZ.¶›­–)Þ³V6öç7B7FFRÒ°¢6W76–öä–C¢vWD÷$7&VFU6W76–öä–B‚’À¢6W'fW$öæÆ–æS¢fÇ6RÀ¢÷Vç6V&6…7FGW3¢'Væ¶æ÷vâ"À¢÷Vç6V&6„f–ÇW&W3¢À¢Æ7DÖVÖ÷'•7V66W74C¢À¢Æ7D7F–öç3¢µÒÀ¢6†D'W7“¢fÇ6RÀ¢7V¶–æt'WGFöã¢çVÆÂÀ¢VæF–æt–ÖvS¢çVÆÂÀ¢6öçfW'6F–öç3¢µÒÀ¢6öçfW'6F–öäÆöDW'&÷#¢""À¢ÖVÖ÷'”—FV×3¢µÒÀ¢&V6övæ—F–öã¢çVÆÂÀ¢Æ—7FVæ–æs¢fÇ6RÀ¢WF†VçF–6FVEW6W#¢çVÆÂÀ¢&Vv—7G&F–öäVæ&ÆVC¢fÇ6RÀ¢Æ–6F–öå7F'FVC¢fÇ6RÀ§Ó° ¦6öç7BVÆVÖVçG2Ò°¢WF„vFS¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&WF„vFR"’À¢6†VÆÃ¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&6†VÆÂ"’À¢Æöv–äf÷&Ó¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&Æöv–äf÷&Ò"’À¢Æöv–äVÖ–Ã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&Æöv–äVÖ–Â"’À¢Æöv–å77v÷&C¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&Æöv–å77v÷&B"’À¢Æöv–ä'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&Æöv–ä'Fâ"’À¢6†÷u&Vv—7FW$'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'6†÷u&Vv—7FW$'Fâ"’À¢&Vv—7FW$f÷&Ó¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'&Vv—7FW$f÷&Ò"’À¢&Vv—7FW$æÖS¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'&Vv—7FW$æÖR"’À¢&Vv—7FW$VÖ–Ã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'&Vv—7FW$VÖ–Â"’À¢&Vv—7FW%77v÷&C¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'&Vv—7FW%77v÷&B"’À¢&Vv—7FW$–çf—FT6öFS¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'&Vv—7FW$–çf—FT6öFR"’À¢&Vv—7FW$'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'&Vv—7FW$'Fâ"’À¢&6µFôÆöv–ä'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&&6µFôÆöv–ä'Fâ"’À¢WF„ÖW76vS¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&WF„ÖW76vR"’À¢6†DÖW76vW3¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&6†DÖW76vW2"’À¢6†D–çWC¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&6†D–çWB"’À¢6VæD'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'6VæD'Fâ"’À¢GF6„'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&GF6„'Fâ"’À¢–ÖvT–çWC¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&–ÖvT–çWB"’À¢GF6†ÖVçE&Wf–Ws¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&GF6†ÖVçE&Wf–Wr"’À¢GF6†ÖVçD–ÖvS¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&GF6†ÖVçD–ÖvR"’À¢GF6†ÖVçDæÖS¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&GF6†ÖVçDæÖR"’À¢&VÖ÷fTGF6†ÖVçD'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'&VÖ÷fTGF6†ÖVçD'Fâ"’À¢æWt6†D'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&æWt6†D'Fâ"’À¢FövvÆU7FGW4'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'FövvÆU7FGW4'Fâ"’À¢6Æ÷6T6öçFW‡D'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&6Æ÷6T6öçFW‡D'Fâ"’À¢7FGW5æVÃ¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'7FGW5æVÂ"’À¢vVçE7FGW4F÷C¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&vVçE7FGW4F÷B"’À¢vVçE7FGW5FW‡C¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&vVçE7FGW5FW‡B"’À¢6W76–öä–DF—7Æ“¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'6W76–öä–DF—7Æ’"’À¢6W'fW%7FGW4F—7Æ“¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'6W'fW%7FGW4F—7Æ’"’À¢÷Vç6V&6…7FGW4F—7Æ“¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&÷Vç6V&6…7FGW4F—7Æ’"’À¢7F–öç4Æös¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&7F–öç4Æör"’À¢6öçfW'6F–öäÆ—7C¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&6öçfW'6F–öäÆ—7B"’À¢6öçfW'6F–öå6V&6ƒ¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&6öçfW'6F–öå6V&6‚"’À¢6V&6„6†G4'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'6V&6„6†G4'Fâ"’À¢Öö&–ÆTÖVçT'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&Öö&–ÆTÖVçT'Fâ"’À¢6–FV&#¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'6–FV&""’À¢6–FV&$&6¶G&÷¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'6–FV&$&6¶G&÷"’À¢–ÖvW4'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&–ÖvW4'Fâ"’À¢ÖöGVÆW4'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&ÖöGVÆW4'Fâ"’À¢7—7FVÔ6öæf–wW&F–öä'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'7—7FVÔ6öæf–wW&F–öä'Fâ"’À¢fö7W4'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&fö7W4'Fâ"’À¢FööÇ4'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'FööÇ4'Fâ"’À¢ÖVÖ÷'”'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&ÖVÖ÷'”'Fâ"’À¢W&Ö—76–öç4'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'W&Ö—76–öç4'Fâ"’À¢FFG&vW#¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&FFG&vW""’À¢FFG&vW%F—FÆS¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&FFG&vW%F—FÆR"’À¢FFG&vW$&öG“¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&FFG&vW$&öG’"’À¢G&vW$&6¶G&÷¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&G&vW$&6¶G&÷"’À¢6Æ÷6TFFG&vW$'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&6Æ÷6TFFG&vW$'Fâ"’À¢fö–6T'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'fö–6T'Fâ"’À¢&öf–ÆTfF#¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'&öf–ÆTfF""’À¢&öf–ÆTæÖS¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'&öf–ÆTæÖR"’À¢&öf–ÆU&öÆS¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚'&öf–ÆU&öÆR"’À¢Æöv÷WD'Fã¢Fö7VÖVçBævWDVÆVÖVçD'”–B‚&Æöv÷WD'Fâ"’À§Ó° ¦gVæ7F–öâ7&VFU6W76–öä–B‚’°¢–b†vÆö&ÅF†—2æ7'—Fóòç&æFöÕUT”B’°¢&WGW&â'6W72Ò"²vÆö&ÅF†—2æ7'—Fòç&æFöÕUT”B‚“°¢Ð¢&WGW&â€¢'6W72Ò"²ÖF‚ç&æFöÒ‚’çFõ7G&–ærƒ3b’ç6Æ–6Rƒ"’²FFRææ÷r‚’çFõ7G&–ærƒ3b¢“°§Ð ¦gVæ7F–öâvWD÷$7&VFU6W76–öä–B‚’°¢6öç7B7F÷&VBÒÆö6Å7F÷&vRævWD—FVÒ‚'7–æ6‡&öå6W76–öä–B"“°¢–b‡7F÷&VCòç7F'G5v—F‚‚'6W72Ò"’’&WGW&â7F÷&VC°¢6öç7B6W76–öä–BÒ7&VFU6W76–öä–B‚“°¢Æö6Å7F÷&vRç6WD—FVÒ‚'7–æ6‡&öå6W76–öä–B"Â6W76–öä–B“°¢&WGW&â6W76–öä–C°§Ð ¦gVæ7F–öâ6WDWF„ÖW76vR†ÖW76vRÒ""Â7V66W72ÒfÇ6R’°¢VÆVÖVçG2æWF„ÖW76vRçFW‡D6öçFVçBÒÖW76vS°¢VÆVÖVçG2æWF„ÖW76vRæ6Æ74Æ—7BçFövvÆR‚'7V66W72"Â7V66W72“°§Ð ¦gVæ7F–öâ6WDWF„'W7’†—4'W7’’°¢VÆVÖVçG2æÆöv–ä'FâæF—6&ÆVBÒ—4'W7“°¢VÆVÖVçG2ç&Vv—7FW$'FâæF—6&ÆVBÒ—4'W7“°§Ð ¦gVæ7F–öâ6†÷tÆöv–äf÷&Ò‚’°¢VÆVÖVçG2æÆöv–äf÷&Òæ†–FFVâÒfÇ6S°¢VÆVÖVçG2ç&Vv—7FW$f÷&Òæ†–FFVâÒG'VS°¢VÆVÖVçG2ç6†÷u&Vv—7FW$'Fâæ†–FFVâÒ7FFRç&Vv—7G&F–öäVæ&ÆVC°¢6WDWF„ÖW76vR‚“°¢VÆVÖVçG2æÆöv–äVÖ–Âæfö7W2‚“°§Ð ¦gVæ7F–öâ6†÷u&Vv—7FW$f÷&Ò‚’°¢VÆVÖVçG2æÆöv–äf÷&Òæ†–FFVâÒG'VS°¢VÆVÖVçG2ç&Vv—7FW$f÷&Òæ†–FFVâÒfÇ6S°¢VÆVÖVçG2ç6†÷u&Vv—7FW$'Fâæ†–FFVâÒG'VS°¢6WDWF„ÖW76vR‚“°¢VÆVÖVçG2ç&Vv—7FW$æÖRæfö7W2‚“°§Ð ¦7–æ2gVæ7F–öâ&VDWF…6W76–öâ‚’°¢6öç7B&W7öç6RÒv—BfWF6‚‚"ö’öWF‚÷6W76–öâ"Â²66†S¢&æò×7F÷&R"Ò“°¢–b‚&W7öç6Ræö²’°¢F‡&÷ræWrW'&÷"‚-	-]íM­"-]Í]ÝÝâÝRRMí-­ý]Òâ"“°¢Ð¢&WGW&â&W7öç6Ræ§6öâ‚“°§Ð ¦7–æ2gVæ7F–öâ7V&Ö—DWF‚‡F‚Â&öG’’°¢6öç7B&W7öç6RÒv—BfWF6‚‡F‚Â°¢ÖWF†öC¢%õ5B"À¢†VFW'3¢²$6öçFVçBÕG—R#¢&Æ–6F–öâö§6öâ"ÒÀ¢&öG“¢¥4ôâç7G&–æv–g’†&öG’’À¢Ò“°¢6öç7BFFÒv—B&W7öç6Ræ§6öâ‚’æ6F6‚‚‚’ÓâçVÆÂ“°¢–b‚&W7öç6Ræö²’°¢F‡&÷ræWrW'&÷"†FFòæW'&÷"ÇÂ-	-]íM­"ÝR]R=ý]]Òâ"“°¢Ð¢&WGW&âFF°§Ð ¦7–æ2gVæ7F–öâ†æFÆTÆöv–â†WfVçB’°¢WfVçBç&WfVçDFVfVÇB‚“°¢6WDWF„'W7’‡G'VR“°¢6WDWF„ÖW76vR‚“°¢G'’°¢v—B7V&Ö—DWF‚‚"ö’öWF‚öÆöv–â"Â°¢VÖ–Ã¢VÆVÖVçG2æÆöv–äVÖ–ÂçfÇVRÀ¢77v÷&C¢VÆVÖVçG2æÆöv–å77v÷&BçfÇVRÀ¢Ò“°¢VÆVÖVçG2æÆöv–å77v÷&BçfÇVRÒ"#°¢6öç7B6W76–öâÒv—B&VDWF…6W76–öâ‚“°¢–b‚6W76–öâæWF†VçF–6FVB’F‡&÷ræWrW'&÷"‚-
+]ý-ÝR]R­}MM]Ýâ"“°¢v—B7F'DÆ–6F–öâ‡6W76–öâçW6W"“°¢Ò6F6‚†W'&÷"’°¢6WDWF„ÖW76vR†W'&÷"æÖW76vR“°¢Òf–æÆÇ’°¢6WDWF„'W7’†fÇ6R“°¢Ð§Ð ¦7–æ2gVæ7F–öâ†æFÆU&Vv—7G&F–öâ†WfVçB’°¢WfVçBç&WfVçDFVfVÇB‚“°¢6WDWF„'W7’‡G'VR“°¢6WDWF„ÖW76vR‚“°¢G'’°¢6öç7B&W7VÇBÒv—B7V&Ö—DWF‚‚"ö’öWF‚÷&Vv—7FW""Â°¢F—7Æ”æÖS¢VÆVÖVçG2ç&Vv—7FW$æÖRçfÇVRÀ¢VÖ–Ã¢VÆVÖVçG2ç&Vv—7FW$VÖ–ÂçfÇVRÀ¢77v÷&C¢VÆVÖVçG2ç&Vv—7FW%77v÷&BçfÇVRÀ¢–çf—FT6öFS¢VÆVÖVçG2ç&Vv—7FW$–çf—FT6öFRçfÇVRÀ¢Ò“°¢VÆVÖVçG2ç&Vv—7FW%77v÷&BçfÇVRÒ"#°¢VÆVÖVçG2ç&Vv—7FW$–çf—FT6öFRçfÇVRÒ"#°¢–b‡&W7VÇBæ6öæf—&ÖF–öå&WV—&VB’°¢6†÷tÆöv–äf÷&Ò‚“°¢VÆVÖVçG2æÆöv–äVÖ–ÂçfÇVRÒ&W7VÇBçW6W#òæVÖ–ÂÇÂ"#°¢6WDWF„ÖW76vR€¢-	ýíM½­"R­}MM]Òâ	ýí--­M‚Í]½‚‚ýí½R-½]râ"À¢G'VRÀ¢“°¢&WGW&ã°¢Ð¢6öç7B6W76–öâÒv—B&VDWF…6W76–öâ‚“°¢–b‚6W76–öâæWF†VçF–6FVB’F‡&÷ræWrW'&÷"‚-
+]ý-ÝR]R­}MM]Ýâ"“°¢v—B7F'DÆ–6F–öâ‡6W76–öâçW6W"“°¢Ò6F6‚†W'&÷"’°¢6WDWF„ÖW76vR†W'&÷"æÖW76vR“°¢Òf–æÆÇ’°¢6WDWF„'W7’†fÇ6R“°¢Ð§Ð ¦7–æ2gVæ7F–öâ†æFÆTÆöv÷WB‚’°¢VÆVÖVçG2æÆöv÷WD'FâæF—6&ÆVBÒG'VS°¢G'’°¢v—BfWF6‚‚"ö’öWF‚öÆöv÷WB"Â²ÖWF†öC¢%õ5B"Ò“°¢Òf–æÆÇ’°¢vÆö&ÅF†—2æÆö6F–öâæ‡&VbÒ"ò#°¢Ð§Ð ¦gVæ7F–öâÇ”WF†VçF–6FVEW6W"‡W6W"’°¢7FFRæWF†VçF–6FVEW6W"ÒW6W#°¢6öç7BF—7Æ”æÖRÒW6W#òæF—7Æ”æÖRÇÂ-	ýí-]-]²#°¢6öç7B—4÷væW"ÒW6W#òç&öÆRÓÓÒ&÷væW"#°¢VÆVÖVçG2ç&öf–ÆTæÖRçFW‡D6öçFVçBÒF—7Æ”æÖS°¢VÆVÖVçG2ç&öf–ÆTfF"çFW‡D6öçFVçBÐ¢F—7Æ”æÖRçG&–Ò‚’æ6†$Bƒ’çFôÆö6ÆUWW$66R‚&&rÔ$r"’ÇÂ-	ò#°¢VÆVÖVçG2ç&öf–ÆU&öÆRçFW‡D6öçFVçBÒ—4÷væW ¢ò-
+í--]Ý¢+rÝ-í­‚ ¢¢-
+-]-í"ýíM²#°¢Fö7VÖVçBæ&öG’æFF6WBçW6W%&öÆRÒ—4÷væW"ò&÷væW""¢'FW7FW"#°¢f÷"†6öç7B—FVÒöbFö7VÖVçBçVW'•6VÆV7F÷$ÆÂ‚%¶FFÖ÷væW"ÖöæÇ•Ò"’’°¢—FVÒæ†–FFVâÒ—4÷væW#°¢Ð§Ð ¦7–æ2gVæ7F–öâ–æ—B‚’°¢VÆVÖVçG2æÆöv–äf÷&ÒæFDWfVçDÆ—7FVæW"‚'7V&Ö—B"Â†æFÆTÆöv–â“°¢VÆVÖVçG2ç&Vv—7FW$f÷&ÒæFDWfVçDÆ—7FVæW"‚'7V&Ö—B"Â†æFÆU&Vv—7G&F–öâ“°¢VÆVÖVçG2ç6†÷u&Vv—7FW$'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â6†÷u&Vv—7FW$f÷&Ò“°¢VÆVÖVçG2æ&6µFôÆöv–ä'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â6†÷tÆöv–äf÷&Ò“° ¢G'’°¢6öç7B6W76–öâÒv—B&VDWF…6W76–öâ‚“°¢7FFRç&Vv—7G&F–öäVæ&ÆVBÒ&ööÆVâ‡6W76–öâç&Vv—7G&F–öäVæ&ÆVB“°¢VÆVÖVçG2ç6†÷u&Vv—7FW$'Fâæ†–FFVâÒ7FFRç&Vv—7G&F–öäVæ&ÆVC°¢–b‡6W76–öâæWF†VçF–6FVB’°¢v—B7F'DÆ–6F–öâ‡6W76–öâçW6W"“°¢&WGW&ã°¢Ð¢VÆVÖVçG2æWF„vFRæ†–FFVâÒfÇ6S°¢VÆVÖVçG2æ6†VÆÂæ†–FFVâÒG'VS°¢–b‚6W76–öâæ6öæf–wW&VB’°¢6WDWF„ÖW76vR€¢-	-]íM­"}-]-í-‚ýíM½‚íRÝRR­--Òâ
+í--]Ý­­"ÍímRM-½]}Rv—D‡V"â"À¢“°¢Ð¢Ò6F6‚†W'&÷"’°¢6WDWF„ÖW76vR†W'&÷"æÖW76vR“°¢Ð§Ð ¦7–æ2gVæ7F–öâ7F'DÆ–6F–öâ‡W6W"’°¢–b‡7FFRæÆ–6F–öå7F'FVB’&WGW&ã°¢7FFRæÆ–6F–öå7F'FVBÒG'VS°¢Ç”WF†VçF–6FVEW6W"‡W6W"“°¢VÆVÖVçG2æWF„vFRæ†–FFVâÒG'VS°¢VÆVÖVçG2æ6†VÆÂæ†–FFVâÒfÇ6S°¢WFFU6W76–öäF—7Æ’‚“° ¢VÆVÖVçG2ç6VæD'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â6VæDÖW76vR“°¢VÆVÖVçG2æGF6„'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â‚’Óà¢VÆVÖVçG2æ–ÖvT–çWBæ6Æ–6²‚’À¢“°¢VÆVÖVçG2æ–ÖvT–çWBæFDWfVçDÆ—7FVæW"‚&6†ævR"Â†æFÆT–ÖvU6VÆV7F–öâ“°¢VÆVÖVçG2ç&VÖ÷fTGF6†ÖVçD'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â6ÆV%VæF–æt–ÖvR“°¢VÆVÖVçG2æ6†D–çWBæFDWfVçDÆ—7FVæW"‚&¶W–F÷vâ"Â†WfVçB’Óâ°¢–b†WfVçBæ¶W’ÓÓÒ$VçFW""bbWfVçBç6†–gD¶W’’°¢WfVçBç&WfVçDFVfVÇB‚“°¢6VæDÖW76vR‚“°¢Ð¢Ò“°¢VÆVÖVçG2ææWt6†D'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â7F'DæWt6†B“°¢VÆVÖVçG2çFövvÆU7FGW4'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â÷Vå7FGW2“°¢VÆVÖVçG2æ6Æ÷6T6öçFW‡D'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â6Æ÷6U7FGW2“°¢VÆVÖVçG2æ6†DÖW76vW2æFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â†æFÆTÖW76vT7F–öâ“°¢VÆVÖVçG2æ6öçfW'6F–öäÆ—7BæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â†æFÆT6öçfW'6F–öä6Æ–6²“°¢VÆVÖVçG2æ6öçfW'6F–öå6V&6‚æFDWfVçDÆ—7FVæW"‚&–çWB"Â&VæFW$6öçfW'6F–öäÆ—7B“°¢VÆVÖVçG2ç6V&6„6†G4'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"ÂFövvÆT6öçfW'6F–öå6V&6‚“°¢VÆVÖVçG2æÖö&–ÆTÖVçT'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"ÂFövvÆU6–FV&"“°¢VÆVÖVçG2ç6–FV&$&6¶G&÷æFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â6Æ÷6U6–FV&"“°¢VÆVÖVçG2æ–ÖvW4'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â÷Vä–ÖvU–6¶W"“°¢VÆVÖVçG2æÖöGVÆW4'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â÷VäÖöGVÆW4G&vW"“°¢VÆVÖVçG2çFööÇ4'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â÷VåFööÇ4G&vW"“°¢VÆVÖVçG2ç7—7FVÔ6öæf–wW&F–öä'FâæFDWfVçDÆ—7FVæW"€¢&6Æ–6²"À¢÷Vå7—7FVÔ6öæf–wW&F–öäG&vW"À¢“°¢VÆVÖVçG2æÖVÖ÷'”'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â÷VäÖVÖ÷'”G&vW"“°¢VÆVÖVçG2çW&Ö—76–öç4'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â÷VåW&Ö—76–öç4G&vW"“°¢VÆVÖVçG2æ6Æ÷6TFFG&vW$'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â6Æ÷6TFFG&vW"“°¢VÆVÖVçG2æG&vW$&6¶G&÷æFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â6Æ÷6TFFG&vW"“°¢VÆVÖVçG2æFFG&vW$&öG’æFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â†æFÆTFFG&vW$7F–öâ“°¢VÆVÖVçG2çfö–6T'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"ÂFövvÆUfö–6T–çWB“°¢VÆVÖVçG2æÆöv÷WD'FâæFDWfVçDÆ—7FVæW"‚&6Æ–6²"Â†æFÆTÆöv÷WB“°¢Fö7VÖVçBæFDWfVçDÆ—7FVæW"‚&¶W–F÷vâ"Â†æFÆTvÆö&Ä¶W–F÷vâ“°¢&W&Ufö–6T–çWB‚“° ¢6†V6´†VÇF‚‚“°¢6†V6´÷Vå6V&6‚‚“°¢6WD–çFW'fÂ†6†V6´†VÇF‚Â“°¢6WD–çFW'fÂ†6†V6´÷Vå6V&6‚Â#“° ¢v—B&W7F÷&T6öçfW'6F–öâ‚“°¢v—BÆöD6öçfW'6F–öç2‚“°§Ð ¦gVæ7F–öâWFFU6W76–öäF—7Æ’‚’°¢VÆVÖVçG2ç6W76–öä–DF—7Æ’çFW‡D6öçFVçBÒ7FFRç6W76–öä–C°§Ð ¦7–æ2gVæ7F–öâ6†÷uvVÆ6öÖTÖW76vR‚’°¢VæDÖW76vR€¢&vVçB"À¢°¢"225”ä4…$ôâÕ‚"À¢"¢­
+--íý-½}Ý’íý]míÝÝ-]Íâ¢¢"À¢""À¢-	]MÝâ’ýMâÂýí-íýÝÝ­íÝ-í½ÝýÍ]"‚}]]Ý‚Ý-=Í]Ý-‚}]½Ý‚}M}‚â"À¢""À¢$’--­"RÍíý"Ý}ÒÝí=-ÝRâ
+-‚­íÝ-í½‚MÝÝ-RÂýÍ]--‚­í--RM]--òâ"À¢Òæ¦ö–â‚%Æâ"’À¢“°§Ð ¦7–æ2gVæ7F–öâ&W7F÷&T6öçfW'6F–öâ‚’°¢G'’°¢6öç7B&W7öç6RÒv—BfWF6‚€¢"öÖVÖ÷'’ö6öçfW'6F–öâò"²Væ6öFUU$”6ö×öæVçB‡7FFRç6W76–öä–B’À¢²66†S¢&æò×7F÷&R"ÒÀ¢“°¢–b‚&W7öç6Ræö²’F‡&÷ræWrW'&÷"‚-	-íý-ÝRRMí-­ýÝâ"“°¢6öç7BFFÒv—B&W7öç6Ræ§6öâ‚“°¢Ö&´ÖVÖ÷'”÷W&F–öæÂ‚“°¢6öç7B—FV×2Ò'&’æ—4'&’†FFæ—FV×2’òFFæ—FV×2¢µÓ°¢–b†—FV×2æÆVæwF‚ÓÓÒ’°¢v—B6†÷uvVÆ6öÖTÖW76vR‚“°¢&WGW&ã°¢Ð¢f÷"†6öç7B—FVÒöb—FV×2’°¢–b€¢†—FVÒç&öÆRÓÓÒ'W6W""ÇÂ—FVÒç&öÆRÓÓÒ&76—7FçB"’b`¢G—Vöb—FVÒæ6öçFVçBÓÓÒ'7G&–ær ¢’°¢VæDÖW76vR€¢—FVÒç&öÆRÓÓÒ&76—7FçB"ò&vVçB"¢'W6W""À¢—FVÒæ6öçFVçBÀ¢“°¢Ð¢Ð¢Æöt7F–öâ‚-	-­}-Ýí-]ÝR-íý-Ý}=í-í"“°¢Ò6F6‚†W'&÷"’°¢6öç6öÆRæW'&÷"†W'&÷"“°¢v—B6†÷uvVÆ6öÖTÖW76vR‚“°¢Æöt7F–öâ‚-	-íý-ÝRÍímM­MR-­}-Ýí-]Ý"“°¢Ð§Ð ¦7–æ2gVæ7F–öâ7F'DæWt6†B‚’°¢–b‡7FFRæ6†D'W7’’&WGW&ã°¢6Æ÷6U6–FV&"‚“°¢6ÆV%VæF–æt–ÖvR‚“°¢7FFRç6W76–öä–BÒ7&VFU6W76–öä–B‚“°¢Æö6Å7F÷&vRç6WD—FVÒ‚'7–æ6‡&öå6W76–öä–B"Â7FFRç6W76–öä–B“°¢7FFRæÆ7D7F–öç2ÒµÓ°¢VÆVÖVçG2æ6†DÖW76vW2ç&WÆ6T6†–ÆG&Vâ‚“°¢WFFU6W76–öäF—7Æ’‚“°¢&VæFW$7F–öç4Æör‚“°¢v—B6†÷uvVÆ6öÖTÖW76vR‚“°¢Æöt7F–öâ‚-	}ýí}Ý"RÝí"}=í-í"“°¢&VæFW$6öçfW'6F–öäÆ—7B‚“°¢VÆVÖVçG2æ6†D–çWBæfö7W2‚“°§Ð ¦7–æ2gVæ7F–öâÆöD6öçfW'6F–öç2‚’°¢G'’°¢6öç7B&W7öç6RÒv—BfWF6‚‚"öÖVÖ÷'’ö6öçfW'6F–öç2"Â°¢66†S¢&æò×7F÷&R"À¢Ò“°¢–b‚&W7öç6Ræö²’F‡&÷ræWrW'&÷"‚-
+ý­­­"ÝRRMí-­ý]Òâ"“°¢6öç7BFFÒv—B&W7öç6Ræ§6öâ‚“°¢7FFRæ6öçfW'6F–öç2Ò'&’æ—4'&’†FFæ—FV×2’òFFæ—FV×2¢µÓ°¢7FFRæ6öçfW'6F–öäÆöDW'&÷"Ò"#°¢&VæFW$6öçfW'6F–öäÆ—7B‚“°¢Ò6F6‚†W'&÷"’°¢6öç6öÆRæW'&÷"†W'&÷"“°¢7FFRæ6öçfW'6F–öç2ÒµÓ°¢7FFRæ6öçfW'6F–öäÆöDW'&÷"Ð¢-	-íý--]Í]ÝÝâÝRRMí-­ýÝâ	íý-’í-Ýí-ââ#°¢&VæFW$6öçfW'6F–öäÆ—7B‚“°¢Ð§Ð ¦gVæ7F–öâ&VæFW$6öçfW'6F–öäÆ—7B‚’°¢6öç7BVW'’ÒVÆVÖVçG2æ6öçfW'6F–öå6V&6‚çfÇVP¢çG&–Ò‚¢çFôÆö6ÆTÆ÷vW$66R‚&&rÔ$r"“°¢6öç7B6öçfW'6F–öç2Ò7FFRæ6öçfW'6F–öç2æf–ÇFW"€¢†—FVÒ’ÓâVW'’ÇÂ—FVÒçF—FÆRçFôÆö6ÆTÆ÷vW$66R‚&&rÔ$r"’æ–æ6ÇVFW2‡VW'’’À¢“°¢VÆVÖVçG2æ6öçfW'6F–öäÆ—7Bç&WÆ6T6†–ÆG&Vâ‚“° ¢–b‡7FFRæ6öçfW'6F–öäÆöDW'&÷"’°¢6öç7BW'&÷"ÒFö7VÖVçBæ7&VFTVÆVÖVçB‚'"“°¢W'&÷"æ6Æ74æÖRÒ&6öçfW'6F–öâ×7FFR6öçfW'6F–öâ×7FFRÖW'&÷"#°¢W'&÷"çFW‡D6öçFVçBÒ7FFRæ6öçfW'6F–öäÆöDW'&÷#°¢VÆVÖVçG2æ6öçfW'6F–öäÆ—7BæVæD6†–ÆB†W'&÷"“°¢&WGW&ã°¢Ð ¢–b†6öçfW'6F–öç2æÆVæwF‚ÓÓÒ’°¢6öç7BV×G’ÒFö7VÖVçBæ7&VFTVÆVÖVçB‚'"“°¢V×G’æ6Æ74æÖRÒ&6öçfW'6F–öâ×7FFR#°¢V×G’çFW‡D6öçFVçBÒVW'¢ò-	ÝýÍÝÍ]]Ý‚}=í-í‚â ¢¢-	-RíRÝýÍ}ý}]Ý‚}=í-í‚â#°¢VÆVÖVçG2æ6öçfW'6F–öäÆ—7BæVæD6†–ÆB†V×G’“°¢&WGW&ã°¢Ð ¢f÷"†6öç7B—FVÒöb6öçfW'6F–öç2’°¢6öç7B'WGFöâÒFö7VÖVçBæ7&VFTVÆVÖVçB‚&'WGFöâ"“°¢'WGFöâçG—RÒ&'WGFöâ#°¢'WGFöâæ6Æ74æÖRÒ&6öçfW'6F–öâ#°¢–b†—FVÒç6W76–öä–BÓÓÒ7FFRç6W76–öä–B’'WGFöâæ6Æ74Æ—7BæFB‚&7F—fR"“°¢'WGFöâæFF6WBç6W76–öä–BÒ—FVÒç6W76–öä–C°¢'WGFöâçFW‡D6öçFVçBÒ—FVÒçF—FÆS°¢VÆVÖVçG2æ6öçfW'6F–öäÆ—7BæVæD6†–ÆB†'WGFöâ“°¢Ð§Ð ¦7–æ2gVæ7F–öâ†æFÆT6öçfW'6F–öä6Æ–6²†WfVçB’°¢6öç7B'WGFöâÒWfVçBçF&vWBæ6Æ÷6W7B‚&'WGFöå¶FF×6W76–öâÖ–EÒ"“°¢–b‚'WGFöâÇÂ7FFRæ6†D'W7’ÇÂ'WGFöâæFF6WBç6W76–öä–BÓÓÒ7FFRç6W76–öä–B¢&WGW&ã°¢7FFRç6W76–öä–BÒ'WGFöâæFF6WBç6W76–öä–C°¢Æö6Å7F÷&vRç6WD—FVÒ‚'7–æ6‡&öå6W76–öä–B"Â7FFRç6W76–öä–B“°¢VÆVÖVçG2æ6†DÖW76vW2ç&WÆ6T6†–ÆG&Vâ‚“°¢WFFU6W76–öäF—7Æ’‚“°¢&VæFW$6öçfW'6F–öäÆ—7B‚“°¢v—B&W7F÷&T6öçfW'6F–öâ‚“°¢6Æ÷6U6–FV&"‚“°§Ð ¦gVæ7F–öâFövvÆU6–FV&"‚’°¢6öç7B—4÷VâÒVÆVÖVçG2ç6–FV&"æ6Æ74Æ—7BçFövvÆR‚&Öö&–ÆR×f—6–&ÆR"“°¢VÆVÖVçG2ç6–FV&$&6¶G&÷æ†–FFVâÒ—4÷Vã°¢VÆVÖVçG2æÖö&–ÆTÖVçT'Fâç6WDGG&–'WFR‚&&–ÖW‡æFVB"Â7G&–ær†—4÷Vâ’“°§Ð ¦gVæ7F–öâ6Æ÷6U6–FV&"‚’°¢VÆVÖVçG2ç6–FV&"æ6Æ74Æ—7Bç&VÖ÷fR‚&Öö&–ÆR×f—6–&ÆR"“°¢VÆVÖVçG2ç6–FV&$&6¶G&÷æ†–FFVâÒG'VS°¢VÆVÖVçG2æÖö&–ÆTÖVçT'Fâç6WDGG&–'WFR‚&&–ÖW‡æFVB"Â&fÇ6R"“°§Ð ¦gVæ7F–öâ÷Vä–ÖvU–6¶W"‚’°¢6Æ÷6U6–FV&"‚“°¢VÆVÖVçG2æ–ÖvT–çWBæ6Æ–6²‚“°§Ð ¦gVæ7F–öâ†æFÆTvÆö&Ä¶W–F÷vâ†WfVçB’°¢–b†WfVçBæ¶W’ÓÒ$W66R"’&WGW&ã°¢6Æ÷6U6–FV&"‚“°¢6Æ÷6U7FGW2‚“°¢6Æ÷6TFFG&vW"‚“°§Ð ¦gVæ7F–öâFövvÆT6öçfW'6F–öå6V&6‚‚’°¢VÆVÖVçG2æ6öçfW'6F–öå6V&6‚æ†–FFVâÒfÇ6S°¢VÆVÖVçG2æ6öçfW'6F–öäÆ—7@¢æ6Æ÷6W7B‚"ç6–FV&"×6V7F–öâ"¢òç67&öÆÄ–çFõf–Wr‡²&Æö6³¢'7F'B"Â&V†f–÷#¢'6Öö÷F‚"Ò“°¢VÆVÖVçG2æ6öçfW'6F–öå6V&6‚æfö7W2‡²&WfVçE67&öÆÃ¢G'VRÒ“°§Ð ¦gVæ7F–öâ†æFÆT–ÖvU6VÆV7F–öâ†WfVçB’°¢6öç7Bf–ÆRÒWfVçBçF&vWBæf–ÆW3òå³Ó°¢–b‚f–ÆR’&WGW&ã° ¢6öç7BÆÆ÷vVEG—W2Ò²&–ÖvRö§Vr"Â&–ÖvR÷ær"Â&–ÖvR÷vV'%Ó°¢–b‚ÆÆ÷vVEG—W2æ–æ6ÇVFW2†f–ÆRçG—R’’°¢VæDÖW76vR‚&vVçB"Â.)ØÂ	ýíMM­m"RÍâ¥TrÂär‚vV%ÝÍ­‚â"“°¢6ÆV%VæF–æt–ÖvR‚“°¢&WGW&ã°¢Ð ¢–b†f–ÆRç6—¦RâR¢#B¢#B’°¢VæDÖW76vR‚&vVçB"Â.)ØÂ
+ÝÍ­--ý-M­MRMâRÔ"â"“°¢6ÆV%VæF–æt–ÖvR‚“°¢&WGW&ã°¢Ð ¢6öç7B&VFW"ÒæWrf–ÆU&VFW"‚“°¢&VFW"æöæÆöBÒ‚’Óâ°¢7FFRçVæF–æt–ÖvRÒ°¢FFW&Ã¢&VFW"ç&W7VÇBÀ¢Ö–ÖUG—S¢f–ÆRçG—RÀ¢æÖS¢f–ÆRææÖRÀ¢Ó°¢VÆVÖVçG2æGF6†ÖVçD–ÖvRç7&2Ò&VFW"ç&W7VÇC°¢VÆVÖVçG2æGF6†ÖVçDæÖRçFW‡D6öçFVçBÒf–ÆRææÖS°¢VÆVÖVçG2æGF6†ÖVçE&Wf–Wræ†–FFVâÒfÇ6S°¢VÆVÖVçG2æ6†D–çWBæfö7W2‚“°¢Ó°¢&VFW"æöæW'&÷"Ò‚’Óâ°¢VæDÖW76vR‚&vVçB"Â.)ØÂ
+ÝÍ­-ÝRÍímM­MRýí}]-]Ýâ"“°¢6ÆV%VæF–æt–ÖvR‚“°¢Ó°¢&VFW"ç&VD4FFU$Â†f–ÆR“°§Ð ¦gVæ7F–öâ6ÆV%VæF–æt–ÖvR‚’°¢7FFRçVæF–æt–ÖvRÒçVÆÃ°¢VÆVÖVçG2æ–ÖvT–çWBçfÇVRÒ"#°¢VÆVÖVçG2æGF6†ÖVçD–ÖvRç&VÖ÷fTGG&–'WFR‚'7&2"“°¢VÆVÖVçG2æGF6†ÖVçDæÖRçFW‡D6öçFVçBÒ"#°¢VÆVÖVçG2æGF6†ÖVçE&Wf–Wræ†–FFVâÒG'VS°§Ð ¦gVæ7F–öâ÷Vå7FGW2‚’°¢6Æ÷6U6–FV&"‚“°¢VÆVÖVçG2ç7FGW5æVÂæ6Æ74Æ—7BæFB‚&Öö&–ÆR×f—6–&ÆR"“°§Ð ¦gVæ7F–öâ6Æ÷6U7FGW2‚’°¢VÆVÖVçG2ç7FGW5æVÂæ6Æ74Æ—7Bç&VÖ÷fR‚&Öö&–ÆR×f—6–&ÆR"“°§Ð ¦gVæ7F–öâ&W&Ufö–6T–çWB‚’°¢6öç7B7VV6…&V6övæ—F–öâÐ¢v–æF÷rå7VV6…&V6övæ—F–öâÇÂv–æF÷rçvV&¶—E7VV6…&V6övæ—F–öã°¢–b‚7VV6…&V6övæ—F–öâ’°¢VÆVÖVçG2çfö–6T'Fâæ†–FFVâÒG'VS°¢&WGW&ã°¢Ð ¢6öç7B&V6övæ—F–öâÒæWr7VV6…&V6övæ—F–öâ‚“°¢&V6övæ—F–öâæÆærÒ&&rÔ$r#°¢&V6övæ—F–öâæ6öçF–çV÷W2ÒfÇ6S°¢&V6övæ—F–öâæ–çFW&–Õ&W7VÇG2ÒG'VS° ¢&V6övæ—F–öâæöç7F'BÒ‚’Óâ6WDÆ—7FVæ–ær‡G'VR“°¢&V6övæ—F–öâæöæVæBÒ‚’Óâ6WDÆ—7FVæ–ær†fÇ6R“°¢&V6övæ—F–öâæöæW'&÷"Ò†WfVçB’Óâ°¢6WDÆ—7FVæ–ær†fÇ6R“°¢–b†WfVçBæW'&÷"ÓÒ&&÷'FVB"bbWfVçBæW'&÷"ÓÒ&æò×7VV6‚"’°¢VæDÖW76vR€¢&vVçB"À¢-	=½í-í-â-­-]mMÝRÝRÍímM--â	ýí-]‚Mí-­ýMâÍ­íMíÝâ"À¢“°¢Ð¢Ó°¢&V6övæ—F–öâæöç&W7VÇBÒ†WfVçB’Óâ°¢ÆWBG&ç67&—BÒ"#°¢f÷"€¢ÆWB–æFW‚ÒWfVçBç&W7VÇD–æFWƒ°¢–æFW‚ÂWfVçBç&W7VÇG2æÆVæwFƒ°¢–æFW‚³Ò¢’°¢G&ç67&—B³ÒWfVçBç&W7VÇG5¶–æFW…Õ³ÒçG&ç67&—C°¢Ð¢VÆVÖVçG2æ6†D–çWBçfÇVRÒG&ç67&—BçG&–Ò‚“°¢6öç7BÆ7E&W7VÇBÒWfVçBç&W7VÇG5¶WfVçBç&W7VÇG2æÆVæwF‚ÒÓ°¢–b†Æ7E&W7VÇCòæ—4f–æÂ’VÆVÖVçG2æ6†D–çWBæfö7W2‚“°¢Ó°¢7FFRç&V6övæ—F–öâÒ&V6övæ—F–öã°§Ð ¦gVæ7F–öâ6WDÆ—7FVæ–ær†—4Æ—7FVæ–ær’°¢7FFRæÆ—7FVæ–ærÒ—4Æ—7FVæ–æs°¢VÆVÖVçG2çfö–6T'Fâæ6Æ74Æ—7BçFövvÆR‚&Æ—7FVæ–ær"Â—4Æ—7FVæ–ær“°¢VÆVÖVçG2çfö–6T'Fâç6WDGG&–'WFR‚&&–×&W76VB"Â7G&–ær†—4Æ—7FVæ–ær’“°¢VÆVÖVçG2çfö–6T'FâçF—FÆRÒ—4Æ—7FVæ–æp¢ò-
+ý‚½=Ý]-â ¢¢-	=½í-â-­-]mMÝR#°§Ð ¦gVæ7F–öâFövvÆUfö–6T–çWB‚’°¢–b‚7FFRç&V6övæ—F–öâÇÂ7FFRæ6†D'W7’’&WGW&ã°¢–b‡7FFRæÆ—7FVæ–ær’°¢7FFRç&V6övæ—F–öâç7F÷‚“°¢ÒVÇ6R°¢7FFRç&V6övæ—F–öâç7F'B‚“°¢Ð§Ð ¦gVæ7F–öâ÷VäÖöGVÆW4G&vW"‚’°¢÷VäFFG&vW"‚-
+í-Ý‚í½-‚"“°¢VÆVÖVçG2æFFG&vW$&öG’æ–ææW$…DÔÂÒ ¢ÆF—b6Æ73Ò&ÖöGVÆR×7VÖÖ'’#à¢
+-í-í½-‚Â"­í-â½}Ý-’íý]míÝÝ-]Í}ýí½}-}=í-íÀ¢ýÍ]--‚}]]Ý-RÝ-=Í]Ý-‚â	í½--Íýâ]R‚ÝP¢í}Ý}-Â}R-­ÝÝ=½==R-­}Ýà¢ÂöF—cà¢Ç6V7F–öâ6Æ73Ò&G&vW"×6V7F–öâW&Ö—76–öâÖÆ—7BÖöGVÆRÖÆ—7B"FFÖÖöGVÆRÖÆ—7CãÂ÷6V7F–öãæ°¢Fö7VÖVçBæF—7F6„WfVçB†æWr7W7FöÔWfVçB‚'7–æ6‡&öã¦ÖöGVÆW2Ö÷VæVB"’“°§Ð ¦gVæ7F–öâ—4vöövÆUFööÂ‡FööÂ’°¢&WGW&â€¢FööÃòç&÷f–FW"ÓÓÒ&vöövÆR"ÇÀ¢FööÃòæ–Còç7F'G5v—F‚‚&vöövÆRÒ"’ÇÀ¢FööÃòæ–BÓÓÒ&vÖ–Â×&VB ¢“°§Ð ¦gVæ7F–öâFööÅ7FFR‡FööÂÂvöövÆT6öææV7FVBÂv—F‡V$6öææV7FVB’°¢–b‡FööÂæf–Æ&–Æ—G”6öFRÓÓÒ$4õ”ÄõEôUDôÔD”ôåôD•4$ÄTB"’°¢&WGW&â²Æ&VÃ¢-	}­½í}]Ýâ+r]mÂ]r6÷–Æ÷B"Â6Æ74æÖS¢&6öæf—&Ò"Ó°¢Ð¢–b‚FööÂæVæ&ÆVBÇÂFööÂæW†V7WF&ÆR’°¢&WGW&â²Æ&VÃ¢-	ÝRR-­}Ò"Â6Æ74æÖS¢&FVç’"Ó°¢Ð¢–b‚FööÂæ6öæf–wW&VB’°¢&WGW&â²Æ&VÃ¢-	ÝRR­íÝM==Ò"Â6Æ74æÖS¢&FVç’"Ó°¢Ð¢–b†—4vöövÆUFööÂ‡FööÂ’bbvöövÆT6öææV7FVB’°¢&WGW&â²Æ&VÃ¢-	­-­}-ÝR"Â6Æ74æÖS¢&6öæf—&Ò"Ó°¢Ð¢–b‡FööÂæ–BÓÓÒ&v—F‡V"×w&—FR"bbv—F‡V$6öææV7FVB’°¢&WGW&â²Æ&VÃ¢-	­-­}-ÝR"Â6Æ74æÖS¢&6öæf—&Ò"Ó°¢Ð¢&WGW&â²Æ&VÃ¢-
+í-‚"Â6Æ74æÖS¢&ÆÆ÷r"Ó°§Ð ¦gVæ7F–öâFööÅ7FGW47F–öç2‡FööÂÂ7FGW2ÂvöövÆT6öææV7FVBÂv—F‡V$6öææV7FVB’°¢ÆWB7F–öâÒ"#°¢–b‡FööÂæf–Æ&–Æ—G”6öFRÓÓÒ$4õ”ÄõEôUDôÔD”ôåôD•4$ÄTB"’°¢7F–öâÒ"#°¢ÒVÇ6R–b†—4vöövÆUFööÂ‡FööÂ’bbvöövÆT6öææV7FVBbbFööÂæ6öæf–wW&VB’°¢7F–öâÐ¢sÆ'WGFöâG—SÒ&'WGFöâ"6Æ73Ò'FööÂÖ6öææV7BÖ'Fâ"FFÖ6öææV7B×6W'f–6SÒ&vöövÆR#í
+-­m‚vöövÆSÂö'WGFöãâs°¢ÒVÇ6R–b€¢FööÂæ–BÓÓÒ&v—F‡V"×w&—FR"b`¢FööÂæ6öæf–wW&VBb`¢v—F‡V$6öææV7FV@¢’°¢7F–öâÐ¢sÆ'WGFöâG—SÒ&'WGFöâ"6Æ73Ò'FööÂÖ6öææV7BÖ'Fâ"FFÖ6öææV7B×6W'f–6SÒ&v—F‡V"#í
+-­m‚v—D‡V#Âö'WGFöãâs°¢ÒVÇ6R–b‡FööÂæ–BÓÓÒ&v—F‡V"×w&—FR"bbFööÂæ6öæf–wW&VB’°¢7F–öâÐ¢sÆ'WGFöâG—SÒ&'WGFöâ"6Æ73Ò'FööÂÖ6öææV7BÖ'Fâ"FFÖv—F‡V"×6WGWí	Ý-í’v—D‡V#Âö'WGFöãâs°¢Ð ¢&WGW&â ¢ÆF—b6Æ73Ò'FööÂ×7FGW2Ö7F–öç2#à¢Ç7â6Æ73Ò'W&Ö—76–öâÖ&FvRG·7FGW2æ6Æ74æÖWÒ#âG·7FGW2æÆ&VÇÓÂ÷7ãà¢G¶7F–öçÐ¢ÂöF—cæ°§Ð ¦gVæ7F–öâW&Ö—76–öä7F–öâ†—FVÒÂFööÄÖÂvöövÆT6öææV7FVBÂv—F‡V$6öææV7FVB’°¢6öç7BvöövÆUW&Ö—76–öç2ÒæWr6WB…°¢&6ÆVæF"ç&VB"À¢&6ÆVæF"çw&—FR"À¢&G&—fRç&VB"À¢&Ö–Âç&VB"À¢Ò“°¢–b†vöövÆUW&Ö—76–öç2æ†2†—FVÒæ7F–öâ’bbvöövÆT6öææV7FVB’°¢&WGW&âsÆ'WGFöâG—SÒ&'WGFöâ"6Æ73Ò'FööÂÖ6öææV7BÖ'Fâ"FFÖ6öææV7B×6W'f–6SÒ&vöövÆR#í
+-­m‚vöövÆSÂö'WGFöãâs°¢Ð ¢6öç7Bv—F‡V%w&—FRÒFööÄÖævWB‚&v—F‡V"×w&—FR"“°¢–b€¢—FVÒæ7F–öâÓÓÒ&v—F‡V"çw&—FR"b`¢v—F‡V%w&—FSòæf–Æ&–Æ—G”6öFRÓÓÒ$4õ”ÄõEôUDôÔD”ôåôD•4$ÄTB ¢’°¢&WGW&â"#°¢Ð¢–b€¢—FVÒæ7F–öâÓÓÒ&v—F‡V"çw&—FR"b`¢v—F‡V%w&—FSòæ6öæf–wW&VBb`¢v—F‡V%w&—FSòæW†V7WF&ÆRb`¢v—F‡V$6öææV7FV@¢’°¢&WGW&âsÆ'WGFöâG—SÒ&'WGFöâ"6Æ73Ò'FööÂÖ6öææV7BÖ'Fâ"FFÖ6öææV7B×6W'f–6SÒ&v—F‡V"#í
+-­m‚v—D‡V#Âö'WGFöãâs°¢Ð¢–b€¢—FVÒæ7F–öâÓÓÒ&v—F‡V"çw&—FR"b`¢‚v—F‡V%w&—FSòæ6öæf–wW&VBÇÂv—F‡V%w&—FSòæW†V7WF&ÆR¢’°¢&WGW&âsÆ'WGFöâG—SÒ&'WGFöâ"6Æ73Ò'FööÂÖ6öææV7BÖ'Fâ"FFÖv—F‡V"×6WGWí	Ý-í’v—D‡V#Âö'WGFöãâs°¢Ð ¢–b†—FVÒæFV6—6–öâÓÓÒ&6öæf—&Ò"’°¢&WGW&âÆ'WGFöâG—SÒ&'WGFöâ"6Æ73Ò'W&Ö—76–öâÖ–æfòÖ'Fâ"FF×W&Ö—76–öâÖ–æfóÒ"G¶W66T‡FÖÂ†—FVÒæ7F–öâ—Ò#í	­¢í-ƒÂö'WGFöãæ°¢Ð¢&WGW&â"#°§Ð ¦7–æ2gVæ7F–öâ÷VåFööÇ4G&vW"‚’°¢÷VäFFG&vW"‚-	Ý-=Í]Ý-‚"“°¢&VæFW$G&vW$ÆöF–ær‚“°¢G'’°¢6öç7B¶†VÇF…&W7öç6RÂvöövÆU&W7öç6RÂv—F‡V%&W7öç6UÒÒv—B&öÖ—6RæÆÂ…°¢fWF6‚‚"ö†VÇF‚ö–çFVw&F–öç2"Â²66†S¢&æò×7F÷&R"Ò’À¢fWF6‚‚"ö’övöövÆR÷7FGW2"Â²66†S¢&æò×7F÷&R"Ò’æ6F6‚‚‚’ÓâçVÆÂ’À¢fWF6‚‚"ö’öv—F‡V"÷7FGW2"Â²66†S¢&æò×7F÷&R"Ò’æ6F6‚‚‚’ÓâçVÆÂ’À¢Ò“°¢–b‚†VÇF…&W7öç6Ræö²’°¢F‡&÷ræWrW'&÷"‚-
+­-íýÝ]-âÝÝ-=Í]Ý--RÝRRMí-­ýÝââ"“°¢Ð¢6öç7BFFÒv—B†VÇF…&W7öç6Ræ§6öâ‚“°¢6öç7BvöövÆTFFÒvöövÆU&W7öç6Sòæö°¢òv—BvöövÆU&W7öç6Ræ§6öâ‚’æ6F6‚‚‚’Óâ‡·Ò’¢¢·Ó°¢6öç7Bv—F‡V$FFÒv—F‡V%&W7öç6Sòæö°¢òv—Bv—F‡V%&W7öç6Ræ§6öâ‚’æ6F6‚‚‚’Óâ‡·Ò’¢¢·Ó°¢6öç7BFööÇ2Ò'&’æ—4'&’†FFçFööÇ2’òFFçFööÇ2¢µÓ°¢6öç7BFW67&—F–öç2Ò°¢&v—F‡V"×&VB#¢-	ýí-]ý-6öÖÖ—BÝ‚‚M½í-Râ
+Íâ}}]-]ÝRâ"À¢&v—F‡V"×w&—FR# ¢$6÷–Æ÷BÍí#¢í-M]½]Ò­½íÒÂ6öÖÖ—BÝ‚‚VÆÂ&WVW7B½]B-í}Ýâýí--­mM]ÝRâ	]r--íÍ-}Ýâ½-ÝRâ"À¢&vöövÆRÖG&—fR×&VB#¢-
+}]-R}]]Ý‚M½í-Rí"vöövÆRG&—fRâ"À¢&vöövÆRÖ6ÆVæF"×&VB#¢-	ýí­}-­-òí"vöövÆR6ÆVæF"â"À¢&vÖ–Â×&VB#¢-	ýí­}-}]]Ý‚Í]½‚â	ÝR}ýâ"À¢&÷Væ’×vV"×6V&6‚#¢-
+-­‚­-=½ÝÝMíÍmò"Ý-]Ý]"â"À¢&÷Vç6V&6‚ÖÖVÖ÷'’#¢-	ý}‚½}Ý‚ýí]­-ÝýÍ]"ýíB--í’­íÝ-í²â"À¢'7–æ6‡&öâ×7—7FVÒÖ–ç7V7F÷"# ¢-	ýí-]ý-ýMí-â‚-}­‚'VçF–ÖRôF–v—FÄö6VâÝ-í­‚]r-]]Ý-R-íÝí-‚â"À¢Ó°¢VÆVÖVçG2æFFG&vW$&öG’æ–ææW$…DÔÂÒ ¢ÆF—b6Æ73Ò'W&Ö—76–öâÖFVfVÇB#à¢	ýí­}ÝâR]½Ýí-â­-íýÝRâ(	í
+]=-Þ(	ÂÝRí}Ý}---íÍ-}Ýâ(	íí-Ž(	Âà¢ÂöF—cà¢Ç6V7F–öâ6Æ73Ò&G&vW"×6V7F–öâW&Ö—76–öâÖÆ—7B#à¢Æ'WGFöâG—SÒ&'WGFöâ"6Æ73Ò'W&Ö—76–öâÖ6&BFööÂ×7FGW2Ö6&B7—7FVÒÖ6öçG&öÂÖÆ–æ²"FF×7—7FVÒÖ6öæf–wW&F–öãà¢ÆF—cà¢Ç7G&öæsí
+-]Í]Ò­íÝ-í³Â÷7G&öæsà¢Çí
+ýMâÂÝ-=Í]Ý-‚‚-}­‚ýíÍ]Ý½-‚]rýí­}-ÝRÝ-Ý-RÂ-íÝí-‚ãÂ÷à¢ÂöF—cà¢Ç7â6Æ73Ò'W&Ö—76–öâÖ&FvRÆÆ÷r#í	í--íƒÂ÷7ãà¢Âö'WGFöãà¢Æ'F–6ÆR6Æ73Ò'W&Ö—76–öâÖ6&BFööÂ×7FGW2Ö6&B#à¢ÆF—cãÇ7G&öæsí
+ÝÍ­ƒÂ÷7G&öæsãÇä¥TrÂär‚vV%MâRÔ"ãÂ÷ãÂöF—cà¢Ç7â6Æ73Ò'W&Ö—76–öâÖ&FvRÆÆ÷r#í
+í-ƒÂ÷7ãà¢Âö'F–6ÆSà¢G·FööÇ0¢æÖ‚‡FööÂ’Óâ°¢6öç7B7FGW2ÒFööÅ7FFR€¢FööÂÀ¢&ööÆVâ†vöövÆTFFæ6öææV7FVB’À¢&ööÆVâ†v—F‡V$FFæ6öææV7FVB’À¢“°¢6öç7BFW67&—F–öâÐ¢FööÂæ–BÓÓÒ&v—F‡V"×w&—FR"b`¢FööÂæf–Æ&–Æ—G”6öFRÓÓÒ$4õ”ÄõEôUDôÔD”ôåôD•4$ÄTB ¢ò-	­íMí-ý"Íí"R}ý}]ÒÂÝâR}­½í}]Ò"-]­=ò]mÂ]r6÷–Æ÷Bâ ¢¢FW67&—F–öç5·FööÂæ–EÒÇÂ-	Ý-=Í]Ý"Ý5”ä4…$ôâÕ‚â#°¢&WGW&â ¢Æ'F–6ÆR6Æ73Ò'W&Ö—76–öâÖ6&BFööÂ×7FGW2Ö6&B#à¢ÆF—cà¢Ç7G&öæsâG¶W66T‡FÖÂ‡FööÂææÖR—ÓÂ÷7G&öæsà¢ÇâG¶W66T‡FÖÂ†FW67&—F–öâ—ÓÂ÷à¢ÂöF—cà¢G·FööÅ7FGW47F–öç2€¢FööÂÀ¢7FGW2À¢&ööÆVâ†vöövÆTFFæ6öææV7FVB’À¢&ööÆVâ†v—F‡V$FFæ6öææV7FVB’À¢—Ð¢Âö'F–6ÆSæ°¢Ò¢æ¦ö–â‚""—Ð¢Â÷6V7F–öãæ°¢Ò6F6‚†W'&÷"’°¢&VæFW$G&vW$W'&÷"†W'&÷"æÖW76vR“°¢Ð§Ð ¦gVæ7F–öâ6öæf–wW&F–öå7FGW2†—FVÒ’°¢6öç7BÆ&VÇ2Ò°¢6öæf–wW&VC¢²-	Ý-í]Ý"Â&ÆÆ÷r%ÒÀ¢FVfVÇFVC¢²-	ýâýíM}ÝR"Â&ÆÆ÷r%ÒÀ¢&Ö—76–ær×&WV—&VB#¢²-	½ý-"Â&FVç’%ÒÀ¢&÷F–öæÂÖÖ—76–ær#¢²-	Ý]}M­½m-]½Ý"Â&6öæf—&Ò%ÒÀ¢6ö×F–&–Æ—G“¢²-
+-]}]-]Òý­""Â&6öæf—&Ò%ÒÀ¢&æ÷BÖæVVFVB#¢²-	ÝRRÝ=mÝ"Â&ÆÆ÷r%ÒÀ¢VçW6VC¢²-	ÝRR}ýí½}-"Â&FVç’%ÒÀ¢Ó°¢6öç7B¶Æ&VÂÂ6Æ74æÖUÒÒÆ&VÇ5¶—FVÒç7FGW5ÒÇÂ¶—FVÒç7FGW2Â&6öæf—&Ò%Ó°¢&WGW&â²Æ&VÂÂ6Æ74æÖRÓ°§Ð ¦gVæ7F–öâ&VæFW$Vçf—&öæÖVçDw&÷W†&VÂ—FV×2’°¢&WGW&â ¢ÆFWF–Ç26Æ73Ò&6öæf–wW&F–öâÖw&÷W"G¶—FV×2ç6öÖR‚†—FVÒ’Óâ—FVÒç7FGW2ÓÓÒ&Ö—76–ær×&WV—&VB"’ò&÷Vâ"¢"'Óà¢Ç7VÖÖ'“âG¶W66T‡FÖÂ†&V—ÒÇ7ãâG¶—FV×2æÆVæwF‡ÓÂ÷7ããÂ÷7VÖÖ'“à¢ÆF—b6Æ73Ò&6öæf–wW&F–öâÖÆ—7B#à¢G¶—FV×0¢æÖ‚†—FVÒ’Óâ°¢6öç7B7FGW2Ò6öæf–wW&F–öå7FGW2†—FVÒ“°¢&WGW&â ¢Æ'F–6ÆR6Æ73Ò&6öæf–wW&F–öâÖ—FVÒ#à¢ÆF—cà¢Æ6öFSâG¶W66T‡FÖÂ†—FVÒæ¶W’—ÓÂö6öFSà¢ÇâG¶W66T‡FÖÂ†—FVÒçW'÷6R—ÓÂ÷à¢Ç6ÖÆÃà¢G¶—FVÒç6Vç6—F—f—G’ÓÓÒ'6V7&WB"ò-
+-Ý-íÝí"+rÝ­í=ÝRRýí­}-"¢-	íÝ-í­'Ð¢+rF–v—FÄö6Vã¢G¶—FVÒæF–v—FÄö6VäFV6Æ&VBò-M]­½Ý"¢-ÝRRM]­½Ý'Ð¢Â÷6ÖÆÃà¢ÂöF—cà¢Ç7â6Æ73Ò'W&Ö—76–öâÖ&FvRG·7FGW2æ6Æ74æÖWÒ#âG·7FGW2æÆ&VÇÓÂ÷7ãà¢Âö'F–6ÆSæ°¢Ò¢æ¦ö–â‚""—Ð¢ÂöF—cà¢ÂöFWF–Ç3æ°§Ð ¦7–æ2gVæ7F–öâ÷Vå7—7FVÔ6öæf–wW&F–öäG&vW"‚’°¢÷VäFFG&vW"‚-
+-]Í]Ò­íÝ-í²"“°¢&VæFW$G&vW$ÆöF–ær‚“°¢G'’°¢6öç7B¶6öæf–wW&F–öå&W7öç6RÂ–çFVw&F–öç5&W7öç6RÂ&VF–æW75&W7öç6UÒÐ¢v—B&öÖ—6RæÆÂ…°¢fWF6‚‚"ö’÷7—7FVÒö6öæf–wW&F–öâ"Â²66†S­wÒÚ$z{-®éÜj×st integrations = await integrationsResponse.json();
     const readiness = readinessResponse.ok
       ? await readinessResponse.json()
       : null;

--- a/public/app.js
+++ b/public/app.js
@@ -1,34 +1,825 @@
-Y™Áäx-ÆÈ‹j◊ù¢Îi∫⁄+äßj[hëÈ‹¢ÈÌ€Mw—:-jZ.∂õ≠ñ)ﬁ≥V6ˆÁ7B7FFR“∞¢6W76ñˆ‰ñC¢vWD˜$7&VFU6W76ñˆ‰ñBÇí¿¢6W'fW$ˆÊ∆ñÊS¢f«6R¿¢˜VÁ6V&6Ö7FGW3¢'VÊ∂Ê˜v‚"¿¢˜VÁ6V&6Ñfñ«W&W3¢¿¢∆7D÷V÷˜'ï7V66W74C¢¿¢∆7D7FñˆÁ3¢µ“¿¢6ÜD'W7ì¢f«6R¿¢7V∂ñÊt'WGFˆ„¢ÁV∆¬¿¢VÊFñÊtñ÷vS¢ÁV∆¬¿¢6ˆÁfW'6FñˆÁ3¢µ“¿¢6ˆÁfW'6Fñˆ‰∆ˆDW'&˜#¢""¿¢÷V÷˜'îóFV◊3¢µ“¿¢&V6ˆvÊóFñˆ„¢ÁV∆¬¿¢∆ó7FVÊñÊs¢f«6R¿¢WFÜVÁFñ6FVEW6W#¢ÁV∆¬¿¢&Vvó7G&Fñˆ‰VÊ&∆VC¢f«6R¿¢∆ñ6FñˆÂ7F'FVC¢f«6R¿ß”∞†¶6ˆÁ7BV∆V÷VÁG2“∞¢WFÑvFS¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&WFÑvFR"í¿¢6ÜV∆√¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&6ÜV∆¬"í¿¢∆ˆvñ‰f˜&”¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&∆ˆvñ‰f˜&“"í¿¢∆ˆvñ‰V÷ñ√¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&∆ˆvñ‰V÷ñ¬"í¿¢∆ˆvñÂ77v˜&C¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&∆ˆvñÂ77v˜&B"í¿¢∆ˆvñ‰'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&∆ˆvñ‰'F‚"í¿¢6Ü˜u&Vvó7FW$'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'6Ü˜u&Vvó7FW$'F‚"í¿¢&Vvó7FW$f˜&”¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'&Vvó7FW$f˜&“"í¿¢&Vvó7FW$Ê÷S¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'&Vvó7FW$Ê÷R"í¿¢&Vvó7FW$V÷ñ√¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'&Vvó7FW$V÷ñ¬"í¿¢&Vvó7FW%77v˜&C¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'&Vvó7FW%77v˜&B"í¿¢&Vvó7FW$ñÁfóFT6ˆFS¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'&Vvó7FW$ñÁfóFT6ˆFR"í¿¢&Vvó7FW$'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'&Vvó7FW$'F‚"í¿¢&6µFÙ∆ˆvñ‰'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&&6µFÙ∆ˆvñ‰'F‚"í¿¢WFÑ÷W76vS¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&WFÑ÷W76vR"í¿¢6ÜD÷W76vW3¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&6ÜD÷W76vW2"í¿¢6ÜDñÁWC¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&6ÜDñÁWB"í¿¢6VÊD'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'6VÊD'F‚"í¿¢GF6Ñ'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&GF6Ñ'F‚"í¿¢ñ÷vTñÁWC¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&ñ÷vTñÁWB"í¿¢GF6Ü÷VÁE&WfñWs¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&GF6Ü÷VÁE&WfñWr"í¿¢GF6Ü÷VÁDñ÷vS¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&GF6Ü÷VÁDñ÷vR"í¿¢GF6Ü÷VÁDÊ÷S¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&GF6Ü÷VÁDÊ÷R"í¿¢&V÷˜fTGF6Ü÷VÁD'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'&V÷˜fTGF6Ü÷VÁD'F‚"í¿¢ÊWt6ÜD'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&ÊWt6ÜD'F‚"í¿¢Fˆvv∆U7FGW4'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'Fˆvv∆U7FGW4'F‚"í¿¢6∆˜6T6ˆÁFWáD'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&6∆˜6T6ˆÁFWáD'F‚"í¿¢7FGW5ÊV√¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'7FGW5ÊV¬"í¿¢vVÁE7FGW4F˜C¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&vVÁE7FGW4F˜B"í¿¢vVÁE7FGW5FWáC¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&vVÁE7FGW5FWáB"í¿¢6W76ñˆ‰ñDFó7∆ì¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'6W76ñˆ‰ñDFó7∆í"í¿¢6W'fW%7FGW4Fó7∆ì¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'6W'fW%7FGW4Fó7∆í"í¿¢˜VÁ6V&6Ö7FGW4Fó7∆ì¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&˜VÁ6V&6Ö7FGW4Fó7∆í"í¿¢7FñˆÁ4∆ˆs¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&7FñˆÁ4∆ˆr"í¿¢6ˆÁfW'6Fñˆ‰∆ó7C¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&6ˆÁfW'6Fñˆ‰∆ó7B"í¿¢6ˆÁfW'6FñˆÂ6V&6É¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&6ˆÁfW'6FñˆÂ6V&6Ç"í¿¢6V&6Ñ6ÜG4'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'6V&6Ñ6ÜG4'F‚"í¿¢÷ˆ&ñ∆T÷VÁT'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&÷ˆ&ñ∆T÷VÁT'F‚"í¿¢6ñFV&#¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'6ñFV&""í¿¢6ñFV&$&6∂G&˜¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'6ñFV&$&6∂G&˜"í¿¢ñ÷vW4'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&ñ÷vW4'F‚"í¿¢÷ˆGV∆W4'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&÷ˆGV∆W4'F‚"í¿¢7ó7FV‘6ˆÊfñwW&Fñˆ‰'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'7ó7FV‘6ˆÊfñwW&Fñˆ‰'F‚"í¿¢fˆ7W4'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&fˆ7W4'F‚"í¿¢Fˆˆ«4'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'Fˆˆ«4'F‚"í¿¢÷V÷˜'î'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&÷V÷˜'î'F‚"í¿¢W&÷ó76ñˆÁ4'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'W&÷ó76ñˆÁ4'F‚"í¿¢FFG&vW#¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&FFG&vW""í¿¢FFG&vW%FóF∆S¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&FFG&vW%FóF∆R"í¿¢FFG&vW$&ˆGì¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&FFG&vW$&ˆGí"í¿¢G&vW$&6∂G&˜¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&G&vW$&6∂G&˜"í¿¢6∆˜6TFFG&vW$'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&6∆˜6TFFG&vW$'F‚"í¿¢fˆñ6T'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'fˆñ6T'F‚"í¿¢&ˆfñ∆TfF#¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'&ˆfñ∆TfF""í¿¢&ˆfñ∆TÊ÷S¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'&ˆfñ∆TÊ÷R"í¿¢&ˆfñ∆U&ˆ∆S¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ'&ˆfñ∆U&ˆ∆R"í¿¢∆ˆv˜WD'F„¢Fˆ7V÷VÁBÊvWDV∆V÷VÁD'îñBÇ&∆ˆv˜WD'F‚"í¿ß”∞†¶gVÊ7Fñˆ‚7&VFU6W76ñˆ‰ñBÇí∞¢ñbÜv∆ˆ&≈FÜó2Ê7'óFÛÚÁ&ÊFˆ’UTîBí∞¢&WGW&‚'6W72“"≤v∆ˆ&≈FÜó2Ê7'óFÚÁ&ÊFˆ’UTîBÇì∞¢–¢&WGW&‚Ä¢'6W72“"≤÷FÇÁ&ÊFˆ“ÇíÁFı7G&ñÊrÉ3bíÁ6∆ñ6RÉ"í≤FFRÊÊ˜rÇíÁFı7G&ñÊrÉ3bê¢ì∞ß–†¶gVÊ7Fñˆ‚vWD˜$7&VFU6W76ñˆ‰ñBÇí∞¢6ˆÁ7B7F˜&VB“∆ˆ6≈7F˜&vRÊvWDóFV“Ç'7ñÊ6á&ˆÂ6W76ñˆ‰ñB"ì∞¢ñbá7F˜&VCÚÁ7F'G5vóFÇÇ'6W72“"íí&WGW&‚7F˜&VC∞¢6ˆÁ7B6W76ñˆ‰ñB“7&VFU6W76ñˆ‰ñBÇì∞¢∆ˆ6≈7F˜&vRÁ6WDóFV“Ç'7ñÊ6á&ˆÂ6W76ñˆ‰ñB"¬6W76ñˆ‰ñBì∞¢&WGW&‚6W76ñˆ‰ñC∞ß–†¶gVÊ7Fñˆ‚6WDWFÑ÷W76vRÜ÷W76vR“""¬7V66W72“f«6Rí∞¢V∆V÷VÁG2ÊWFÑ÷W76vRÁFWáD6ˆÁFVÁB“÷W76vS∞¢V∆V÷VÁG2ÊWFÑ÷W76vRÊ6∆74∆ó7BÁFˆvv∆RÇ'7V66W72"¬7V66W72ì∞ß–†¶gVÊ7Fñˆ‚6WDWFÑ'W7íÜó4'W7íí∞¢V∆V÷VÁG2Ê∆ˆvñ‰'F‚ÊFó6&∆VB“ó4'W7ì∞¢V∆V÷VÁG2Á&Vvó7FW$'F‚ÊFó6&∆VB“ó4'W7ì∞ß–†¶gVÊ7Fñˆ‚6Ü˜t∆ˆvñ‰f˜&“Çí∞¢V∆V÷VÁG2Ê∆ˆvñ‰f˜&“ÊÜñFFV‚“f«6S∞¢V∆V÷VÁG2Á&Vvó7FW$f˜&“ÊÜñFFV‚“G'VS∞¢V∆V÷VÁG2Á6Ü˜u&Vvó7FW$'F‚ÊÜñFFV‚“7FFRÁ&Vvó7G&Fñˆ‰VÊ&∆VC∞¢6WDWFÑ÷W76vRÇì∞¢V∆V÷VÁG2Ê∆ˆvñ‰V÷ñ¬Êfˆ7W2Çì∞ß–†¶gVÊ7Fñˆ‚6Ü˜u&Vvó7FW$f˜&“Çí∞¢V∆V÷VÁG2Ê∆ˆvñ‰f˜&“ÊÜñFFV‚“G'VS∞¢V∆V÷VÁG2Á&Vvó7FW$f˜&“ÊÜñFFV‚“f«6S∞¢V∆V÷VÁG2Á6Ü˜u&Vvó7FW$'F‚ÊÜñFFV‚“G'VS∞¢6WDWFÑ÷W76vRÇì∞¢V∆V÷VÁG2Á&Vvó7FW$Ê÷RÊfˆ7W2Çì∞ß–†¶7ñÊ2gVÊ7Fñˆ‚&VDWFÖ6W76ñˆ‚Çí∞¢6ˆÁ7B&W7ˆÁ6R“vóBfWF6ÇÇ"ˆíˆWFÇ˜6W76ñˆ‚"¬≤66ÜS¢&ÊÚ◊7F˜&R"“ì∞¢ñbÇ&W7ˆÁ6RÊˆ≤í∞¢Fá&˜rÊWrW'&˜"Ç-	-]ÌM≠"-]Õ]››‚›RRMÌ-≠˝]“‚"ì∞¢–¢&WGW&‚&W7ˆÁ6RÊß6ˆ‚Çì∞ß–†¶7ñÊ2gVÊ7Fñˆ‚7V&÷óDWFÇáFÇ¬&ˆGíí∞¢6ˆÁ7B&W7ˆÁ6R“vóBfWF6ÇáFÇ¬∞¢÷WFÜˆC¢%ı5B"¿¢ÜVFW'3¢≤$6ˆÁFVÁB’GóR#¢&∆ñ6Fñˆ‚ˆß6ˆ‚"“¿¢&ˆGì¢•4Ù‚Á7G&ñÊvñgíÜ&ˆGíí¿¢“ì∞¢6ˆÁ7BFF“vóB&W7ˆÁ6RÊß6ˆ‚ÇíÊ6F6ÇÇÇí”‚ÁV∆¬ì∞¢ñbÇ&W7ˆÁ6RÊˆ≤í∞¢Fá&˜rÊWrW'&˜"ÜFFÚÊW'&˜"«¬-	-]ÌM≠"›R]çR=˝]ç]“‚"ì∞¢–¢&WGW&‚FF∞ß–†¶7ñÊ2gVÊ7Fñˆ‚ÜÊF∆T∆ˆvñ‚ÜWfVÁBí∞¢WfVÁBÁ&WfVÁDFVfV«BÇì∞¢6WDWFÑ'W7íáG'VRì∞¢6WDWFÑ÷W76vRÇì∞¢G'í∞¢vóB7V&÷óDWFÇÇ"ˆíˆWFÇˆ∆ˆvñ‚"¬∞¢V÷ñ√¢V∆V÷VÁG2Ê∆ˆvñ‰V÷ñ¬Áf«VR¿¢77v˜&C¢V∆V÷VÁG2Ê∆ˆvñÂ77v˜&BÁf«VR¿¢“ì∞¢V∆V÷VÁG2Ê∆ˆvñÂ77v˜&BÁf«VR“"#∞¢6ˆÁ7B6W76ñˆ‚“vóB&VDWFÖ6W76ñˆ‚Çì∞¢ñbÇ6W76ñˆ‚ÊWFÜVÁFñ6FVBíFá&˜rÊWrW'&˜"Ç-
-]ç˝-›R]çR≠}MM]›‚"ì∞¢vóB7F'D∆ñ6Fñˆ‚á6W76ñˆ‚ÁW6W"ì∞¢“6F6ÇÜW'&˜"í∞¢6WDWFÑ÷W76vRÜW'&˜"Ê÷W76vRì∞¢“fñÊ∆«í∞¢6WDWFÑ'W7íÜf«6Rì∞¢–ß–†¶7ñÊ2gVÊ7Fñˆ‚ÜÊF∆U&Vvó7G&Fñˆ‚ÜWfVÁBí∞¢WfVÁBÁ&WfVÁDFVfV«BÇì∞¢6WDWFÑ'W7íáG'VRì∞¢6WDWFÑ÷W76vRÇì∞¢G'í∞¢6ˆÁ7B&W7V«B“vóB7V&÷óDWFÇÇ"ˆíˆWFÇ˜&Vvó7FW""¬∞¢Fó7∆îÊ÷S¢V∆V÷VÁG2Á&Vvó7FW$Ê÷RÁf«VR¿¢V÷ñ√¢V∆V÷VÁG2Á&Vvó7FW$V÷ñ¬Áf«VR¿¢77v˜&C¢V∆V÷VÁG2Á&Vvó7FW%77v˜&BÁf«VR¿¢ñÁfóFT6ˆFS¢V∆V÷VÁG2Á&Vvó7FW$ñÁfóFT6ˆFRÁf«VR¿¢“ì∞¢V∆V÷VÁG2Á&Vvó7FW%77v˜&BÁf«VR“"#∞¢V∆V÷VÁG2Á&Vvó7FW$ñÁfóFT6ˆFRÁf«VR“"#∞¢ñbá&W7V«BÊ6ˆÊfó&÷FñˆÂ&WVó&VBí∞¢6Ü˜t∆ˆvñ‰f˜&“Çì∞¢V∆V÷VÁG2Ê∆ˆvñ‰V÷ñ¬Áf«VR“&W7V«BÁW6W#ÚÊV÷ñ¬«¬"#∞¢6WDWFÑ÷W76vRÄ¢-	˝ÌMçΩ≠"R≠}MM]“‚	˝Ì--≠MÇçÕ]ùΩÇÇ˝ÌΩR-Ω]r‚"¿¢G'VR¿¢ì∞¢&WGW&„∞¢–¢6ˆÁ7B6W76ñˆ‚“vóB&VDWFÖ6W76ñˆ‚Çì∞¢ñbÇ6W76ñˆ‚ÊWFÜVÁFñ6FVBíFá&˜rÊWrW'&˜"Ç-
-]ç˝-›R]çR≠}MM]›‚"ì∞¢vóB7F'D∆ñ6Fñˆ‚á6W76ñˆ‚ÁW6W"ì∞¢“6F6ÇÜW'&˜"í∞¢6WDWFÑ÷W76vRÜW'&˜"Ê÷W76vRì∞¢“fñÊ∆«í∞¢6WDWFÑ'W7íÜf«6Rì∞¢–ß–†¶7ñÊ2gVÊ7Fñˆ‚ÜÊF∆T∆ˆv˜WBÇí∞¢V∆V÷VÁG2Ê∆ˆv˜WD'F‚ÊFó6&∆VB“G'VS∞¢G'í∞¢vóBfWF6ÇÇ"ˆíˆWFÇˆ∆ˆv˜WB"¬≤÷WFÜˆC¢%ı5B"“ì∞¢“fñÊ∆«í∞¢v∆ˆ&≈FÜó2Ê∆ˆ6Fñˆ‚Êá&Vb“"Ú#∞¢–ß–†¶gVÊ7Fñˆ‚«îWFÜVÁFñ6FVEW6W"áW6W"í∞¢7FFRÊWFÜVÁFñ6FVEW6W"“W6W#∞¢6ˆÁ7BFó7∆îÊ÷R“W6W#ÚÊFó7∆îÊ÷R«¬-	˝Ì-]ç-]≤#∞¢6ˆÁ7Bó4˜vÊW"“W6W#ÚÁ&ˆ∆R””“&˜vÊW"#∞¢V∆V÷VÁG2Á&ˆfñ∆TÊ÷RÁFWáD6ˆÁFVÁB“Fó7∆îÊ÷S∞¢V∆V÷VÁG2Á&ˆfñ∆TfF"ÁFWáD6ˆÁFVÁB–¢Fó7∆îÊ÷RÁG&ñ“ÇíÊ6Ü$BÉíÁFÙ∆ˆ6∆UWW$66RÇ&&r‘$r"í«¬-	Ú#∞¢V∆V÷VÁG2Á&ˆfñ∆U&ˆ∆RÁFWáD6ˆÁFVÁB“ó4˜vÊW ¢Ú-
-Ì--]›ç¢+r›-Ìù≠Ç ¢¢-
--]-Ì"˝ÌMç≤#∞¢Fˆ7V÷VÁBÊ&ˆGíÊFF6WBÁW6W%&ˆ∆R“ó4˜vÊW"Ú&˜vÊW""¢'FW7FW"#∞¢f˜"Ü6ˆÁ7BóFV“ˆbFˆ7V÷VÁBÁVW'ï6V∆V7F˜$∆¬Ç%∂FF÷˜vÊW"÷ˆÊ«ï“"íí∞¢óFV“ÊÜñFFV‚“ó4˜vÊW#∞¢–ß–†¶7ñÊ2gVÊ7Fñˆ‚ñÊóBÇí∞¢V∆V÷VÁG2Ê∆ˆvñ‰f˜&“ÊFDWfVÁD∆ó7FVÊW"Ç'7V&÷óB"¬ÜÊF∆T∆ˆvñ‚ì∞¢V∆V÷VÁG2Á&Vvó7FW$f˜&“ÊFDWfVÁD∆ó7FVÊW"Ç'7V&÷óB"¬ÜÊF∆U&Vvó7G&Fñˆ‚ì∞¢V∆V÷VÁG2Á6Ü˜u&Vvó7FW$'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬6Ü˜u&Vvó7FW$f˜&“ì∞¢V∆V÷VÁG2Ê&6µFÙ∆ˆvñ‰'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬6Ü˜t∆ˆvñ‰f˜&“ì∞†¢G'í∞¢6ˆÁ7B6W76ñˆ‚“vóB&VDWFÖ6W76ñˆ‚Çì∞¢7FFRÁ&Vvó7G&Fñˆ‰VÊ&∆VB“&ˆˆ∆V‚á6W76ñˆ‚Á&Vvó7G&Fñˆ‰VÊ&∆VBì∞¢V∆V÷VÁG2Á6Ü˜u&Vvó7FW$'F‚ÊÜñFFV‚“7FFRÁ&Vvó7G&Fñˆ‰VÊ&∆VC∞¢ñbá6W76ñˆ‚ÊWFÜVÁFñ6FVBí∞¢vóB7F'D∆ñ6Fñˆ‚á6W76ñˆ‚ÁW6W"ì∞¢&WGW&„∞¢–¢V∆V÷VÁG2ÊWFÑvFRÊÜñFFV‚“f«6S∞¢V∆V÷VÁG2Ê6ÜV∆¬ÊÜñFFV‚“G'VS∞¢ñbÇ6W76ñˆ‚Ê6ˆÊfñwW&VBí∞¢6WDWFÑ÷W76vRÄ¢-	-]ÌM≠"}-]-Ì-Ç˝ÌMçΩÇÌùR›RR≠-ç-ç“‚
-Ì--]›ç≠≠"ÕÌmRM-Ω]}RvóDáV"‚"¿¢ì∞¢–¢“6F6ÇÜW'&˜"í∞¢6WDWFÑ÷W76vRÜW'&˜"Ê÷W76vRì∞¢–ß–†¶7ñÊ2gVÊ7Fñˆ‚7F'D∆ñ6Fñˆ‚áW6W"í∞¢ñbá7FFRÊ∆ñ6FñˆÂ7F'FVBí&WGW&„∞¢7FFRÊ∆ñ6FñˆÂ7F'FVB“G'VS∞¢«îWFÜVÁFñ6FVEW6W"áW6W"ì∞¢V∆V÷VÁG2ÊWFÑvFRÊÜñFFV‚“G'VS∞¢V∆V÷VÁG2Ê6ÜV∆¬ÊÜñFFV‚“f«6S∞¢WFFU6W76ñˆ‰Fó7∆íÇì∞†¢V∆V÷VÁG2Á6VÊD'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬6VÊD÷W76vRì∞¢V∆V÷VÁG2ÊGF6Ñ'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬Çí”‡¢V∆V÷VÁG2Êñ÷vTñÁWBÊ6∆ñ6≤Çí¿¢ì∞¢V∆V÷VÁG2Êñ÷vTñÁWBÊFDWfVÁD∆ó7FVÊW"Ç&6ÜÊvR"¬ÜÊF∆Tñ÷vU6V∆V7Fñˆ‚ì∞¢V∆V÷VÁG2Á&V÷˜fTGF6Ü÷VÁD'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬6∆V%VÊFñÊtñ÷vRì∞¢V∆V÷VÁG2Ê6ÜDñÁWBÊFDWfVÁD∆ó7FVÊW"Ç&∂WñF˜v‚"¬ÜWfVÁBí”‚∞¢ñbÜWfVÁBÊ∂Wí””“$VÁFW""bbWfVÁBÁ6ÜñgD∂Wíí∞¢WfVÁBÁ&WfVÁDFVfV«BÇì∞¢6VÊD÷W76vRÇì∞¢–¢“ì∞¢V∆V÷VÁG2ÊÊWt6ÜD'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬7F'DÊWt6ÜBì∞¢V∆V÷VÁG2ÁFˆvv∆U7FGW4'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬˜VÂ7FGW2ì∞¢V∆V÷VÁG2Ê6∆˜6T6ˆÁFWáD'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬6∆˜6U7FGW2ì∞¢V∆V÷VÁG2Ê6ÜD÷W76vW2ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬ÜÊF∆T÷W76vT7Fñˆ‚ì∞¢V∆V÷VÁG2Ê6ˆÁfW'6Fñˆ‰∆ó7BÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬ÜÊF∆T6ˆÁfW'6Fñˆ‰6∆ñ6≤ì∞¢V∆V÷VÁG2Ê6ˆÁfW'6FñˆÂ6V&6ÇÊFDWfVÁD∆ó7FVÊW"Ç&ñÁWB"¬&VÊFW$6ˆÁfW'6Fñˆ‰∆ó7Bì∞¢V∆V÷VÁG2Á6V&6Ñ6ÜG4'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬Fˆvv∆T6ˆÁfW'6FñˆÂ6V&6Çì∞¢V∆V÷VÁG2Ê÷ˆ&ñ∆T÷VÁT'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬Fˆvv∆U6ñFV&"ì∞¢V∆V÷VÁG2Á6ñFV&$&6∂G&˜ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬6∆˜6U6ñFV&"ì∞¢V∆V÷VÁG2Êñ÷vW4'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬˜V‰ñ÷vUñ6∂W"ì∞¢V∆V÷VÁG2Ê÷ˆGV∆W4'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬˜V‰÷ˆGV∆W4G&vW"ì∞¢V∆V÷VÁG2ÁFˆˆ«4'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬˜VÂFˆˆ«4G&vW"ì∞¢V∆V÷VÁG2Á7ó7FV‘6ˆÊfñwW&Fñˆ‰'F‚ÊFDWfVÁD∆ó7FVÊW"Ä¢&6∆ñ6≤"¿¢˜VÂ7ó7FV‘6ˆÊfñwW&Fñˆ‰G&vW"¿¢ì∞¢V∆V÷VÁG2Ê÷V÷˜'î'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬˜V‰÷V÷˜'îG&vW"ì∞¢V∆V÷VÁG2ÁW&÷ó76ñˆÁ4'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬˜VÂW&÷ó76ñˆÁ4G&vW"ì∞¢V∆V÷VÁG2Ê6∆˜6TFFG&vW$'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬6∆˜6TFFG&vW"ì∞¢V∆V÷VÁG2ÊG&vW$&6∂G&˜ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬6∆˜6TFFG&vW"ì∞¢V∆V÷VÁG2ÊFFG&vW$&ˆGíÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬ÜÊF∆TFFG&vW$7Fñˆ‚ì∞¢V∆V÷VÁG2Áfˆñ6T'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬Fˆvv∆Ufˆñ6TñÁWBì∞¢V∆V÷VÁG2Ê∆ˆv˜WD'F‚ÊFDWfVÁD∆ó7FVÊW"Ç&6∆ñ6≤"¬ÜÊF∆T∆ˆv˜WBì∞¢Fˆ7V÷VÁBÊFDWfVÁD∆ó7FVÊW"Ç&∂WñF˜v‚"¬ÜÊF∆Tv∆ˆ&ƒ∂WñF˜v‚ì∞¢&W&Ufˆñ6TñÁWBÇì∞†¢6ÜV6¥ÜV«FÇÇì∞¢6ÜV6¥˜VÂ6V&6ÇÇì∞¢6WDñÁFW'f¬Ü6ÜV6¥ÜV«FÇ¬ì∞¢6WDñÁFW'f¬Ü6ÜV6¥˜VÂ6V&6Ç¬#ì∞†¢vóB&W7F˜&T6ˆÁfW'6Fñˆ‚Çì∞¢vóB∆ˆD6ˆÁfW'6FñˆÁ2Çì∞ß–†¶gVÊ7Fñˆ‚WFFU6W76ñˆ‰Fó7∆íÇí∞¢V∆V÷VÁG2Á6W76ñˆ‰ñDFó7∆íÁFWáD6ˆÁFVÁB“7FFRÁ6W76ñˆ‰ñC∞ß–†¶7ñÊ2gVÊ7Fñˆ‚6Ü˜uvV∆6ˆ÷T÷W76vRÇí∞¢VÊD÷W76vRÄ¢&vVÁB"¿¢∞¢"225î‰4Ö$Ù‚’Ç"¿¢"¢≠
---Ì˝-Ωç}›íÌ˝]mçÌ››ç-]Õ‚¢¢"¿¢""¿¢-	]M›‚í˝M‚¬˝Ì-Ì˝››≠Ì›-ÌΩç›˝Õ]"Ç}]ç]›Çç›-=Õ]›-Ç}]Ω›Ç}M}Ç‚"¿¢""¿¢$í--≠"RÕÌ˝"›}ç“›Ìù=-›R‚
--Ç≠Ì›-ÌΩçÇM››ç-R¬˝Õ]--Çç≠Ì-ç-RM]ù--çÚ‚"¿¢“Ê¶ˆñ‚Ç%∆‚"í¿¢ì∞ß–†¶7ñÊ2gVÊ7Fñˆ‚&W7F˜&T6ˆÁfW'6Fñˆ‚Çí∞¢G'í∞¢6ˆÁ7B&W7ˆÁ6R“vóBfWF6ÇÄ¢"ˆ÷V÷˜'íˆ6ˆÁfW'6Fñˆ‚Ú"≤VÊ6ˆFUU$î6ˆ◊ˆÊVÁBá7FFRÁ6W76ñˆ‰ñBí¿¢≤66ÜS¢&ÊÚ◊7F˜&R"“¿¢ì∞¢ñbÇ&W7ˆÁ6RÊˆ≤íFá&˜rÊWrW'&˜"Ç-	ç-Ìç˝-›RRMÌ-≠˝›‚"ì∞¢6ˆÁ7BFF“vóB&W7ˆÁ6RÊß6ˆ‚Çì∞¢÷&¥÷V÷˜'î˜W&FñˆÊ¬Çì∞¢6ˆÁ7BóFV◊2“'&íÊó4'&íÜFFÊóFV◊2íÚFFÊóFV◊2¢µ”∞¢ñbÜóFV◊2Ê∆VÊwFÇ””“í∞¢vóB6Ü˜uvV∆6ˆ÷T÷W76vRÇì∞¢&WGW&„∞¢–¢f˜"Ü6ˆÁ7BóFV“ˆbóFV◊2í∞¢ñbÄ¢ÜóFV“Á&ˆ∆R””“'W6W""«¬óFV“Á&ˆ∆R””“&76ó7FÁB"íb`¢GóVˆbóFV“Ê6ˆÁFVÁB””“'7G&ñÊr ¢í∞¢VÊD÷W76vRÄ¢óFV“Á&ˆ∆R””“&76ó7FÁB"Ú&vVÁB"¢'W6W""¿¢óFV“Ê6ˆÁFVÁB¿¢ì∞¢–¢–¢∆ˆt7Fñˆ‚Ç-	-≠}-›Ì-]›Rç-Ìç˝-›}=Ì-Ì"ì∞¢“6F6ÇÜW'&˜"í∞¢6ˆÁ6ˆ∆RÊW'&˜"ÜW'&˜"ì∞¢vóB6Ü˜uvV∆6ˆ÷T÷W76vRÇì∞¢∆ˆt7Fñˆ‚Ç-	ç-Ìç˝-›RÕÌmM≠MR-≠}-›Ì-]›"ì∞¢–ß–†¶7ñÊ2gVÊ7Fñˆ‚7F'DÊWt6ÜBÇí∞¢ñbá7FFRÊ6ÜD'W7íí&WGW&„∞¢6∆˜6U6ñFV&"Çì∞¢6∆V%VÊFñÊtñ÷vRÇì∞¢7FFRÁ6W76ñˆ‰ñB“7&VFU6W76ñˆ‰ñBÇì∞¢∆ˆ6≈7F˜&vRÁ6WDóFV“Ç'7ñÊ6á&ˆÂ6W76ñˆ‰ñB"¬7FFRÁ6W76ñˆ‰ñBì∞¢7FFRÊ∆7D7FñˆÁ2“µ”∞¢V∆V÷VÁG2Ê6ÜD÷W76vW2Á&W∆6T6Üñ∆G&V‚Çì∞¢WFFU6W76ñˆ‰Fó7∆íÇì∞¢&VÊFW$7FñˆÁ4∆ˆrÇì∞¢vóB6Ü˜uvV∆6ˆ÷T÷W76vRÇì∞¢∆ˆt7Fñˆ‚Ç-	}˝Ì}›"R›Ì"}=Ì-Ì"ì∞¢&VÊFW$6ˆÁfW'6Fñˆ‰∆ó7BÇì∞¢V∆V÷VÁG2Ê6ÜDñÁWBÊfˆ7W2Çì∞ß–†¶7ñÊ2gVÊ7Fñˆ‚∆ˆD6ˆÁfW'6FñˆÁ2Çí∞¢G'í∞¢6ˆÁ7B&W7ˆÁ6R“vóBfWF6ÇÇ"ˆ÷V÷˜'íˆ6ˆÁfW'6FñˆÁ2"¬∞¢66ÜS¢&ÊÚ◊7F˜&R"¿¢“ì∞¢ñbÇ&W7ˆÁ6RÊˆ≤íFá&˜rÊWrW'&˜"Ç-
-˝ç≠≠≠"›RRMÌ-≠˝]“‚"ì∞¢6ˆÁ7BFF“vóB&W7ˆÁ6RÊß6ˆ‚Çì∞¢7FFRÊ6ˆÁfW'6FñˆÁ2“'&íÊó4'&íÜFFÊóFV◊2íÚFFÊóFV◊2¢µ”∞¢7FFRÊ6ˆÁfW'6Fñˆ‰∆ˆDW'&˜"“"#∞¢&VÊFW$6ˆÁfW'6Fñˆ‰∆ó7BÇì∞¢“6F6ÇÜW'&˜"í∞¢6ˆÁ6ˆ∆RÊW'&˜"ÜW'&˜"ì∞¢7FFRÊ6ˆÁfW'6FñˆÁ2“µ”∞¢7FFRÊ6ˆÁfW'6Fñˆ‰∆ˆDW'&˜"–¢-	ç-Ìç˝--]Õ]››‚›RRMÌ-≠˝›‚	Ì˝ç-íÌ-›Ì-‚‚#∞¢&VÊFW$6ˆÁfW'6Fñˆ‰∆ó7BÇì∞¢–ß–†¶gVÊ7Fñˆ‚&VÊFW$6ˆÁfW'6Fñˆ‰∆ó7BÇí∞¢6ˆÁ7BVW'í“V∆V÷VÁG2Ê6ˆÁfW'6FñˆÂ6V&6ÇÁf«VP¢ÁG&ñ“Çê¢ÁFÙ∆ˆ6∆T∆˜vW$66RÇ&&r‘$r"ì∞¢6ˆÁ7B6ˆÁfW'6FñˆÁ2“7FFRÊ6ˆÁfW'6FñˆÁ2Êfñ«FW"Ä¢ÜóFV“í”‚VW'í«¬óFV“ÁFóF∆RÁFÙ∆ˆ6∆T∆˜vW$66RÇ&&r‘$r"íÊñÊ6«VFW2áVW'íí¿¢ì∞¢V∆V÷VÁG2Ê6ˆÁfW'6Fñˆ‰∆ó7BÁ&W∆6T6Üñ∆G&V‚Çì∞†¢ñbá7FFRÊ6ˆÁfW'6Fñˆ‰∆ˆDW'&˜"í∞¢6ˆÁ7BW'&˜"“Fˆ7V÷VÁBÊ7&VFTV∆V÷VÁBÇ'"ì∞¢W'&˜"Ê6∆74Ê÷R“&6ˆÁfW'6Fñˆ‚◊7FFR6ˆÁfW'6Fñˆ‚◊7FFR÷W'&˜"#∞¢W'&˜"ÁFWáD6ˆÁFVÁB“7FFRÊ6ˆÁfW'6Fñˆ‰∆ˆDW'&˜#∞¢V∆V÷VÁG2Ê6ˆÁfW'6Fñˆ‰∆ó7BÊVÊD6Üñ∆BÜW'&˜"ì∞¢&WGW&„∞¢–†¢ñbÜ6ˆÁfW'6FñˆÁ2Ê∆VÊwFÇ””“í∞¢6ˆÁ7BV◊Gí“Fˆ7V÷VÁBÊ7&VFTV∆V÷VÁBÇ'"ì∞¢V◊GíÊ6∆74Ê÷R“&6ˆÁfW'6Fñˆ‚◊7FFR#∞¢V◊GíÁFWáD6ˆÁFVÁB“VW'ê¢Ú-	›˝Õ›Õ]]›Ç}=Ì-ÌÇ‚ ¢¢-	-RÌùR›˝Õ}˝}]›Ç}=Ì-ÌÇ‚#∞¢V∆V÷VÁG2Ê6ˆÁfW'6Fñˆ‰∆ó7BÊVÊD6Üñ∆BÜV◊Gíì∞¢&WGW&„∞¢–†¢f˜"Ü6ˆÁ7BóFV“ˆb6ˆÁfW'6FñˆÁ2í∞¢6ˆÁ7B'WGFˆ‚“Fˆ7V÷VÁBÊ7&VFTV∆V÷VÁBÇ&'WGFˆ‚"ì∞¢'WGFˆ‚ÁGóR“&'WGFˆ‚#∞¢'WGFˆ‚Ê6∆74Ê÷R“&6ˆÁfW'6Fñˆ‚#∞¢ñbÜóFV“Á6W76ñˆ‰ñB””“7FFRÁ6W76ñˆ‰ñBí'WGFˆ‚Ê6∆74∆ó7BÊFBÇ&7FófR"ì∞¢'WGFˆ‚ÊFF6WBÁ6W76ñˆ‰ñB“óFV“Á6W76ñˆ‰ñC∞¢'WGFˆ‚ÁFWáD6ˆÁFVÁB“óFV“ÁFóF∆S∞¢V∆V÷VÁG2Ê6ˆÁfW'6Fñˆ‰∆ó7BÊVÊD6Üñ∆BÜ'WGFˆ‚ì∞¢–ß–†¶7ñÊ2gVÊ7Fñˆ‚ÜÊF∆T6ˆÁfW'6Fñˆ‰6∆ñ6≤ÜWfVÁBí∞¢6ˆÁ7B'WGFˆ‚“WfVÁBÁF&vWBÊ6∆˜6W7BÇ&'WGFˆÂ∂FF◊6W76ñˆ‚÷ñE“"ì∞¢ñbÇ'WGFˆ‚«¬7FFRÊ6ÜD'W7í«¬'WGFˆ‚ÊFF6WBÁ6W76ñˆ‰ñB””“7FFRÁ6W76ñˆ‰ñBê¢&WGW&„∞¢7FFRÁ6W76ñˆ‰ñB“'WGFˆ‚ÊFF6WBÁ6W76ñˆ‰ñC∞¢∆ˆ6≈7F˜&vRÁ6WDóFV“Ç'7ñÊ6á&ˆÂ6W76ñˆ‰ñB"¬7FFRÁ6W76ñˆ‰ñBì∞¢V∆V÷VÁG2Ê6ÜD÷W76vW2Á&W∆6T6Üñ∆G&V‚Çì∞¢WFFU6W76ñˆ‰Fó7∆íÇì∞¢&VÊFW$6ˆÁfW'6Fñˆ‰∆ó7BÇì∞¢vóB&W7F˜&T6ˆÁfW'6Fñˆ‚Çì∞¢6∆˜6U6ñFV&"Çì∞ß–†¶gVÊ7Fñˆ‚Fˆvv∆U6ñFV&"Çí∞¢6ˆÁ7Bó4˜V‚“V∆V÷VÁG2Á6ñFV&"Ê6∆74∆ó7BÁFˆvv∆RÇ&÷ˆ&ñ∆R◊fó6ñ&∆R"ì∞¢V∆V÷VÁG2Á6ñFV&$&6∂G&˜ÊÜñFFV‚“ó4˜V„∞¢V∆V÷VÁG2Ê÷ˆ&ñ∆T÷VÁT'F‚Á6WDGG&ñ'WFRÇ&&ñ÷WáÊFVB"¬7G&ñÊrÜó4˜V‚íì∞ß–†¶gVÊ7Fñˆ‚6∆˜6U6ñFV&"Çí∞¢V∆V÷VÁG2Á6ñFV&"Ê6∆74∆ó7BÁ&V÷˜fRÇ&÷ˆ&ñ∆R◊fó6ñ&∆R"ì∞¢V∆V÷VÁG2Á6ñFV&$&6∂G&˜ÊÜñFFV‚“G'VS∞¢V∆V÷VÁG2Ê÷ˆ&ñ∆T÷VÁT'F‚Á6WDGG&ñ'WFRÇ&&ñ÷WáÊFVB"¬&f«6R"ì∞ß–†¶gVÊ7Fñˆ‚˜V‰ñ÷vUñ6∂W"Çí∞¢6∆˜6U6ñFV&"Çì∞¢V∆V÷VÁG2Êñ÷vTñÁWBÊ6∆ñ6≤Çì∞ß–†¶gVÊ7Fñˆ‚ÜÊF∆Tv∆ˆ&ƒ∂WñF˜v‚ÜWfVÁBí∞¢ñbÜWfVÁBÊ∂Wí”“$W66R"í&WGW&„∞¢6∆˜6U6ñFV&"Çì∞¢6∆˜6U7FGW2Çì∞¢6∆˜6TFFG&vW"Çì∞ß–†¶gVÊ7Fñˆ‚Fˆvv∆T6ˆÁfW'6FñˆÂ6V&6ÇÇí∞¢V∆V÷VÁG2Ê6ˆÁfW'6FñˆÂ6V&6ÇÊÜñFFV‚“f«6S∞¢V∆V÷VÁG2Ê6ˆÁfW'6Fñˆ‰∆ó7@¢Ê6∆˜6W7BÇ"Á6ñFV&"◊6V7Fñˆ‚"ê¢ÚÁ67&ˆ∆ƒñÁFıfñWrá≤&∆ˆ6≥¢'7F'B"¬&VÜfñ˜#¢'6÷ˆ˜FÇ"“ì∞¢V∆V÷VÁG2Ê6ˆÁfW'6FñˆÂ6V&6ÇÊfˆ7W2á≤&WfVÁE67&ˆ∆√¢G'VR“ì∞ß–†¶gVÊ7Fñˆ‚ÜÊF∆Tñ÷vU6V∆V7Fñˆ‚ÜWfVÁBí∞¢6ˆÁ7Bfñ∆R“WfVÁBÁF&vWBÊfñ∆W3ÚÂ≥”∞¢ñbÇfñ∆Rí&WGW&„∞†¢6ˆÁ7B∆∆˜vVEGóW2“≤&ñ÷vRˆßVr"¬&ñ÷vR˜Êr"¬&ñ÷vR˜vV'%”∞¢ñbÇ∆∆˜vVEGóW2ÊñÊ6«VFW2Üfñ∆RÁGóRíí∞¢VÊD÷W76vRÇ&vVÁB"¬.)ÿ¬	˝ÌMM≠m"RÕ‚•Tr¬‰rÇvV%›çÕ≠Ç‚"ì∞¢6∆V%VÊFñÊtñ÷vRÇì∞¢&WGW&„∞¢–†¢ñbÜfñ∆RÁ6ó¶R‚R¢#B¢#Bí∞¢VÊD÷W76vRÇ&vVÁB"¬.)ÿ¬
-›çÕ≠--˝-M≠MRM‚R‘"‚"ì∞¢6∆V%VÊFñÊtñ÷vRÇì∞¢&WGW&„∞¢–†¢6ˆÁ7B&VFW"“ÊWrfñ∆U&VFW"Çì∞¢&VFW"ÊˆÊ∆ˆB“Çí”‚∞¢7FFRÁVÊFñÊtñ÷vR“∞¢FFW&√¢&VFW"Á&W7V«B¿¢÷ñ÷UGóS¢fñ∆RÁGóR¿¢Ê÷S¢fñ∆RÊÊ÷R¿¢”∞¢V∆V÷VÁG2ÊGF6Ü÷VÁDñ÷vRÁ7&2“&VFW"Á&W7V«C∞¢V∆V÷VÁG2ÊGF6Ü÷VÁDÊ÷RÁFWáD6ˆÁFVÁB“fñ∆RÊÊ÷S∞¢V∆V÷VÁG2ÊGF6Ü÷VÁE&WfñWrÊÜñFFV‚“f«6S∞¢V∆V÷VÁG2Ê6ÜDñÁWBÊfˆ7W2Çì∞¢”∞¢&VFW"ÊˆÊW'&˜"“Çí”‚∞¢VÊD÷W76vRÇ&vVÁB"¬.)ÿ¬
-›çÕ≠-›RÕÌmM≠MR˝Ì}]-]›‚"ì∞¢6∆V%VÊFñÊtñ÷vRÇì∞¢”∞¢&VFW"Á&VD4FFU$¬Üfñ∆Rì∞ß–†¶gVÊ7Fñˆ‚6∆V%VÊFñÊtñ÷vRÇí∞¢7FFRÁVÊFñÊtñ÷vR“ÁV∆√∞¢V∆V÷VÁG2Êñ÷vTñÁWBÁf«VR“"#∞¢V∆V÷VÁG2ÊGF6Ü÷VÁDñ÷vRÁ&V÷˜fTGG&ñ'WFRÇ'7&2"ì∞¢V∆V÷VÁG2ÊGF6Ü÷VÁDÊ÷RÁFWáD6ˆÁFVÁB“"#∞¢V∆V÷VÁG2ÊGF6Ü÷VÁE&WfñWrÊÜñFFV‚“G'VS∞ß–†¶gVÊ7Fñˆ‚˜VÂ7FGW2Çí∞¢6∆˜6U6ñFV&"Çì∞¢V∆V÷VÁG2Á7FGW5ÊV¬Ê6∆74∆ó7BÊFBÇ&÷ˆ&ñ∆R◊fó6ñ&∆R"ì∞ß–†¶gVÊ7Fñˆ‚6∆˜6U7FGW2Çí∞¢V∆V÷VÁG2Á7FGW5ÊV¬Ê6∆74∆ó7BÁ&V÷˜fRÇ&÷ˆ&ñ∆R◊fó6ñ&∆R"ì∞ß–†¶gVÊ7Fñˆ‚&W&Ufˆñ6TñÁWBÇí∞¢6ˆÁ7B7VV6Ö&V6ˆvÊóFñˆ‚–¢vñÊF˜rÂ7VV6Ö&V6ˆvÊóFñˆ‚«¬vñÊF˜rÁvV&∂óE7VV6Ö&V6ˆvÊóFñˆ„∞¢ñbÇ7VV6Ö&V6ˆvÊóFñˆ‚í∞¢V∆V÷VÁG2Áfˆñ6T'F‚ÊÜñFFV‚“G'VS∞¢&WGW&„∞¢–†¢6ˆÁ7B&V6ˆvÊóFñˆ‚“ÊWr7VV6Ö&V6ˆvÊóFñˆ‚Çì∞¢&V6ˆvÊóFñˆ‚Ê∆Êr“&&r‘$r#∞¢&V6ˆvÊóFñˆ‚Ê6ˆÁFñÁV˜W2“f«6S∞¢&V6ˆvÊóFñˆ‚ÊñÁFW&ñ’&W7V«G2“G'VS∞†¢&V6ˆvÊóFñˆ‚ÊˆÁ7F'B“Çí”‚6WD∆ó7FVÊñÊráG'VRì∞¢&V6ˆvÊóFñˆ‚ÊˆÊVÊB“Çí”‚6WD∆ó7FVÊñÊrÜf«6Rì∞¢&V6ˆvÊóFñˆ‚ÊˆÊW'&˜"“ÜWfVÁBí”‚∞¢6WD∆ó7FVÊñÊrÜf«6Rì∞¢ñbÜWfVÁBÊW'&˜"”“&&˜'FVB"bbWfVÁBÊW'&˜"”“&ÊÚ◊7VV6Ç"í∞¢VÊD÷W76vRÄ¢&vVÁB"¿¢-	=ΩÌ-Ì-‚-≠-]mM›R›RÕÌmM--ç‚	˝Ì-]ÇMÌ-≠˝M‚Õç≠ÌMÌ›‚"¿¢ì∞¢–¢”∞¢&V6ˆvÊóFñˆ‚ÊˆÁ&W7V«B“ÜWfVÁBí”‚∞¢∆WBG&Á67&óB“"#∞¢f˜"Ä¢∆WBñÊFWÇ“WfVÁBÁ&W7V«DñÊFWÉ∞¢ñÊFWÇ¬WfVÁBÁ&W7V«G2Ê∆VÊwFÉ∞¢ñÊFWÇ≥“¢í∞¢G&Á67&óB≥“WfVÁBÁ&W7V«G5∂ñÊFWÖ’≥“ÁG&Á67&óC∞¢–¢V∆V÷VÁG2Ê6ÜDñÁWBÁf«VR“G&Á67&óBÁG&ñ“Çì∞¢6ˆÁ7B∆7E&W7V«B“WfVÁBÁ&W7V«G5∂WfVÁBÁ&W7V«G2Ê∆VÊwFÇ“”∞¢ñbÜ∆7E&W7V«CÚÊó4fñÊ¬íV∆V÷VÁG2Ê6ÜDñÁWBÊfˆ7W2Çì∞¢”∞¢7FFRÁ&V6ˆvÊóFñˆ‚“&V6ˆvÊóFñˆ„∞ß–†¶gVÊ7Fñˆ‚6WD∆ó7FVÊñÊrÜó4∆ó7FVÊñÊrí∞¢7FFRÊ∆ó7FVÊñÊr“ó4∆ó7FVÊñÊs∞¢V∆V÷VÁG2Áfˆñ6T'F‚Ê6∆74∆ó7BÁFˆvv∆RÇ&∆ó7FVÊñÊr"¬ó4∆ó7FVÊñÊrì∞¢V∆V÷VÁG2Áfˆñ6T'F‚Á6WDGG&ñ'WFRÇ&&ñ◊&W76VB"¬7G&ñÊrÜó4∆ó7FVÊñÊríì∞¢V∆V÷VÁG2Áfˆñ6T'F‚ÁFóF∆R“ó4∆ó7FVÊñÊp¢Ú-
-˝ÇΩ=ç›]-‚ ¢¢-	=ΩÌ-‚-≠-]mM›R#∞ß–†¶gVÊ7Fñˆ‚Fˆvv∆Ufˆñ6TñÁWBÇí∞¢ñbÇ7FFRÁ&V6ˆvÊóFñˆ‚«¬7FFRÊ6ÜD'W7íí&WGW&„∞¢ñbá7FFRÊ∆ó7FVÊñÊrí∞¢7FFRÁ&V6ˆvÊóFñˆ‚Á7F˜Çì∞¢“V«6R∞¢7FFRÁ&V6ˆvÊóFñˆ‚Á7F'BÇì∞¢–ß–†¶gVÊ7Fñˆ‚˜V‰÷ˆGV∆W4G&vW"Çí∞¢˜V‰FFG&vW"Ç-
-Ì-›ÇÌΩ-Ç"ì∞¢V∆V÷VÁG2ÊFFG&vW$&ˆGíÊñÊÊW$ÖD‘¬“ ¢∆Fób6∆73“&÷ˆGV∆R◊7V÷÷'í#‡¢
--Ì-ÌΩ-Ç¬"≠Ìç-‚Ωç}›-íÌ˝]mçÌ››ç-]Õç}˝ÌΩ}-}=Ì-Ì¿¢˝Õ]--Ç}]ç]›ç-Rç›-=Õ]›-Ç‚	ÌΩ--Õ˝‚]RÇ›P¢Ì}›}-¬}R-≠›ç›=Ω==R-≠}›‡¢¬ˆFóc‡¢«6V7Fñˆ‚6∆73“&G&vW"◊6V7Fñˆ‚W&÷ó76ñˆ‚÷∆ó7B÷ˆGV∆R÷∆ó7B"FF÷÷ˆGV∆R÷∆ó7C„¬˜6V7Fñˆ„Ê∞¢Fˆ7V÷VÁBÊFó7F6ÑWfVÁBÜÊWr7W7Fˆ‘WfVÁBÇ'7ñÊ6á&ˆ„¶÷ˆGV∆W2÷˜VÊVB"íì∞ß–†¶gVÊ7Fñˆ‚ó4vˆˆv∆UFˆˆ¬áFˆˆ¬í∞¢&WGW&‚Ä¢Fˆˆ√ÚÁ&˜fñFW"””“&vˆˆv∆R"«¿¢Fˆˆ√ÚÊñCÚÁ7F'G5vóFÇÇ&vˆˆv∆R“"í«¿¢Fˆˆ√ÚÊñB””“&v÷ñ¬◊&VB ¢ì∞ß–†¶gVÊ7Fñˆ‚Fˆˆ≈7FFRáFˆˆ¬¬vˆˆv∆T6ˆÊÊV7FVB¬vóFáV$6ˆÊÊV7FVBí∞¢ñbáFˆˆ¬Êfñ∆&ñ∆óGî6ˆFR””“$4ıîƒıEÙUDÙ‘DîÙÂÙDï4$ƒTB"í∞¢&WGW&‚≤∆&V√¢-	ç}≠ΩÌ}]›‚+r]mç¬]r6˜ñ∆˜B"¬6∆74Ê÷S¢&6ˆÊfó&“"”∞¢–¢ñbÇFˆˆ¬ÊVÊ&∆VB«¬Fˆˆ¬ÊWÜV7WF&∆Rí∞¢&WGW&‚≤∆&V√¢-	›RR-≠}“"¬6∆74Ê÷S¢&FVÁí"”∞¢–¢ñbÇFˆˆ¬Ê6ˆÊfñwW&VBí∞¢&WGW&‚≤∆&V√¢-	›RR≠Ì›Mç==ç“"¬6∆74Ê÷S¢&FVÁí"”∞¢–¢ñbÜó4vˆˆv∆UFˆˆ¬áFˆˆ¬íbbvˆˆv∆T6ˆÊÊV7FVBí∞¢&WGW&‚≤∆&V√¢-	ç≠-≠}-›R"¬6∆74Ê÷S¢&6ˆÊfó&“"”∞¢–¢ñbáFˆˆ¬ÊñB””“&vóFáV"◊w&óFR"bbvóFáV$6ˆÊÊV7FVBí∞¢&WGW&‚≤∆&V√¢-	ç≠-≠}-›R"¬6∆74Ê÷S¢&6ˆÊfó&“"”∞¢–¢&WGW&‚≤∆&V√¢-
-Ì-Ç"¬6∆74Ê÷S¢&∆∆˜r"”∞ß–†¶gVÊ7Fñˆ‚Fˆˆ≈7FGW47FñˆÁ2áFˆˆ¬¬7FGW2¬vˆˆv∆T6ˆÊÊV7FVB¬vóFáV$6ˆÊÊV7FVBí∞¢∆WB7Fñˆ‚“"#∞¢ñbáFˆˆ¬Êfñ∆&ñ∆óGî6ˆFR””“$4ıîƒıEÙUDÙ‘DîÙÂÙDï4$ƒTB"í∞¢7Fñˆ‚“"#∞¢“V«6RñbÜó4vˆˆv∆UFˆˆ¬áFˆˆ¬íbbvˆˆv∆T6ˆÊÊV7FVBbbFˆˆ¬Ê6ˆÊfñwW&VBí∞¢7Fñˆ‚–¢s∆'WGFˆ‚GóS“&'WGFˆ‚"6∆73“'Fˆˆ¬÷6ˆÊÊV7B÷'F‚"FF÷6ˆÊÊV7B◊6W'fñ6S“&vˆˆv∆R#Ì
--≠mÇvˆˆv∆S¬ˆ'WGFˆ„‚s∞¢“V«6RñbÄ¢Fˆˆ¬ÊñB””“&vóFáV"◊w&óFR"b`¢Fˆˆ¬Ê6ˆÊfñwW&VBb`¢vóFáV$6ˆÊÊV7FV@¢í∞¢7Fñˆ‚–¢s∆'WGFˆ‚GóS“&'WGFˆ‚"6∆73“'Fˆˆ¬÷6ˆÊÊV7B÷'F‚"FF÷6ˆÊÊV7B◊6W'fñ6S“&vóFáV"#Ì
--≠mÇvóDáV#¬ˆ'WGFˆ„‚s∞¢“V«6RñbáFˆˆ¬ÊñB””“&vóFáV"◊w&óFR"bbFˆˆ¬Ê6ˆÊfñwW&VBí∞¢7Fñˆ‚–¢s∆'WGFˆ‚GóS“&'WGFˆ‚"6∆73“'Fˆˆ¬÷6ˆÊÊV7B÷'F‚"FF÷vóFáV"◊6WGWÌ	›-ÌívóDáV#¬ˆ'WGFˆ„‚s∞¢–†¢&WGW&‚ ¢∆Fób6∆73“'Fˆˆ¬◊7FGW2÷7FñˆÁ2#‡¢«7‚6∆73“'W&÷ó76ñˆ‚÷&FvRG∑7FGW2Ê6∆74Ê÷W“#‚G∑7FGW2Ê∆&V«”¬˜7„‡¢G∂7FñˆÁ–¢¬ˆFócÊ∞ß–†¶gVÊ7Fñˆ‚W&÷ó76ñˆ‰7Fñˆ‚ÜóFV“¬Fˆˆƒ÷¬vˆˆv∆T6ˆÊÊV7FVB¬vóFáV$6ˆÊÊV7FVBí∞¢6ˆÁ7Bvˆˆv∆UW&÷ó76ñˆÁ2“ÊWr6WBÖ∞¢&6∆VÊF"Á&VB"¿¢&6∆VÊF"Áw&óFR"¿¢&G&ófRÁ&VB"¿¢&÷ñ¬Á&VB"¿¢“ì∞¢ñbÜvˆˆv∆UW&÷ó76ñˆÁ2ÊÜ2ÜóFV“Ê7Fñˆ‚íbbvˆˆv∆T6ˆÊÊV7FVBí∞¢&WGW&‚s∆'WGFˆ‚GóS“&'WGFˆ‚"6∆73“'Fˆˆ¬÷6ˆÊÊV7B÷'F‚"FF÷6ˆÊÊV7B◊6W'fñ6S“&vˆˆv∆R#Ì
--≠mÇvˆˆv∆S¬ˆ'WGFˆ„‚s∞¢–†¢6ˆÁ7BvóFáV%w&óFR“Fˆˆƒ÷ÊvWBÇ&vóFáV"◊w&óFR"ì∞¢ñbÄ¢óFV“Ê7Fñˆ‚””“&vóFáV"Áw&óFR"b`¢vóFáV%w&óFSÚÊfñ∆&ñ∆óGî6ˆFR””“$4ıîƒıEÙUDÙ‘DîÙÂÙDï4$ƒTB ¢í∞¢&WGW&‚"#∞¢–¢ñbÄ¢óFV“Ê7Fñˆ‚””“&vóFáV"Áw&óFR"b`¢vóFáV%w&óFSÚÊ6ˆÊfñwW&VBb`¢vóFáV%w&óFSÚÊWÜV7WF&∆Rb`¢vóFáV$6ˆÊÊV7FV@¢í∞¢&WGW&‚s∆'WGFˆ‚GóS“&'WGFˆ‚"6∆73“'Fˆˆ¬÷6ˆÊÊV7B÷'F‚"FF÷6ˆÊÊV7B◊6W'fñ6S“&vóFáV"#Ì
--≠mÇvóDáV#¬ˆ'WGFˆ„‚s∞¢–¢ñbÄ¢óFV“Ê7Fñˆ‚””“&vóFáV"Áw&óFR"b`¢ÇvóFáV%w&óFSÚÊ6ˆÊfñwW&VB«¬vóFáV%w&óFSÚÊWÜV7WF&∆Rê¢í∞¢&WGW&‚s∆'WGFˆ‚GóS“&'WGFˆ‚"6∆73“'Fˆˆ¬÷6ˆÊÊV7B÷'F‚"FF÷vóFáV"◊6WGWÌ	›-ÌívóDáV#¬ˆ'WGFˆ„‚s∞¢–†¢ñbÜóFV“ÊFV6ó6ñˆ‚””“&6ˆÊfó&“"í∞¢&WGW&‚∆'WGFˆ‚GóS“&'WGFˆ‚"6∆73“'W&÷ó76ñˆ‚÷ñÊfÚ÷'F‚"FF◊W&÷ó76ñˆ‚÷ñÊfÛ“"G∂W66TáF÷¬ÜóFV“Ê7Fñˆ‚ó“#Ì	≠¢Ì-É¬ˆ'WGFˆ„Ê∞¢–¢&WGW&‚"#∞ß–†¶7ñÊ2gVÊ7Fñˆ‚˜VÂFˆˆ«4G&vW"Çí∞¢˜V‰FFG&vW"Ç-	ç›-=Õ]›-Ç"ì∞¢&VÊFW$G&vW$∆ˆFñÊrÇì∞¢G'í∞¢6ˆÁ7B∂ÜV«FÖ&W7ˆÁ6R¬vˆˆv∆U&W7ˆÁ6R¬vóFáV%&W7ˆÁ6U““vóB&ˆ÷ó6RÊ∆¬Ö∞¢fWF6ÇÇ"ˆÜV«FÇˆñÁFVw&FñˆÁ2"¬≤66ÜS¢&ÊÚ◊7F˜&R"“í¿¢fWF6ÇÇ"ˆíˆvˆˆv∆R˜7FGW2"¬≤66ÜS¢&ÊÚ◊7F˜&R"“íÊ6F6ÇÇÇí”‚ÁV∆¬í¿¢fWF6ÇÇ"ˆíˆvóFáV"˜7FGW2"¬≤66ÜS¢&ÊÚ◊7F˜&R"“íÊ6F6ÇÇÇí”‚ÁV∆¬í¿¢“ì∞¢ñbÇÜV«FÖ&W7ˆÁ6RÊˆ≤í∞¢Fá&˜rÊWrW'&˜"Ç-
-≠-Ì˝›ç]-‚›ç›-=Õ]›-ç-R›RRMÌ-≠˝›‚‚"ì∞¢–¢6ˆÁ7BFF“vóBÜV«FÖ&W7ˆÁ6RÊß6ˆ‚Çì∞¢6ˆÁ7Bvˆˆv∆TFF“vˆˆv∆U&W7ˆÁ6SÚÊˆ∞¢ÚvóBvˆˆv∆U&W7ˆÁ6RÊß6ˆ‚ÇíÊ6F6ÇÇÇí”‚á∑“íê¢¢∑”∞¢6ˆÁ7BvóFáV$FF“vóFáV%&W7ˆÁ6SÚÊˆ∞¢ÚvóBvóFáV%&W7ˆÁ6RÊß6ˆ‚ÇíÊ6F6ÇÇÇí”‚á∑“íê¢¢∑”∞¢6ˆÁ7BFˆˆ«2“'&íÊó4'&íÜFFÁFˆˆ«2íÚFFÁFˆˆ«2¢µ”∞¢6ˆÁ7BFW67&óFñˆÁ2“∞¢&vóFáV"◊&VB#¢-	˝Ì-]˝-6ˆ÷÷óB›ÇÇMùΩÌ-R‚
-Õ‚}}]-]›R‚"¿¢&vóFáV"◊w&óFR#†¢$6˜ñ∆˜BÕÌ#¢Ì-M]Ω]“≠ΩÌ“¬6ˆ÷÷óB›ÇÇV∆¬&WVW7BΩ]B-Ì}›‚˝Ì--≠mM]›çR‚	]r--ÌÕ-ç}›‚Ωç-›R‚"¿¢&vˆˆv∆R÷G&ófR◊&VB#¢-
-}]-R}]ç]›ÇMùΩÌ-RÌ"vˆˆv∆RG&ófR‚"¿¢&vˆˆv∆R÷6∆VÊF"◊&VB#¢-	˝Ì≠}-≠ç-çÚÌ"vˆˆv∆R6∆VÊF"‚"¿¢&v÷ñ¬◊&VB#¢-	˝Ì≠}-}]ç]›ÇçÕ]ùΩÇ‚	›Rç}˝ù‚"¿¢&˜VÊí◊vV"◊6V&6Ç#¢-
--≠Ç≠-=Ω›ç›MÌÕmçÚ"ç›-]›]"‚"¿¢&˜VÁ6V&6Ç÷÷V÷˜'í#¢-	˝}ÇΩç}›Ç˝Ì]≠-›˝Õ]"˝ÌB--Ìí≠Ì›-Ì≤‚"¿¢'7ñÊ6á&ˆ‚◊7ó7FV“÷ñÁ7V7F˜"#†¢-	˝Ì-]˝-˝MÌ-‚Ç-ç}≠Ç'VÁFñ÷RÙFñvóFƒˆ6V‚›-Ìù≠Ç]r-]]›ç-R-Ìù›Ì-Ç‚"¿¢”∞¢V∆V÷VÁG2ÊFFG&vW$&ˆGíÊñÊÊW$ÖD‘¬“ ¢∆Fób6∆73“'W&÷ó76ñˆ‚÷FVfV«B#‡¢	˝Ì≠}›‚R]Ω›Ì-‚≠-Ì˝›çR‚(	Ì
-]=ç-çﬁ(	¬›RÌ}›}---ÌÕ-ç}›‚(	ÌÌ-é(	¬‡¢¬ˆFóc‡¢«6V7Fñˆ‚6∆73“&G&vW"◊6V7Fñˆ‚W&÷ó76ñˆ‚÷∆ó7B#‡¢∆'WGFˆ‚GóS“&'WGFˆ‚"6∆73“'W&÷ó76ñˆ‚÷6&BFˆˆ¬◊7FGW2÷6&B7ó7FV“÷6ˆÁG&ˆ¬÷∆ñÊ≤"FF◊7ó7FV“÷6ˆÊfñwW&Fñˆ„‡¢∆Fóc‡¢«7G&ˆÊsÌ
-ç-]Õ]“≠Ì›-Ì≥¬˜7G&ˆÊs‡¢«Ì
-˝M‚¬ç›-=Õ]›-ÇÇ-ç}≠Ç˝ÌÕ]›Ωç-Ç]r˝Ì≠}-›R›-ù›ç-Rç¬-Ìù›Ì-Ç„¬˜‡¢¬ˆFóc‡¢«7‚6∆73“'W&÷ó76ñˆ‚÷&FvR∆∆˜r#Ì	Ì--ÌÉ¬˜7„‡¢¬ˆ'WGFˆ„‡¢∆'Fñ6∆R6∆73“'W&÷ó76ñˆ‚÷6&BFˆˆ¬◊7FGW2÷6&B#‡¢∆Fóc„«7G&ˆÊsÌ
-›çÕ≠É¬˜7G&ˆÊs„«‰•Tr¬‰rÇvV%M‚R‘"„¬˜„¬ˆFóc‡¢«7‚6∆73“'W&÷ó76ñˆ‚÷&FvR∆∆˜r#Ì
-Ì-É¬˜7„‡¢¬ˆ'Fñ6∆S‡¢G∑Fˆˆ«0¢Ê÷ÇáFˆˆ¬í”‚∞¢6ˆÁ7B7FGW2“Fˆˆ≈7FFRÄ¢Fˆˆ¬¿¢&ˆˆ∆V‚Üvˆˆv∆TFFÊ6ˆÊÊV7FVBí¿¢&ˆˆ∆V‚ÜvóFáV$FFÊ6ˆÊÊV7FVBí¿¢ì∞¢6ˆÁ7BFW67&óFñˆ‚–¢Fˆˆ¬ÊñB””“&vóFáV"◊w&óFR"b`¢Fˆˆ¬Êfñ∆&ñ∆óGî6ˆFR””“$4ıîƒıEÙUDÙ‘DîÙÂÙDï4$ƒTB ¢Ú-	≠ÌMÌ-ç˝"ÕÌ"R}˝}]“¬›‚Rç}≠ΩÌ}]“"-]≠=ùçÚ]mç¬]r6˜ñ∆˜B‚ ¢¢FW67&óFñˆÁ5∑Fˆˆ¬ÊñE“«¬-	ç›-=Õ]›"›5î‰4Ö$Ù‚’Ç‚#∞¢&WGW&‚ ¢∆'Fñ6∆R6∆73“'W&÷ó76ñˆ‚÷6&BFˆˆ¬◊7FGW2÷6&B#‡¢∆Fóc‡¢«7G&ˆÊs‚G∂W66TáF÷¬áFˆˆ¬ÊÊ÷Ró”¬˜7G&ˆÊs‡¢«‚G∂W66TáF÷¬ÜFW67&óFñˆ‚ó”¬˜‡¢¬ˆFóc‡¢G∑Fˆˆ≈7FGW47FñˆÁ2Ä¢Fˆˆ¬¿¢7FGW2¿¢&ˆˆ∆V‚Üvˆˆv∆TFFÊ6ˆÊÊV7FVBí¿¢&ˆˆ∆V‚ÜvóFáV$FFÊ6ˆÊÊV7FVBí¿¢ó–¢¬ˆ'Fñ6∆SÊ∞¢“ê¢Ê¶ˆñ‚Ç""ó–¢¬˜6V7Fñˆ„Ê∞¢“6F6ÇÜW'&˜"í∞¢&VÊFW$G&vW$W'&˜"ÜW'&˜"Ê÷W76vRì∞¢–ß–†¶gVÊ7Fñˆ‚6ˆÊfñwW&FñˆÂ7FGW2ÜóFV“í∞¢6ˆÁ7B∆&V«2“∞¢6ˆÊfñwW&VC¢≤-	›-Ì]›"¬&∆∆˜r%“¿¢FVfV«FVC¢≤-	˝‚˝ÌM}ç›R"¬&∆∆˜r%“¿¢&÷ó76ñÊr◊&WVó&VB#¢≤-	Ωç˝-"¬&FVÁí%“¿¢&˜FñˆÊ¬÷÷ó76ñÊr#¢≤-	›]}M≠Ωmç-]Ω›"¬&6ˆÊfó&“%“¿¢6ˆ◊Fñ&ñ∆óGì¢≤-
--]}]-]“˝≠""¬&6ˆÊfó&“%“¿¢&Ê˜B÷ÊVVFVB#¢≤-	›RR›=m›"¬&∆∆˜r%“¿¢VÁW6VC¢≤-	›RRç}˝ÌΩ}-"¬&FVÁí%“¿¢”∞¢6ˆÁ7B∂∆&V¬¬6∆74Ê÷U““∆&V«5∂óFV“Á7FGW5“«¬∂óFV“Á7FGW2¬&6ˆÊfó&“%”∞¢&WGW&‚≤∆&V¬¬6∆74Ê÷R”∞ß–†¶gVÊ7Fñˆ‚&VÊFW$VÁfó&ˆÊ÷VÁDw&˜WÜ&V¬óFV◊2í∞¢&WGW&‚ ¢∆FWFñ«26∆73“&6ˆÊfñwW&Fñˆ‚÷w&˜W"G∂óFV◊2Á6ˆ÷RÇÜóFV“í”‚óFV“Á7FGW2””“&÷ó76ñÊr◊&WVó&VB"íÚ&˜V‚"¢"'”‡¢«7V÷÷'ì‚G∂W66TáF÷¬Ü&Vó“«7„‚G∂óFV◊2Ê∆VÊwFá”¬˜7„„¬˜7V÷÷'ì‡¢∆Fób6∆73“&6ˆÊfñwW&Fñˆ‚÷∆ó7B#‡¢G∂óFV◊0¢Ê÷ÇÜóFV“í”‚∞¢6ˆÁ7B7FGW2“6ˆÊfñwW&FñˆÂ7FGW2ÜóFV“ì∞¢&WGW&‚ ¢∆'Fñ6∆R6∆73“&6ˆÊfñwW&Fñˆ‚÷óFV“#‡¢∆Fóc‡¢∆6ˆFS‚G∂W66TáF÷¬ÜóFV“Ê∂Wíó”¬ˆ6ˆFS‡¢«‚G∂W66TáF÷¬ÜóFV“ÁW'˜6Ró”¬˜‡¢«6÷∆√‡¢G∂óFV“Á6VÁ6óFófóGí””“'6V7&WB"Ú-
--ù›-Ìù›Ì"+r›ç≠Ì=›RR˝Ì≠}-"¢-	Ìù›-Ìù≠'–¢+rFñvóFƒˆ6V„¢G∂óFV“ÊFñvóFƒˆ6V‰FV6∆&VBÚ-M]≠Ωç›"¢-›RRM]≠Ωç›'–¢¬˜6÷∆√‡¢¬ˆFóc‡¢«7‚6∆73“'W&÷ó76ñˆ‚÷&FvRG∑7FGW2Ê6∆74Ê÷W“#‚G∑7FGW2Ê∆&V«”¬˜7„‡¢¬ˆ'Fñ6∆SÊ∞¢“ê¢Ê¶ˆñ‚Ç""ó–¢¬ˆFóc‡¢¬ˆFWFñ«3Ê∞ß–†¶7ñÊ2gVÊ7Fñˆ‚˜VÂ7ó7FV‘6ˆÊfñwW&Fñˆ‰G&vW"Çí∞¢˜V‰FFG&vW"Ç-
-ç-]Õ]“≠Ì›-Ì≤"ì∞¢&VÊFW$G&vW$∆ˆFñÊrÇì∞¢G'í∞¢6ˆÁ7B∂6ˆÊfñwW&FñˆÂ&W7ˆÁ6R¬ñÁFVw&FñˆÁ5&W7ˆÁ6R¬&VFñÊW75&W7ˆÁ6U“–¢vóB&ˆ÷ó6RÊ∆¬Ö∞¢fWF6ÇÇ"ˆí˜7ó7FV“ˆ6ˆÊfñwW&Fñˆ‚"¬≤66ÜS≠w“⁄$z{-ÆÈ‹j◊ùst integrations = await integrationsResponse.json();
+const state = {
+  sessionId: getOrCreateSessionId(),
+  serverOnline: false,
+  opensearchStatus: "unknown",
+  opensearchFailures: 0,
+  lastMemorySuccessAt: 0,
+  lastActions: [],
+  chatBusy: false,
+  speakingButton: null,
+  pendingImage: null,
+  conversations: [],
+  conversationLoadError: "",
+  memoryItems: [],
+  recognition: null,
+  listening: false,
+  authenticatedUser: null,
+  registrationEnabled: false,
+  applicationStarted: false,
+};
+
+const elements = {
+  authGate: document.getElementById("authGate"),
+  appShell: document.getElementById("appShell"),
+  loginForm: document.getElementById("loginForm"),
+  loginEmail: document.getElementById("loginEmail"),
+  loginPassword: document.getElementById("loginPassword"),
+  loginBtn: document.getElementById("loginBtn"),
+  showRegisterBtn: document.getElementById("showRegisterBtn"),
+  registerForm: document.getElementById("registerForm"),
+  registerName: document.getElementById("registerName"),
+  registerEmail: document.getElementById("registerEmail"),
+  registerPassword: document.getElementById("registerPassword"),
+  registerInviteCode: document.getElementById("registerInviteCode"),
+  registerBtn: document.getElementById("registerBtn"),
+  backToLoginBtn: document.getElementById("backToLoginBtn"),
+  authMessage: document.getElementById("authMessage"),
+  chatMessages: document.getElementById("chatMessages"),
+  chatInput: document.getElementById("chatInput"),
+  sendBtn: document.getElementById("sendBtn"),
+  attachBtn: document.getElementById("attachBtn"),
+  imageInput: document.getElementById("imageInput"),
+  attachmentPreview: document.getElementById("attachmentPreview"),
+  attachmentImage: document.getElementById("attachmentImage"),
+  attachmentName: document.getElementById("attachmentName"),
+  removeAttachmentBtn: document.getElementById("removeAttachmentBtn"),
+  newChatBtn: document.getElementById("newChatBtn"),
+  toggleStatusBtn: document.getElementById("toggleStatusBtn"),
+  closeContextBtn: document.getElementById("closeContextBtn"),
+  statusPanel: document.getElementById("statusPanel"),
+  agentStatusDot: document.getElementById("agentStatusDot"),
+  agentStatusText: document.getElementById("agentStatusText"),
+  sessionIdDisplay: document.getElementById("sessionIdDisplay"),
+  serverStatusDisplay: document.getElementById("serverStatusDisplay"),
+  opensearchStatusDisplay: document.getElementById("opensearchStatusDisplay"),
+  actionsLog: document.getElementById("actionsLog"),
+  conversationList: document.getElementById("conversationList"),
+  conversationSearch: document.getElementById("conversationSearch"),
+  searchChatsBtn: document.getElementById("searchChatsBtn"),
+  mobileMenuBtn: document.getElementById("mobileMenuBtn"),
+  sidebar: document.getElementById("sidebar"),
+  sidebarBackdrop: document.getElementById("sidebarBackdrop"),
+  imagesBtn: document.getElementById("imagesBtn"),
+  modulesBtn: document.getElementById("modulesBtn"),
+  systemConfigurationBtn: document.getElementById("systemConfigurationBtn"),
+  focusBtn: document.getElementById("focusBtn"),
+  toolsBtn: document.getElementById("toolsBtn"),
+  memoryBtn: document.getElementById("memoryBtn"),
+  permissionsBtn: document.getElementById("permissionsBtn"),
+  dataDrawer: document.getElementById("dataDrawer"),
+  dataDrawerTitle: document.getElementById("dataDrawerTitle"),
+  dataDrawerBody: document.getElementById("dataDrawerBody"),
+  drawerBackdrop: document.getElementById("drawerBackdrop"),
+  closeDataDrawerBtn: document.getElementById("closeDataDrawerBtn"),
+  voiceBtn: document.getElementById("voiceBtn"),
+  profileAvatar: document.getElementById("profileAvatar"),
+  profileName: document.getElementById("profileName"),
+  profileRole: document.getElementById("profileRole"),
+  logoutBtn: document.getElementById("logoutBtn"),
+};
+
+function createSessionId() {
+  if (globalThis.crypto?.randomUUID) {
+    return "sess-" + globalThis.crypto.randomUUID();
+  }
+  return (
+    "sess-" + Math.random().toString(36).slice(2) + Date.now().toString(36)
+  );
+}
+
+function getOrCreateSessionId() {
+  const stored = localStorage.getItem("synchronSessionId");
+  if (stored?.startsWith("sess-")) return stored;
+  const sessionId = createSessionId();
+  localStorage.setItem("synchronSessionId", sessionId);
+  return sessionId;
+}
+
+function setAuthMessage(message = "", success = false) {
+  elements.authMessage.textContent = message;
+  elements.authMessage.classList.toggle("success", success);
+}
+
+function setAuthBusy(isBusy) {
+  elements.loginBtn.disabled = isBusy;
+  elements.registerBtn.disabled = isBusy;
+}
+
+function showLoginForm() {
+  elements.loginForm.hidden = false;
+  elements.registerForm.hidden = true;
+  elements.showRegisterBtn.hidden = !state.registrationEnabled;
+  setAuthMessage();
+  elements.loginEmail.focus();
+}
+
+function showRegisterForm() {
+  elements.loginForm.hidden = true;
+  elements.registerForm.hidden = false;
+  elements.showRegisterBtn.hidden = true;
+  setAuthMessage();
+  elements.registerName.focus();
+}
+
+async function readAuthSession() {
+  const response = await fetch("/api/auth/session", { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error("–í—Ö–æ–¥—ä—Ç –≤—Ä–µ–º–µ–Ω–Ω–æ –Ω–µ –µ –¥–æ—Å—Ç—ä–ø–µ–Ω.");
+  }
+  return response.json();
+}
+
+async function submitAuth(path, body) {
+  const response = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new Error(data?.error || "–í—Ö–æ–¥—ä—Ç –Ω–µ –±–µ—à–µ —É—Å–ø–µ—à–µ–Ω.");
+  }
+  return data;
+}
+
+async function handleLogin(event) {
+  event.preventDefault();
+  setAuthBusy(true);
+  setAuthMessage();
+  try {
+    await submitAuth("/api/auth/login", {
+      email: elements.loginEmail.value,
+      password: elements.loginPassword.value,
+    });
+    elements.loginPassword.value = "";
+    const session = await readAuthSession();
+    if (!session.authenticated) throw new Error("–°–µ—Å–∏—è—Ç–∞ –Ω–µ –±–µ—à–µ —Å—ä–∑–¥–∞–¥–µ–Ω–∞.");
+    await startApplication(session.user);
+  } catch (error) {
+    setAuthMessage(error.message);
+  } finally {
+    setAuthBusy(false);
+  }
+}
+
+async function handleRegistration(event) {
+  event.preventDefault();
+  setAuthBusy(true);
+  setAuthMessage();
+  try {
+    const result = await submitAuth("/api/auth/register", {
+      displayName: elements.registerName.value,
+      email: elements.registerEmail.value,
+      password: elements.registerPassword.value,
+      inviteCode: elements.registerInviteCode.value,
+    });
+    elements.registerPassword.value = "";
+    elements.registerInviteCode.value = "";
+    if (result.confirmationRequired) {
+      showLoginForm();
+      elements.loginEmail.value = result.user?.email || "";
+      setAuthMessage(
+        "–ü—Ä–æ—Ñ–∏–ª—ä—Ç –µ —Å—ä–∑–¥–∞–¥–µ–Ω. –ü–æ—Ç–≤—ä—Ä–¥–∏ –∏–º–µ–π–ª–∞ —Å–∏ –∏ –ø–æ—Å–ª–µ –≤–ª–µ–∑.",
+        true,
+      );
+      return;
+    }
+    const session = await readAuthSession();
+    if (!session.authenticated) throw new Error("–°–µ—Å–∏—è—Ç–∞ –Ω–µ –±–µ—à–µ —Å—ä–∑–¥–∞–¥–µ–Ω–∞.");
+    await startApplication(session.user);
+  } catch (error) {
+    setAuthMessage(error.message);
+  } finally {
+    setAuthBusy(false);
+  }
+}
+
+async function handleLogout() {
+  elements.logoutBtn.disabled = true;
+  try {
+    await fetch("/api/auth/logout", { method: "POST" });
+  } finally {
+    globalThis.location.href = "/";
+  }
+}
+
+function applyAuthenticatedUser(user) {
+  state.authenticatedUser = user;
+  const displayName = user?.displayName || "–ü–æ—Ç—Ä–µ–±–∏—Ç–µ–ª";
+  const isOwner = user?.role === "owner";
+  elements.profileName.textContent = displayName;
+  elements.profileAvatar.textContent =
+    displayName.trim().charAt(0).toLocaleUpperCase("bg-BG") || "–ü";
+  elements.profileRole.textContent = isOwner
+    ? "–°–æ–±—Å—Ç–≤–µ–Ω–∏–∫ ¬∑ –Ω–∞—Å—Ç—Ä–æ–π–∫–∏"
+    : "–¢–µ—Å—Ç–æ–≤ –ø—Ä–æ—Ñ–∏–ª";
+  document.body.dataset.userRole = isOwner ? "owner" : "tester";
+  for (const item of document.querySelectorAll("[data-owner-only]")) {
+    item.hidden = !isOwner;
+  }
+}
+
+async function init() {
+  elements.loginForm.addEventListener("submit", handleLogin);
+  elements.registerForm.addEventListener("submit", handleRegistration);
+  elements.showRegisterBtn.addEventListener("click", showRegisterForm);
+  elements.backToLoginBtn.addEventListener("click", showLoginForm);
+
+  try {
+    const session = await readAuthSession();
+    state.registrationEnabled = Boolean(session.registrationEnabled);
+    elements.showRegisterBtn.hidden = !state.registrationEnabled;
+    if (session.authenticated) {
+      await startApplication(session.user);
+      return;
+    }
+    elements.authGate.hidden = false;
+    elements.appShell.hidden = true;
+    if (!session.configured) {
+      setAuthMessage(
+        "–í—Ö–æ–¥—ä—Ç –∑–∞ —Ç–µ—Å—Ç–æ–≤–∏ –ø—Ä–æ—Ñ–∏–ª–∏ –æ—â–µ –Ω–µ –µ –∞–∫—Ç–∏–≤–∏—Ä–∞–Ω. –°–æ–±—Å—Ç–≤–µ–Ω–∏–∫—ä—Ç –º–æ–∂–µ –¥–∞ –≤–ª–µ–∑–µ —Å GitHub.",
+      );
+    }
+  } catch (error) {
+    setAuthMessage(error.message);
+  }
+}
+
+async function startApplication(user) {
+  if (state.applicationStarted) return;
+  state.applicationStarted = true;
+  applyAuthenticatedUser(user);
+  elements.authGate.hidden = true;
+  elements.appShell.hidden = false;
+  updateSessionDisplay();
+
+  elements.sendBtn.addEventListener("click", sendMessage);
+  elements.attachBtn.addEventListener("click", () =>
+    elements.imageInput.click(),
+  );
+  elements.imageInput.addEventListener("change", handleImageSelection);
+  elements.removeAttachmentBtn.addEventListener("click", clearPendingImage);
+  elements.chatInput.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      sendMessage();
+    }
+  });
+  elements.newChatBtn.addEventListener("click", startNewChat);
+  elements.toggleStatusBtn.addEventListener("click", openStatus);
+  elements.closeContextBtn.addEventListener("click", closeStatus);
+  elements.chatMessages.addEventListener("click", handleMessageAction);
+  elements.conversationList.addEventListener("click", handleConversationClick);
+  elements.conversationSearch.addEventListener("input", renderConversationList);
+  elements.searchChatsBtn.addEventListener("click", toggleConversationSearch);
+  elements.mobileMenuBtn.addEventListener("click", toggleSidebar);
+  elements.sidebarBackdrop.addEventListener("click", closeSidebar);
+  elements.imagesBtn.addEventListener("click", openImagePicker);
+  elements.modulesBtn.addEventListener("click", openModulesDrawer);
+  elements.toolsBtn.addEventListener("click", openToolsDrawer);
+  elements.systemConfigurationBtn.addEventListener(
+    "click",
+    openSystemConfigurationDrawer,
+  );
+  elements.memoryBtn.addEventListener("click", openMemoryDrawer);
+  elements.permissionsBtn.addEventListener("click", openPermissionsDrawer);
+  elements.closeDataDrawerBtn.addEventListener("click", closeDataDrawer);
+  elements.drawerBackdrop.addEventListener("click", closeDataDrawer);
+  elements.dataDrawerBody.addEventListener("click", handleDataDrawerAction);
+  elements.voiceBtn.addEventListener("click", toggleVoiceInput);
+  elements.logoutBtn.addEventListener("click", handleLogout);
+  document.addEventListener("keydown", handleGlobalKeydown);
+  prepareVoiceInput();
+
+  checkHealth();
+  checkOpenSearch();
+  setInterval(checkHealth, 10000);
+  setInterval(checkOpenSearch, 20000);
+
+  await restoreConversation();
+  await loadConversations();
+}
+
+function updateSessionDisplay() {
+  elements.sessionIdDisplay.textContent = state.sessionId;
+}
+
+async function showWelcomeMessage() {
+  appendMessage(
+    "agent",
+    [
+      "## SYNCHRON-X",
+      "**–¢–≤–æ—è—Ç–∞ –ª–∏—á–Ω–∞ AI –æ–ø–µ—Ä–∞—Ü–∏–æ–Ω–Ω–∞ —Å–∏—Å—Ç–µ–º–∞.**",
+      "",
+      "–ï–¥–Ω–æ AI —è–¥—Ä–æ, –ø–æ—Å—Ç–æ—è–Ω–Ω–∞ –∫–æ–Ω—Ç—Ä–æ–ª–∏—Ä–∞–Ω–∞ –ø–∞–º–µ—Ç –∏ —Ä–∞–∑—Ä–µ—à–µ–Ω–∏ –∏–Ω—Å—Ç—Ä—É–º–µ–Ω—Ç–∏ –∑–∞ —Ä–µ–∞–ª–Ω–∏ –∑–∞–¥–∞—á–∏.",
+      "",
+      "AI –∞–≤–∞—Ç–∞—Ä—ä—Ç –µ –º–æ—è—Ç –Ω–∞—á–∏–Ω –Ω–∞ –æ–±—â—É–≤–∞–Ω–µ. –¢–∏ –∫–æ–Ω—Ç—Ä–æ–ª–∏—Ä–∞—à –¥–∞–Ω–Ω–∏—Ç–µ, –ø–∞–º–µ—Ç—Ç–∞ –∏ —Ä–∏—Å–∫–æ–≤–∏—Ç–µ –¥–µ–π—Å—Ç–≤–∏—è.",
+    ].join("\n"),
+  );
+}
+
+async function restoreConversation() {
+  try {
+    const response = await fetch(
+      "/memory/conversation/" + encodeURIComponent(state.sessionId),
+      { cache: "no-store" },
+    );
+    if (!response.ok) throw new Error("–ò—Å—Ç–æ—Ä–∏—è—Ç–∞ –Ω–µ –µ –¥–æ—Å—Ç—ä–ø–Ω–∞.");
+    const data = await response.json();
+    markMemoryOperational();
+    const items = Array.isArray(data.items) ? data.items : [];
+    if (items.length === 0) {
+      await showWelcomeMessage();
+      return;
+    }
+    for (const item of items) {
+      if (
+        (item.role === "user" || item.role === "assistant") &&
+        typeof item.content === "string"
+      ) {
+        appendMessage(
+          item.role === "assistant" ? "agent" : "user",
+          item.content,
+        );
+      }
+    }
+    logAction("–í—ä–∑—Å—Ç–∞–Ω–æ–≤–µ–Ω–∞ –µ –∏—Å—Ç–æ—Ä–∏—è—Ç–∞ –Ω–∞ —Ä–∞–∑–≥–æ–≤–æ—Ä–∞");
+  } catch (error) {
+    console.error(error);
+    await showWelcomeMessage();
+    logAction("–ò—Å—Ç–æ—Ä–∏—è—Ç–∞ –Ω–µ –º–æ–∂–∞ –¥–∞ –±—ä–¥–µ –≤—ä–∑—Å—Ç–∞–Ω–æ–≤–µ–Ω–∞");
+  }
+}
+
+async function startNewChat() {
+  if (state.chatBusy) return;
+  closeSidebar();
+  clearPendingImage();
+  state.sessionId = createSessionId();
+  localStorage.setItem("synchronSessionId", state.sessionId);
+  state.lastActions = [];
+  elements.chatMessages.replaceChildren();
+  updateSessionDisplay();
+  renderActionsLog();
+  await showWelcomeMessage();
+  logAction("–ó–∞–ø–æ—á–Ω–∞—Ç –µ –Ω–æ–≤ —Ä–∞–∑–≥–æ–≤–æ—Ä");
+  renderConversationList();
+  elements.chatInput.focus();
+}
+
+async function loadConversations() {
+  try {
+    const response = await fetch("/memory/conversations", {
+      cache: "no-store",
+    });
+    if (!response.ok) throw new Error("–°–ø–∏—Å—ä–∫—ä—Ç –Ω–µ –µ –¥–æ—Å—Ç—ä–ø–µ–Ω.");
+    const data = await response.json();
+    state.conversations = Array.isArray(data.items) ? data.items : [];
+    state.conversationLoadError = "";
+    renderConversationList();
+  } catch (error) {
+    console.error(error);
+    state.conversations = [];
+    state.conversationLoadError =
+      "–ò—Å—Ç–æ—Ä–∏—è—Ç–∞ –≤—Ä–µ–º–µ–Ω–Ω–æ –Ω–µ –µ –¥–æ—Å—Ç—ä–ø–Ω–∞. –û–ø–∏—Ç–∞–π –æ—Ç–Ω–æ–≤–æ.";
+    renderConversationList();
+  }
+}
+
+function renderConversationList() {
+  const query = elements.conversationSearch.value
+    .trim()
+    .toLocaleLowerCase("bg-BG");
+  const conversations = state.conversations.filter(
+    (item) => !query || item.title.toLocaleLowerCase("bg-BG").includes(query),
+  );
+  elements.conversationList.replaceChildren();
+
+  if (state.conversationLoadError) {
+    const error = document.createElement("p");
+    error.className = "conversation-state conversation-state-error";
+    error.textContent = state.conversationLoadError;
+    elements.conversationList.appendChild(error);
+    return;
+  }
+
+  if (conversations.length === 0) {
+    const empty = document.createElement("p");
+    empty.className = "conversation-state";
+    empty.textContent = query
+      ? "–ù—è–º–∞ –Ω–∞–º–µ—Ä–µ–Ω–∏ —Ä–∞–∑–≥–æ–≤–æ—Ä–∏."
+      : "–í—Å–µ –æ—â–µ –Ω—è–º–∞ –∑–∞–ø–∞–∑–µ–Ω–∏ —Ä–∞–∑–≥–æ–≤–æ—Ä–∏.";
+    elements.conversationList.appendChild(empty);
+    return;
+  }
+
+  for (const item of conversations) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "conversation";
+    if (item.sessionId === state.sessionId) button.classList.add("active");
+    button.dataset.sessionId = item.sessionId;
+    button.textContent = item.title;
+    elements.conversationList.appendChild(button);
+  }
+}
+
+async function handleConversationClick(event) {
+  const button = event.target.closest("button[data-session-id]");
+  if (!button || state.chatBusy || button.dataset.sessionId === state.sessionId)
+    return;
+  state.sessionId = button.dataset.sessionId;
+  localStorage.setItem("synchronSessionId", state.sessionId);
+  elements.chatMessages.replaceChildren();
+  updateSessionDisplay();
+  renderConversationList();
+  await restoreConversation();
+  closeSidebar();
+}
+
+function toggleSidebar() {
+  const isOpen = elements.sidebar.classList.toggle("mobile-visible");
+  elements.sidebarBackdrop.hidden = !isOpen;
+  elements.mobileMenuBtn.setAttribute("aria-expanded", String(isOpen));
+}
+
+function closeSidebar() {
+  elements.sidebar.classList.remove("mobile-visible");
+  elements.sidebarBackdrop.hidden = true;
+  elements.mobileMenuBtn.setAttribute("aria-expanded", "false");
+}
+
+function openImagePicker() {
+  closeSidebar();
+  elements.imageInput.click();
+}
+
+function handleGlobalKeydown(event) {
+  if (event.key !== "Escape") return;
+  closeSidebar();
+  closeStatus();
+  closeDataDrawer();
+}
+
+function toggleConversationSearch() {
+  elements.conversationSearch.hidden = false;
+  elements.conversationList
+    .closest(".sidebar-section")
+    ?.scrollIntoView({ block: "start", behavior: "smooth" });
+  elements.conversationSearch.focus({ preventScroll: true });
+}
+
+function handleImageSelection(event) {
+  const file = event.target.files?.[0];
+  if (!file) return;
+
+  const allowedTypes = ["image/jpeg", "image/png", "image/webp"];
+  if (!allowedTypes.includes(file.type)) {
+    appendMessage("agent", "‚ùå –ü–æ–¥–¥—ä—Ä–∂–∞—Ç —Å–µ —Å–∞–º–æ JPEG, PNG –∏ WebP —Å–Ω–∏–º–∫–∏.");
+    clearPendingImage();
+    return;
+  }
+
+  if (file.size > 5 * 1024 * 1024) {
+    appendMessage("agent", "‚ùå –°–Ω–∏–º–∫–∞—Ç–∞ —Ç—Ä—è–±–≤–∞ –¥–∞ –±—ä–¥–µ –¥–æ 5 MB.");
+    clearPendingImage();
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    state.pendingImage = {
+      dataUrl: reader.result,
+      mimeType: file.type,
+      name: file.name,
+    };
+    elements.attachmentImage.src = reader.result;
+    elements.attachmentName.textContent = file.name;
+    elements.attachmentPreview.hidden = false;
+    elements.chatInput.focus();
+  };
+  reader.onerror = () => {
+    appendMessage("agent", "‚ùå –°–Ω–∏–º–∫–∞—Ç–∞ –Ω–µ –º–æ–∂–∞ –¥–∞ –±—ä–¥–µ –ø—Ä–æ—á–µ—Ç–µ–Ω–∞.");
+    clearPendingImage();
+  };
+  reader.readAsDataURL(file);
+}
+
+function clearPendingImage() {
+  state.pendingImage = null;
+  elements.imageInput.value = "";
+  elements.attachmentImage.removeAttribute("src");
+  elements.attachmentName.textContent = "";
+  elements.attachmentPreview.hidden = true;
+}
+
+function openStatus() {
+  closeSidebar();
+  elements.statusPanel.classList.add("mobile-visible");
+}
+
+function closeStatus() {
+  elements.statusPanel.classList.remove("mobile-visible");
+}
+
+function prepareVoiceInput() {
+  const SpeechRecognition =
+    window.SpeechRecognition || window.webkitSpeechRecognition;
+  if (!SpeechRecognition) {
+    elements.voiceBtn.hidden = true;
+    return;
+  }
+
+  const recognition = new SpeechRecognition();
+  recognition.lang = "bg-BG";
+  recognition.continuous = false;
+  recognition.interimResults = true;
+
+  recognition.onstart = () => setListening(true);
+  recognition.onend = () => setListening(false);
+  recognition.onerror = (event) => {
+    setListening(false);
+    if (event.error !== "aborted" && event.error !== "no-speech") {
+      appendMessage(
+        "agent",
+        "–ì–ª–∞—Å–æ–≤–æ—Ç–æ –≤—ä–≤–µ–∂–¥–∞–Ω–µ –Ω–µ –º–æ–∂–∞ –¥–∞ —Å—Ç–∞—Ä—Ç–∏—Ä–∞. –ü—Ä–æ–≤–µ—Ä–∏ –¥–æ—Å—Ç—ä–ø–∞ –¥–æ –º–∏–∫—Ä–æ—Ñ–æ–Ω–∞.",
+      );
+    }
+  };
+  recognition.onresult = (event) => {
+    let transcript = "";
+    for (
+      let index = event.resultIndex;
+      index < event.results.length;
+      index += 1
+    ) {
+      transcript += event.results[index][0].transcript;
+    }
+    elements.chatInput.value = transcript.trim();
+    const lastResult = event.results[event.results.length - 1];
+    if (lastResult?.isFinal) elements.chatInput.focus();
+  };
+  state.recognition = recognition;
+}
+
+function setListening(isListening) {
+  state.listening = isListening;
+  elements.voiceBtn.classList.toggle("listening", isListening);
+  elements.voiceBtn.setAttribute("aria-pressed", String(isListening));
+  elements.voiceBtn.title = isListening
+    ? "–°–ø—Ä–∏ —Å–ª—É—à–∞–Ω–µ—Ç–æ"
+    : "–ì–ª–∞—Å–æ–≤–æ –≤—ä–≤–µ–∂–¥–∞–Ω–µ";
+}
+
+function toggleVoiceInput() {
+  if (!state.recognition || state.chatBusy) return;
+  if (state.listening) {
+    state.recognition.stop();
+  } else {
+    state.recognition.start();
+  }
+}
+
+function openModulesDrawer() {
+  openDataDrawer("–†–∞–±–æ—Ç–Ω–∏ –æ–±–ª–∞—Å—Ç–∏");
+  elements.dataDrawerBody.innerHTML = `
+        <div class="module-summary">
+            –¢–æ–≤–∞ —Å–∞ –æ–±–ª–∞—Å—Ç–∏, –≤ –∫–æ–∏—Ç–æ –ª–∏—á–Ω–∞—Ç–∞ AI –æ–ø–µ—Ä–∞—Ü–∏–æ–Ω–Ω–∞ —Å–∏—Å—Ç–µ–º–∞ –∏–∑–ø–æ–ª–∑–≤–∞ —Ä–∞–∑–≥–æ–≤–æ—Ä–∞,
+            –ø–∞–º–µ—Ç—Ç–∞ –∏ —Ä–∞–∑—Ä–µ—à–µ–Ω–∏—Ç–µ –∏–Ω—Å—Ç—Ä—É–º–µ–Ω—Ç–∏. –û–±–ª–∞—Å—Ç—Ç–∞ —Å–∞–º–∞ –ø–æ —Å–µ–±–µ —Å–∏ –Ω–µ
+            –æ–∑–Ω–∞—á–∞–≤–∞, —á–µ –≤—ä–Ω—à–Ω–∞ —É—Å–ª—É–≥–∞ –µ —Å–≤—ä—Ä–∑–∞–Ω–∞.
+        </div>
+        <section class="drawer-section permission-list module-list" data-module-list></section>`;
+  document.dispatchEvent(new CustomEvent("synchron:modules-opened"));
+}
+
+function isGoogleTool(tool) {
+  return (
+    tool?.provider === "google" ||
+    tool?.id?.startsWith("google-") ||
+    tool?.id === "gmail-read"
+  );
+}
+
+function toolState(tool, googleConnected, githubConnected) {
+  if (tool.availabilityCode === "COPILOT_AUTOMATION_DISABLED") {
+    return { label: "–ò–∑–∫–ª—é—á–µ–Ω–æ ¬∑ —Ä–µ–∂–∏–º –±–µ–∑ Copilot", className: "confirm" };
+  }
+  if (!tool.enabled || !tool.executable) {
+    return { label: "–ù–µ –µ —Å–≤—ä—Ä–∑–∞–Ω", className: "deny" };
+  }
+  if (!tool.configured) {
+    return { label: "–ù–µ –µ –∫–æ–Ω—Ñ–∏–≥—É—Ä–∏—Ä–∞–Ω", className: "deny" };
+  }
+  if (isGoogleTool(tool) && !googleConnected) {
+    return { label: "–ò—Å–∫–∞ —Å–≤—ä—Ä–∑–≤–∞–Ω–µ", className: "confirm" };
+  }
+  if (tool.id === "github-write" && !githubConnected) {
+    return { label: "–ò—Å–∫–∞ —Å–≤—ä—Ä–∑–≤–∞–Ω–µ", className: "confirm" };
+  }
+  return { label: "–†–∞–±–æ—Ç–∏", className: "allow" };
+}
+
+function toolStatusActions(tool, status, googleConnected, githubConnected) {
+  let action = "";
+  if (tool.availabilityCode === "COPILOT_AUTOMATION_DISABLED") {
+    action = "";
+  } else if (isGoogleTool(tool) && !googleConnected && tool.configured) {
+    action =
+      '<button type="button" class="tool-connect-btn" data-connect-service="google">–°–≤—ä—Ä–∂–∏ Google</button>';
+  } else if (
+    tool.id === "github-write" &&
+    tool.configured &&
+    !githubConnected
+  ) {
+    action =
+      '<button type="button" class="tool-connect-btn" data-connect-service="github">–°–≤—ä—Ä–∂–∏ GitHub</button>';
+  } else if (tool.id === "github-write" && !tool.configured) {
+    action =
+      '<button type="button" class="tool-connect-btn" data-github-setup>–ù–∞—Å—Ç—Ä–æ–π GitHub</button>';
+  }
+
+  return `
+    <div class="tool-status-actions">
+      <span class="permission-badge ${status.className}">${status.label}</span>
+      ${action}
+    </div>`;
+}
+
+function permissionAction(item, toolMap, googleConnected, githubConnected) {
+  const googlePermissions = new Set([
+    "calendar.read",
+    "calendar.write",
+    "drive.read",
+    "mail.read",
+  ]);
+  if (googlePermissions.has(item.action) && !googleConnected) {
+    return '<button type="button" class="tool-connect-btn" data-connect-service="google">–°–≤—ä—Ä–∂–∏ Google</button>';
+  }
+
+  const githubWrite = toolMap.get("github-write");
+  if (
+    item.action === "github.write" &&
+    githubWrite?.availabilityCode === "COPILOT_AUTOMATION_DISABLED"
+  ) {
+    return "";
+  }
+  if (
+    item.action === "github.write" &&
+    githubWrite?.configured &&
+    githubWrite?.executable &&
+    !githubConnected
+  ) {
+    return '<button type="button" class="tool-connect-btn" data-connect-service="github">–°–≤—ä—Ä–∂–∏ GitHub</button>';
+  }
+  if (
+    item.action === "github.write" &&
+    (!githubWrite?.configured || !githubWrite?.executable)
+  ) {
+    return '<button type="button" class="tool-connect-btn" data-github-setup>–ù–∞—Å—Ç—Ä–æ–π GitHub</button>';
+  }
+
+  if (item.decision === "confirm") {
+    return `<button type="button" class="permission-info-btn" data-permission-info="${escapeHtml(item.action)}">–ö–∞–∫ —Ä–∞–±–æ—Ç–∏</button>`;
+  }
+  return "";
+}
+
+async function openToolsDrawer() {
+  openDataDrawer("–ò–Ω—Å—Ç—Ä—É–º–µ–Ω—Ç–∏");
+  renderDrawerLoading();
+  try {
+    const [healthResponse, googleResponse, githubResponse] = await Promise.all([
+      fetch("/health/integrations", { cache: "no-store" }),
+      fetch("/api/google/status", { cache: "no-store" }).catch(() => null),
+      fetch("/api/github/status", { cache: "no-store" }).catch(() => null),
+    ]);
+    if (!healthResponse.ok) {
+      throw new Error("–°—ä—Å—Ç–æ—è–Ω–∏–µ—Ç–æ –Ω–∞ –∏–Ω—Å—Ç—Ä—É–º–µ–Ω—Ç–∏—Ç–µ –Ω–µ –µ –¥–æ—Å—Ç—ä–ø–Ω–æ.");
+    }
+    const data = await healthResponse.json();
+    const googleData = googleResponse?.ok
+      ? await googleResponse.json().catch(() => ({}))
+      : {};
+    const githubData = githubResponse?.ok
+      ? await githubResponse.json().catch(() => ({}))
+      : {};
+    const tools = Array.isArray(data.tools) ? data.tools : [];
+    const descriptions = {
+      "github-read": "–ü—Ä–æ–≤–µ—Ä—è–≤–∞ commit-–∏ –∏ —Ñ–∞–π–ª–æ–≤–µ. –°–∞–º–æ –∑–∞ —á–µ—Ç–µ–Ω–µ.",
+      "github-write":
+        "Copilot –º–æ—Å—Ç: –æ—Ç–¥–µ–ª–µ–Ω –∫–ª–æ–Ω, commit-–∏ –∏ Pull Request —Å–ª–µ–¥ —Ç–æ—á–Ω–æ –ø–æ—Ç–≤—ä—Ä–∂–¥–µ–Ω–∏–µ. –ë–µ–∑ –∞–≤—Ç–æ–º–∞—Ç–∏—á–Ω–æ —Å–ª–∏–≤–∞–Ω–µ.",
+      "google-drive-read": "–ß–µ—Ç–µ —Ä–∞–∑—Ä–µ—à–µ–Ω–∏ —Ñ–∞–π–ª–æ–≤–µ –æ—Ç Google Drive.",
+      "google-calendar-read": "–ü–æ–∫–∞–∑–≤–∞ —Å—ä–±–∏—Ç–∏—è –æ—Ç Google Calendar.",
+      "gmail-read": "–ü–æ–∫–∞–∑–≤–∞ —Ä–∞–∑—Ä–µ—à–µ–Ω–∏ –∏–º–µ–π–ª–∏. –ù–µ –∏–∑–ø—Ä–∞—â–∞.",
+      "openai-web-search": "–¢—ä—Ä—Å–∏ –∞–∫—Ç—É–∞–ª–Ω–∞ –∏–Ω—Ñ–æ—Ä–º–∞—Ü–∏—è –≤ –∏–Ω—Ç–µ—Ä–Ω–µ—Ç.",
+      "opensearch-memory": "–ü–∞–∑–∏ –ª–∏—á–Ω–∞ –∏ –ø—Ä–æ–µ–∫—Ç–Ω–∞ –ø–∞–º–µ—Ç –ø–æ–¥ —Ç–≤–æ–π –∫–æ–Ω—Ç—Ä–æ–ª.",
+      "synchron-system-inspector":
+        "–ü—Ä–æ–≤–µ—Ä—è–≤–∞ —è–¥—Ä–æ—Ç–æ –∏ –≤—Å–∏—á–∫–∏ runtime/DigitalOcean –Ω–∞—Å—Ç—Ä–æ–π–∫–∏ –±–µ–∑ —Ç–µ—Ö–Ω–∏—Ç–µ —Å—Ç–æ–π–Ω–æ—Å—Ç–∏.",
+    };
+    elements.dataDrawerBody.innerHTML = `
+      <div class="permission-default">
+        –ü–æ–∫–∞–∑–∞–Ω–æ –µ —Ä–µ–∞–ª–Ω–æ—Ç–æ —Å—ä—Å—Ç–æ—è–Ω–∏–µ. ‚Äû–†–µ–≥–∏—Å—Ç—Ä–∏—Ä–∞–Ω‚Äú –Ω–µ –æ–∑–Ω–∞—á–∞–≤–∞ –∞–≤—Ç–æ–º–∞—Ç–∏—á–Ω–æ ‚Äû—Ä–∞–±–æ—Ç–∏‚Äú.
+      </div>
+      <section class="drawer-section permission-list">
+        <button type="button" class="permission-card tool-status-card system-control-link" data-system-configuration>
+          <div>
+            <strong>–°–∏—Å—Ç–µ–º–µ–Ω –∫–æ–Ω—Ç—Ä–æ–ª</strong>
+            <p>–Ø–¥—Ä–æ, –∏–Ω—Å—Ç—Ä—É–º–µ–Ω—Ç–∏ –∏ –≤—Å–∏—á–∫–∏ –ø—Ä–æ–º–µ–Ω–ª–∏–≤–∏ –±–µ–∑ –ø–æ–∫–∞–∑–≤–∞–Ω–µ –Ω–∞ —Ç–∞–π–Ω–∏—Ç–µ –∏–º —Å—Ç–æ–π–Ω–æ—Å—Ç–∏.</p>
+          </div>
+          <span class="permission-badge allow">–û—Ç–≤–æ—Ä–∏</span>
+        </button>
+        <article class="permission-card tool-status-card">
+          <div><strong>–°–Ω–∏–º–∫–∏</strong><p>JPEG, PNG –∏ WebP –¥–æ 5 MB.</p></div>
+          <span class="permission-badge allow">–†–∞–±–æ—Ç–∏</span>
+        </article>
+        ${tools
+          .map((tool) => {
+            const status = toolState(
+              tool,
+              Boolean(googleData.connected),
+              Boolean(githubData.connected),
+            );
+            const description =
+              tool.id === "github-write" &&
+              tool.availabilityCode === "COPILOT_AUTOMATION_DISABLED"
+                ? "–ö–æ–¥–æ–≤–∏—è—Ç –º–æ—Å—Ç –µ –∑–∞–ø–∞–∑–µ–Ω, –Ω–æ –µ –∏–∑–∫–ª—é—á–µ–Ω –≤ —Ç–µ–∫—É—â–∏—è —Ä–µ–∂–∏–º –±–µ–∑ Copilot."
+                : descriptions[tool.id] || "–ò–Ω—Å—Ç—Ä—É–º–µ–Ω—Ç –Ω–∞ SYNCHRON-X.";
+            return `
+              <article class="permission-card tool-status-card">
+                <div>
+                  <strong>${escapeHtml(tool.name)}</strong>
+                  <p>${escapeHtml(description)}</p>
+                </div>
+                ${toolStatusActions(
+                  tool,
+                  status,
+                  Boolean(googleData.connected),
+                  Boolean(githubData.connected),
+                )}
+              </article>`;
+          })
+          .join("")}
+      </section>`;
+  } catch (error) {
+    renderDrawerError(error.message);
+  }
+}
+
+function configurationStatus(item) {
+  const labels = {
+    configured: ["–ù–∞—Å—Ç—Ä–æ–µ–Ω–∞", "allow"],
+    defaulted: ["–ü–æ –ø–æ–¥—Ä–∞–∑–±–∏—Ä–∞–Ω–µ", "allow"],
+    "missing-required": ["–õ–∏–ø—Å–≤–∞", "deny"],
+    "optional-missing": ["–ù–µ–∑–∞–¥—ä–ª–∂–∏—Ç–µ–ª–Ω–∞", "confirm"],
+    compatibility: ["–°—Ç–∞—Ä —Ä–µ–∑–µ—Ä–≤–µ–Ω –ø—ä—Ç", "confirm"],
+    "not-needed": ["–ù–µ –µ –Ω—É–∂–Ω–∞", "allow"],
+    unused: ["–ù–µ —Å–µ –∏–∑–ø–æ–ª–∑–≤–∞", "deny"],
+  };
+  const [label, className] = labels[item.status] || [item.status, "confirm"];
+  return { label, className };
+}
+
+function renderEnvironmentGroup(area, items) {
+  return `
+    <details class="configuration-group" ${items.some((item) => item.status === "missing-required") ? "open" : ""}>
+      <summary>${escapeHtml(area)} <span>${items.length}</span></summary>
+      <div class="configuration-list">
+        ${items
+          .map((item) => {
+            const status = configurationStatus(item);
+            return `
+              <article class="configuration-item">
+                <div>
+                  <code>${escapeHtml(item.key)}</code>
+                  <p>${escapeHtml(item.purpose)}</p>
+                  <small>
+                    ${item.sensitivity === "secret" ? "–¢–∞–π–Ω–∞ —Å—Ç–æ–π–Ω–æ—Å—Ç ¬∑ –Ω–∏–∫–æ–≥–∞ –Ω–µ —Å–µ –ø–æ–∫–∞–∑–≤–∞" : "–û–±—â–∞ –Ω–∞—Å—Ç—Ä–æ–π–∫–∞"}
+                    ¬∑ DigitalOcean: ${item.digitalOceanDeclared ? "–¥–µ–∫–ª–∞—Ä–∏—Ä–∞–Ω–∞" : "–Ω–µ –µ –¥–µ–∫–ª–∞—Ä–∏—Ä–∞–Ω–∞"}
+                  </small>
+                </div>
+                <span class="permission-badge ${status.className}">${status.label}</span>
+              </article>`;
+          })
+          .join("")}
+      </div>
+    </details>`;
+}
+
+async function openSystemConfigurationDrawer() {
+  openDataDrawer("–°–∏—Å—Ç–µ–º–µ–Ω –∫–æ–Ω—Ç—Ä–æ–ª");
+  renderDrawerLoading();
+  try {
+    const [configurationResponse, integrationsResponse, readinessResponse] =
+      await Promise.all([
+        fetch("/api/system/configuration", { cache: "no-store" }),
+        fetch("/health/integrations", { cache: "no-store" }),
+        fetch("/health/ready", { cache: "no-store" }),
+      ]);
+    if (!configurationResponse.ok || !integrationsResponse.ok) {
+      throw new Error("–°–∏—Å—Ç–µ–º–Ω–∞—Ç–∞ –ø—Ä–æ–≤–µ—Ä–∫–∞ –≤—Ä–µ–º–µ–Ω–Ω–æ –Ω–µ –µ –¥–æ—Å—Ç—ä–ø–Ω–∞.");
+    }
+    const configuration = await configurationResponse.json();
+    const integrations = await integrationsResponse.json();
     const readiness = readinessResponse.ok
       ? await readinessResponse.json()
       : null;

--- a/public/index.html
+++ b/public/index.html
@@ -393,9 +393,9 @@
     </main>
 
     <script src="/markdown-renderer.js?v=20260728-xss"></script>
-    <script src="/assets/20260730-opensearch-status-v1/app.js"></script>
+    <script src="/assets/20260731-no-copilot-v1/app.js"></script>
     <script src="/accessibility.js?v=20260728-font-stepper"></script>
-    <script src="/assets/20260730-connections-v1/work-center.js"></script>
+    <script src="/assets/20260731-no-copilot-v1/work-center.js"></script>
     <script src="/task-journal.js?v=20260728-task-journal"></script>
     <script src="/google-drive.js?v=20260727-connection-actions"></script>
     <script src="/google-apps.js?v=20260727-connection-actions"></script>

--- a/public/work-center.js
+++ b/public/work-center.js
@@ -224,6 +224,11 @@
         ? "working"
         : "action"
       : "unavailable";
+    const githubWrite = integrations?.tools?.find(
+      (item) => item.id === "github-write",
+    );
+    const githubWriteDisabled =
+      githubWrite?.availabilityCode === "COPILOT_AUTOMATION_DISABLED";
 
     return [
       {
@@ -239,7 +244,9 @@
         state: resolveCapabilityState(integrations, "github-read"),
       },
       {
-        label: "GitHub запис с точно потвърждение",
+        label: githubWriteDisabled
+          ? "GitHub запис · изключен в режим без Copilot"
+          : "GitHub запис с точно потвърждение",
         state: resolveCapabilityState(integrations, "github-write", {
           connected: Boolean(sessions.githubConnected),
         }),
@@ -383,12 +390,7 @@
     );
     body.appendChild(intro);
     body.appendChild(
-      renderCurrentCapabilities(
-        readiness,
-        integrations,
-        sessions,
-        testerAuth,
-      ),
+      renderCurrentCapabilities(readiness, integrations, sessions, testerAuth),
     );
 
     const grid = document.createElement("section");

--- a/src/config/environmentCatalog.js
+++ b/src/config/environmentCatalog.js
@@ -192,6 +192,12 @@ export const ENVIRONMENT_CATALOG = Object.freeze(
       requiredNow: true,
     }),
     general(
+      "COPILOT_AUTOMATION_ENABLED",
+      "GitHub",
+      "Включва кодовото делегиране към Copilot само при точна стойност true.",
+      { hasDefault: true },
+    ),
+    general(
       "GITHUB_REDIRECT_URI",
       "GitHub",
       "Защитен обратен адрес след GitHub вход.",

--- a/src/config/featureFlags.js
+++ b/src/config/featureFlags.js
@@ -1,0 +1,3 @@
+export function isCopilotAutomationEnabled(env = process.env) {
+  return env.COPILOT_AUTOMATION_ENABLED === "true";
+}

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -13,6 +13,7 @@ import {
   createMcpRequestHandler,
 } from "../services/mcpReadService.js";
 import { isMcpOAuthConfigured } from "../services/mcpOAuthService.js";
+import { isCopilotAutomationEnabled } from "../config/featureFlags.js";
 import { isToolExecutable } from "../tools/capabilityEngine.js";
 import { listTools, registerCoreTools } from "../tools/toolRegistry.js";
 
@@ -182,13 +183,20 @@ function hasAllProcessEnvironmentVariables(...names) {
 }
 
 function resolveToolHealthStatus(tool, configuration = {}) {
-  if (!tool.enabled || !configuration.configured) return "unavailable";
+  if (
+    !tool.enabled ||
+    configuration.runtimeEnabled === false ||
+    !configuration.configured
+  ) {
+    return "unavailable";
+  }
   if (configuration.authenticated === false) return "degraded";
   return "healthy";
 }
 
 export function getIntegrationStatus({ githubAuthenticated = false } = {}) {
   registerCoreTools();
+  const copilotAutomationEnabled = isCopilotAutomationEnabled();
   const configuration = {
     "synchron-integrations-status": {
       configured: true,
@@ -205,6 +213,13 @@ export function getIntegrationStatus({ githubAuthenticated = false } = {}) {
     "github-write": {
       configured: isGitHubOAuthConfigured(),
       authenticated: githubAuthenticated,
+      runtimeEnabled: copilotAutomationEnabled,
+      availabilityCode: copilotAutomationEnabled
+        ? null
+        : "COPILOT_AUTOMATION_DISABLED",
+      availabilityReason: copilotAutomationEnabled
+        ? null
+        : "GitHub Write е изключен — режим без Copilot.",
     },
     "google-drive-read": {
       configured: hasAllProcessEnvironmentVariables(
@@ -282,15 +297,20 @@ export function getIntegrationStatus({ githubAuthenticated = false } = {}) {
       },
       memory: configuration["opensearch-memory"],
     },
-    tools: listTools().map((tool) => ({
-      id: tool.id,
-      name: tool.name,
-      enabled: tool.enabled,
-      executable: isToolExecutable(tool.id),
-      configured: Boolean(configuration[tool.id]?.configured),
-      authenticated: configuration[tool.id]?.authenticated,
-      healthStatus: resolveToolHealthStatus(tool, configuration[tool.id]),
-    })),
+    tools: listTools().map((tool) => {
+      const toolConfiguration = configuration[tool.id] || {};
+      return {
+        id: tool.id,
+        name: tool.name,
+        enabled: tool.enabled && toolConfiguration.runtimeEnabled !== false,
+        executable: isToolExecutable(tool.id),
+        configured: Boolean(toolConfiguration.configured),
+        authenticated: toolConfiguration.authenticated,
+        healthStatus: resolveToolHealthStatus(tool, toolConfiguration),
+        availabilityCode: toolConfiguration.availabilityCode || null,
+        availabilityReason: toolConfiguration.availabilityReason || null,
+      };
+    }),
   };
 }
 

--- a/src/services/copilotTaskService.js
+++ b/src/services/copilotTaskService.js
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 
+import { isCopilotAutomationEnabled } from "../config/featureFlags.js";
 import {
   createDurableConfirmation,
   markDurableConfirmationUsed,
@@ -551,6 +552,17 @@ export async function getCopilotBridgeStatus({
   fetchImpl = fetch,
 } = {}) {
   splitRepository(repository);
+  if (!isCopilotAutomationEnabled()) {
+    return Object.freeze({
+      status: "disabled",
+      configured: isGitHubOAuthConfigured(),
+      connected: false,
+      copilotEnabled: false,
+      repository,
+      mode: "disabled-without-copilot",
+      reasonCode: "COPILOT_AUTOMATION_DISABLED",
+    });
+  }
   if (!isGitHubOAuthConfigured()) {
     return Object.freeze({
       status: "not-configured",
@@ -603,6 +615,13 @@ export async function getCopilotBridgeStatus({
 }
 
 export function formatCopilotBridgeStatus(status) {
+  if (status.reasonCode === "COPILOT_AUTOMATION_DISABLED") {
+    return [
+      "Проверих текущия режим за GitHub Write.",
+      "Резултат: изключен е — работим без Copilot.",
+      "GitHub Read остава активен; кодовият мост не прави assignment, branch, commit или Pull Request.",
+    ].join("\n");
+  }
   if (!status.configured) {
     return [
       "Проверих GitHub Write моста реално.",
@@ -640,6 +659,13 @@ export async function startCopilotTask({
   baseRef = "main",
   fetchImpl = fetch,
 }) {
+  if (!isCopilotAutomationEnabled()) {
+    throw new CopilotTaskError(
+      "GitHub Write е изключен — режим без Copilot.",
+      503,
+      "COPILOT_AUTOMATION_DISABLED",
+    );
+  }
   const session = await getGitHubSession(githubSessionId);
   if (!session || !isAuthorizedGitHubLogin(session.login)) {
     throw new GitHubOAuthError(

--- a/src/tools/capabilityEngine.js
+++ b/src/tools/capabilityEngine.js
@@ -1,4 +1,5 @@
 import { evaluatePermission } from "../services/permissionService.js";
+import { isCopilotAutomationEnabled } from "../config/featureFlags.js";
 import { answerGitHubReadRequest } from "../services/githubService.js";
 import {
   GoogleDriveError,
@@ -80,6 +81,13 @@ export function getToolRuntimeAvailability(
     case "github-read":
       return configured(true, null);
     case "github-write":
+      if (!isCopilotAutomationEnabled(env)) {
+        return configured(
+          false,
+          "GitHub Write е изключен — режим без Copilot.",
+          "COPILOT_AUTOMATION_DISABLED",
+        );
+      }
       if (!hasEnvironment(env, "GITHUB_CLIENT_ID", "GITHUB_CLIENT_SECRET")) {
         return configured(
           false,
@@ -181,7 +189,15 @@ export async function buildIntegrationStatusReport(
     env = process.env,
   } = {},
 ) {
+  const copilotAutomationEnabled = isCopilotAutomationEnabled(env);
   if (isCopilotBridgeStatusRequest(input.message)) {
+    if (!copilotAutomationEnabled) {
+      return [
+        "Проверих текущия режим за GitHub Write.",
+        "Резултат: изключен е — работим без Copilot.",
+        "GitHub Read остава активен; кодовият мост не прави assignment, branch, commit или Pull Request.",
+      ].join("\n");
+    }
     const bridge = await checkGitHubWriteBridge({
       githubSessionId: input.githubSessionId,
     });
@@ -208,7 +224,13 @@ export async function buildIntegrationStatusReport(
     ["OpenAI Web Search", Boolean(env.OPENAI_API_KEY)],
   ];
   const sessionTools = [
-    ["GitHub Write", Boolean(input.githubSessionId), "изисква потвърждение"],
+    [
+      "GitHub Write",
+      copilotAutomationEnabled && Boolean(input.githubSessionId),
+      copilotAutomationEnabled
+        ? "изисква потвърждение"
+        : "изключен — режим без Copilot",
+    ],
     ["Google Drive", googleConnected, "изисква Google вход"],
     ["Google Calendar", googleConnected, "изисква Google вход"],
     ["Gmail", googleConnected, "изисква Google вход"],
@@ -476,6 +498,19 @@ const executors = Object.freeze({
 
 export async function executeCapability(capability, input = {}, options = {}) {
   const resolved = resolveCapability(capability, options);
+  const runtimeEnvironment = options.env || process.env;
+  if (
+    resolved.tool.id === "github-write" &&
+    !isCopilotAutomationEnabled(runtimeEnvironment)
+  ) {
+    const runtime = getToolRuntimeAvailability(
+      resolved.tool.id,
+      input,
+      runtimeEnvironment,
+    );
+    throw new CapabilityError(runtime.reason, runtime.code, 503);
+  }
+
   if (resolved.requiresConfirmation && options.confirmed !== true) {
     const canPrepareConfirmation =
       options.prepareConfirmation === true &&
@@ -501,7 +536,7 @@ export async function executeCapability(capability, input = {}, options = {}) {
   const runtime = getToolRuntimeAvailability(
     resolved.tool.id,
     input,
-    options.env || process.env,
+    runtimeEnvironment,
   );
   if (!runtime.available) {
     throw new CapabilityError(runtime.reason, runtime.code, 503);
@@ -523,6 +558,9 @@ export async function executeCapability(capability, input = {}, options = {}) {
   return Object.freeze({ ...resolved, output });
 }
 
-export function isToolExecutable(toolId) {
+export function isToolExecutable(toolId, env = process.env) {
+  if (toolId === "github-write" && !isCopilotAutomationEnabled(env)) {
+    return false;
+  }
   return typeof executors[toolId] === "function";
 }

--- a/tests/capabilityEngine.test.js
+++ b/tests/capabilityEngine.test.js
@@ -76,11 +76,19 @@ test("блокира липсваща способност по подразби
   );
 });
 
-test("маркира GitHub Copilot адаптера като изпълним и изисква потвърждение", () => {
+test("пази GitHub Copilot адаптера, но го изключва по подразбиране", () => {
   const result = resolveCapability("code.write");
   assert.equal(result.tool.id, "github-write");
   assert.equal(result.requiresConfirmation, true);
-  assert.equal(isToolExecutable("github-write"), true);
+  assert.equal(isToolExecutable("github-write", {}), false);
+  assert.equal(
+    isToolExecutable("github-write", { COPILOT_AUTOMATION_ENABLED: "TRUE" }),
+    false,
+  );
+  assert.equal(
+    isToolExecutable("github-write", { COPILOT_AUTOMATION_ENABLED: "true" }),
+    true,
+  );
 });
 
 test("Calendar Write има изпълним адаптер и изисква потвърждение", () => {
@@ -117,6 +125,29 @@ test("runtime availability blocks configured-looking tools without credentials",
   );
   assert.equal(
     getToolRuntimeAvailability(
+      "github-write",
+      { githubSessionId: "owner-session" },
+      {
+        GITHUB_CLIENT_ID: "client",
+        GITHUB_CLIENT_SECRET: "secret",
+      },
+    ).code,
+    "COPILOT_AUTOMATION_DISABLED",
+  );
+  assert.equal(
+    getToolRuntimeAvailability(
+      "github-write",
+      { githubSessionId: "owner-session" },
+      {
+        COPILOT_AUTOMATION_ENABLED: "true",
+        GITHUB_CLIENT_ID: "client",
+        GITHUB_CLIENT_SECRET: "secret",
+      },
+    ).available,
+    true,
+  );
+  assert.equal(
+    getToolRuntimeAvailability(
       "google-calendar-read",
       {},
       {
@@ -126,6 +157,30 @@ test("runtime availability blocks configured-looking tools without credentials",
       },
     ).code,
     "CAPABILITY_AUTH_REQUIRED",
+  );
+});
+
+test("code.write спира преди Copilot flow в изключен режим", async () => {
+  await assert.rejects(
+    () =>
+      executeCapability(
+        "code.write",
+        {
+          githubSessionId: "owner-session",
+          message: "Създай Pull Request.",
+        },
+        {
+          env: {
+            GITHUB_CLIENT_ID: "client",
+            GITHUB_CLIENT_SECRET: "secret",
+          },
+          prepareConfirmation: true,
+        },
+      ),
+    (error) =>
+      error instanceof CapabilityError &&
+      error.code === "COPILOT_AUTOMATION_DISABLED" &&
+      /режим без Copilot/u.test(error.message),
   );
 });
 
@@ -189,7 +244,10 @@ test("връща общ статус само след реални провер
       checkMemory: async () => [],
       checkSupabase: async () => ({ status: "healthy" }),
       checkDigitalOcean: async () => ({ app: { id: "app-1" } }),
-      env: { OPENAI_API_KEY: "configured" },
+      env: {
+        OPENAI_API_KEY: "configured",
+        COPILOT_AUTOMATION_ENABLED: "true",
+      },
     },
   );
 
@@ -220,6 +278,7 @@ test("връща фокусиран проверен статус за GitHub Co
         createsPullRequest: true,
         mergesMainAutomatically: false,
       }),
+      env: { COPILOT_AUTOMATION_ENABLED: "true" },
     },
   );
 
@@ -227,6 +286,27 @@ test("връща фокусиран проверен статус за GitHub Co
   assert.match(report, /отделен клон/u);
   assert.match(report, /Pull Request/u);
   assert.match(report, /Не слива автоматично/u);
+});
+
+test("връща режим без Copilot без да проверява външния мост", async () => {
+  let bridgeChecked = false;
+  const report = await buildIntegrationStatusReport(
+    {
+      message: "Работи ли GitHub Write мостът?",
+      githubSessionId: "github-session",
+    },
+    {
+      checkGitHubWriteBridge: async () => {
+        bridgeChecked = true;
+        throw new Error("не трябва да се извиква");
+      },
+      env: {},
+    },
+  );
+
+  assert.equal(bridgeChecked, false);
+  assert.match(report, /изключен е — работим без Copilot/u);
+  assert.match(report, /GitHub Read остава активен/u);
 });
 
 test("не изпълнява способност за потвърждение без разрешение", async () => {
@@ -252,7 +332,11 @@ test("всеки регистриран основен инструмент им
     "supabase-status",
     "opensearch-memory",
   ]) {
-    assert.equal(isToolExecutable(id), true, id);
+    assert.equal(
+      isToolExecutable(id, { COPILOT_AUTOMATION_ENABLED: "true" }),
+      true,
+      id,
+    );
   }
 });
 

--- a/tests/copilotTaskService.test.js
+++ b/tests/copilotTaskService.test.js
@@ -103,6 +103,7 @@ test.beforeEach(() => {
   resetGitHubSessionsForTests();
   resetConfirmationsForTests();
   resetToolRegistryForTests();
+  process.env.COPILOT_AUTOMATION_ENABLED = "true";
   process.env.GITHUB_CLIENT_ID = "test-client";
   process.env.GITHUB_CLIENT_SECRET = "test-secret";
 });
@@ -111,6 +112,7 @@ test.afterEach(() => {
   resetGitHubSessionsForTests();
   resetConfirmationsForTests();
   resetToolRegistryForTests();
+  delete process.env.COPILOT_AUTOMATION_ENABLED;
   delete process.env.GITHUB_CLIENT_ID;
   delete process.env.GITHUB_CLIENT_SECRET;
 });
@@ -129,6 +131,51 @@ test("code.write prepares a Copilot confirmation through Capability Engine", asy
   assert.equal(result.tool.id, "github-write");
   assert.match(result.output, /Подготвих кодовата задача/u);
   assert.match(result.output, /Потвърждавам GitHub задача:/u);
+});
+
+test("service blocks a direct Copilot start when automation is disabled", async () => {
+  const session = await connectedSession();
+  let externalCallStarted = false;
+  delete process.env.COPILOT_AUTOMATION_ENABLED;
+
+  try {
+    await assert.rejects(
+      () =>
+        startCopilotTask({
+          githubSessionId: session.id,
+          prompt: "Промени бутона.",
+          fetchImpl: async () => {
+            externalCallStarted = true;
+            throw new Error("не трябва да се извиква");
+          },
+        }),
+      (error) => error.code === "COPILOT_AUTOMATION_DISABLED",
+    );
+    assert.equal(externalCallStarted, false);
+  } finally {
+    process.env.COPILOT_AUTOMATION_ENABLED = "true";
+  }
+});
+
+test("bridge status reports disabled mode without a GitHub call", async () => {
+  let externalCallStarted = false;
+  delete process.env.COPILOT_AUTOMATION_ENABLED;
+
+  try {
+    const status = await getCopilotBridgeStatus({
+      githubSessionId: "unused",
+      fetchImpl: async () => {
+        externalCallStarted = true;
+        throw new Error("не трябва да се извиква");
+      },
+    });
+    assert.equal(status.status, "disabled");
+    assert.equal(status.reasonCode, "COPILOT_AUTOMATION_DISABLED");
+    assert.equal(externalCallStarted, false);
+    assert.match(formatCopilotBridgeStatus(status), /работим без Copilot/u);
+  } finally {
+    process.env.COPILOT_AUTOMATION_ENABLED = "true";
+  }
 });
 
 test("recognizes a GitHub Write availability question without starting a task", () => {
@@ -412,7 +459,6 @@ test("requires an exact one-time confirmation before starting Copilot", async ()
     (error) => error.code === "CONFIRMATION_NOT_FOUND",
   );
 });
-
 
 test("Copilot adapter is not called when the audited write guard blocks", async () => {
   const session = await connectedSession();

--- a/tests/dataControlsUi.test.js
+++ b/tests/dataControlsUi.test.js
@@ -30,7 +30,10 @@ test("application exposes working memory and permission controls", async () => {
   assert.doesNotMatch(script, /function openFocusDrawer\(\)/u);
   assert.doesNotMatch(script, /Свързване на GitHub Copilot/u);
   assert.match(script, /function openToolsDrawer\(\)/u);
-  assert.match(script, /<strong>Снимки<\/strong><p>JPEG, PNG и WebP до 5 MB\.<\/p>/u);
+  assert.match(
+    script,
+    /<strong>Снимки<\/strong><p>JPEG, PNG и WebP до 5 MB\.<\/p>/u,
+  );
   assert.doesNotMatch(script, /Снимки и файлове/u);
   assert.match(script, /fetch\(["']\/health\/integrations["']/u);
   assert.match(script, /Твоята лична AI операционна система/u);
@@ -39,6 +42,12 @@ test("application exposes working memory and permission controls", async () => {
   assert.match(script, /markMemoryOperational\(\)/u);
   assert.match(script, /state\.opensearchFailures >= 3/u);
   assert.match(script, /Свързан · работи/u);
+  assert.match(script, /Изключено · режим без Copilot/u);
+  assert.match(script, /COPILOT_AUTOMATION_DISABLED/u);
+  assert.match(
+    script,
+    /Кодовият мост е запазен, но е изключен в текущия режим без Copilot/u,
+  );
   assert.doesNotMatch(script, /fetch\(["']\/opensearch-status["']/u);
-  assert.match(html, /\/assets\/20260730-opensearch-status-v1\/app\.js/u);
+  assert.match(html, /\/assets\/20260731-no-copilot-v1\/app\.js/u);
 });

--- a/tests/environmentContract.test.js
+++ b/tests/environmentContract.test.js
@@ -86,3 +86,9 @@ test("bridge variables stay documented without real secret values", () => {
     assert.match(envExample, new RegExp(`^${key}=$`, "mu"));
   }
 });
+
+test("Copilot automation stays explicitly disabled by default", () => {
+  const appSpecBlock = appSpecKeyBlock(appSpec, "COPILOT_AUTOMATION_ENABLED");
+  assert.match(appSpecBlock, /^\s*value:\s*["']?false["']?\s*$/mu);
+  assert.match(envExample, /^COPILOT_AUTOMATION_ENABLED=false$/mu);
+});

--- a/tests/integrationHealth.test.js
+++ b/tests/integrationHealth.test.js
@@ -14,6 +14,7 @@ const ENV_NAMES = [
   "GOOGLE_CLIENT_ID",
   "GOOGLE_CLIENT_SECRET",
   "GOOGLE_REDIRECT_URI",
+  "COPILOT_AUTOMATION_ENABLED",
   "GITHUB_CLIENT_ID",
   "GITHUB_CLIENT_SECRET",
   "GITHUB_REDIRECT_URI",
@@ -30,6 +31,7 @@ test("integration status reports configuration without exposing secret values", 
     ENV_NAMES.map((name) => [name, process.env[name]]),
   );
   for (const name of ENV_NAMES) process.env[name] = `secret-${name}`;
+  process.env.COPILOT_AUTOMATION_ENABLED = "true";
   resetToolRegistryForTests();
 
   try {
@@ -69,6 +71,7 @@ test("GitHub Write reports the authenticated owner session", () => {
   );
   process.env.GITHUB_CLIENT_ID = "client-id";
   process.env.GITHUB_CLIENT_SECRET = "client-secret";
+  process.env.COPILOT_AUTOMATION_ENABLED = "true";
   resetToolRegistryForTests();
 
   try {
@@ -92,6 +95,7 @@ test("GitHub Write is configured with client id and secret only", () => {
   );
   process.env.GITHUB_CLIENT_ID = "client-id";
   process.env.GITHUB_CLIENT_SECRET = "client-secret";
+  process.env.COPILOT_AUTOMATION_ENABLED = "true";
   delete process.env.GITHUB_REDIRECT_URI;
   resetToolRegistryForTests();
 
@@ -99,6 +103,33 @@ test("GitHub Write is configured with client id and secret only", () => {
     const status = getIntegrationStatus();
     const githubWrite = status.tools.find((tool) => tool.id === "github-write");
     assert.equal(githubWrite.configured, true);
+  } finally {
+    for (const [name, value] of Object.entries(original)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    resetToolRegistryForTests();
+  }
+});
+
+test("GitHub Write reports the explicit mode without Copilot", () => {
+  const original = Object.fromEntries(
+    ENV_NAMES.map((name) => [name, process.env[name]]),
+  );
+  process.env.GITHUB_CLIENT_ID = "client-id";
+  process.env.GITHUB_CLIENT_SECRET = "client-secret";
+  delete process.env.COPILOT_AUTOMATION_ENABLED;
+  resetToolRegistryForTests();
+
+  try {
+    const status = getIntegrationStatus({ githubAuthenticated: true });
+    const githubWrite = status.tools.find((tool) => tool.id === "github-write");
+    assert.equal(githubWrite.enabled, false);
+    assert.equal(githubWrite.executable, false);
+    assert.equal(githubWrite.configured, true);
+    assert.equal(githubWrite.healthStatus, "unavailable");
+    assert.equal(githubWrite.availabilityCode, "COPILOT_AUTOMATION_DISABLED");
+    assert.match(githubWrite.availabilityReason, /режим без Copilot/u);
   } finally {
     for (const [name, value] of Object.entries(original)) {
       if (value === undefined) delete process.env[name];

--- a/tests/workCenterUi.test.js
+++ b/tests/workCenterUi.test.js
@@ -529,6 +529,44 @@ test("current capabilities summary uses only live verified status", async () => 
   assert.match(working.textContent, /Тестови профили/u);
 });
 
+test("current capabilities reports GitHub Write as disabled without Copilot", async () => {
+  const harness = createHarness({
+    integrations: {
+      tools: [
+        {
+          id: "github-read",
+          enabled: true,
+          executable: true,
+          configured: true,
+        },
+        {
+          id: "github-write",
+          enabled: false,
+          executable: false,
+          configured: true,
+          availabilityCode: "COPILOT_AUTOMATION_DISABLED",
+        },
+      ],
+    },
+    githubConnected: true,
+  });
+  await openCenter(harness);
+  const unavailable = harness.dom.window.document.querySelector(
+    '[data-capability-group="unavailable"]',
+  );
+
+  assert.match(
+    unavailable.textContent,
+    /GitHub запис · изключен в режим без Copilot/u,
+  );
+  assert.doesNotMatch(
+    harness.dom.window.document.querySelector(
+      '[data-capability-group="working"]',
+    ).textContent,
+    /GitHub запис/u,
+  );
+});
+
 test("missing Google session is an action and never a working capability", async () => {
   const harness = createHarness({ googleConnected: false });
   await openCenter(harness);
@@ -536,7 +574,10 @@ test("missing Google session is an action and never a working capability", async
   const working = document.querySelector('[data-capability-group="working"]');
   const action = document.querySelector('[data-capability-group="action"]');
 
-  assert.doesNotMatch(working.textContent, /Google Drive|Gmail|Google Calendar/u);
+  assert.doesNotMatch(
+    working.textContent,
+    /Google Drive|Gmail|Google Calendar/u,
+  );
   assert.match(action.textContent, /Google Drive/u);
   assert.match(action.textContent, /Gmail/u);
   assert.match(action.textContent, /Google Calendar/u);


### PR DESCRIPTION
Closes #198

## Какво се променя
- `COPILOT_AUTOMATION_ENABLED=false` е явната безопасна production стойност.
- Capability Engine, естественият status отговор и самата Copilot услуга спират fail-closed преди външно извикване.
- GitHub Read остава активен.
- `/health/integrations`, Инструменти и Работният център показват „режим без Copilot“ без подвеждащо свързване.
- Runbook описва условията за евентуално бъдещо включване.

## Проверки
- `npm test`: 445/445
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities
- Prettier + `git diff --check`: зелени

Не се добавят тайни, платени ресурси или промени по реални данни.