### PR TITLE
Hotfix: възстанови обслужваните frontend asset URL-и

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -393,9 +393,9 @@
     </main>
 
     <script src="/markdown-renderer.js?v=20260728-xss"></script>
-    <script src="/assets/20260731-no-copilot-v1/app.js"></script>
+    <script src="/assets/20260730-opensearch-status-v1/app.js"></script>
     <script src="/accessibility.js?v=20260728-font-stepper"></script>
-    <script src="/assets/20260731-no-copilot-v1/work-center.js"></script>
+    <script src="/assets/20260730-connections-v1/work-center.js"></script>
     <script src="/task-journal.js?v=20260728-task-journal"></script>
     <script src="/google-drive.js?v=20260727-connection-actions"></script>
     <script src="/google-apps.js?v=20260727-connection-actions"></script>

--- a/tests/dataControlsUi.test.js
+++ b/tests/dataControlsUi.test.js
@@ -49,5 +49,5 @@ test("application exposes working memory and permission controls", async () => {
     /Кодовият мост е запазен, но е изключен в текущия режим без Copilot/u,
   );
   assert.doesNotMatch(script, /fetch\(["']\/opensearch-status["']/u);
-  assert.match(html, /\/assets\/20260731-no-copilot-v1\/app\.js/u);
+  assert.match(html, /\/assets\/20260730-opensearch-status-v1\/app\.js/u);
 });

--- a/tests/versionedAssetRoutes.test.js
+++ b/tests/versionedAssetRoutes.test.js
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import request from "supertest";
+
+process.env.NODE_ENV = "test";
+const { default: app } = await import("../server.js");
+
+test("versioned application assets referenced by HTML are served", async () => {
+  const index = await request(app).get("/");
+  assert.equal(index.status, 200);
+
+  const assetUrls = [
+    ...index.text.matchAll(
+      /<script src="(\/assets\/[^"]+\/(?:app|work-center)\.js)"><\/script>/gu,
+    ),
+  ].map((match) => match[1]);
+  assert.deepEqual(assetUrls, [
+    "/assets/20260730-opensearch-status-v1/app.js",
+    "/assets/20260730-connections-v1/work-center.js",
+  ]);
+
+  for (const assetUrl of assetUrls) {
+    const response = await request(app).get(assetUrl);
+    assert.equal(response.status, 200, assetUrl);
+    assert.equal(response.headers["cache-control"], "no-store, max-age=0");
+    assert.match(response.headers["content-type"], /javascript/u);
+  }
+});


### PR DESCRIPTION
Closes #200

Production smoke след #199 установи 404 за новия frontend asset prefix.

- Връща HTML към съществуващите versioned `no-store` маршрути.
- Запазва цялото ново съдържание за режима без Copilot.
- Добавя supertest договор: двата URL-а от HTML трябва реално да връщат 200, JavaScript и `Cache-Control: no-store, max-age=0`.

Проверки: 446/446 теста, audit 0.