### PR TITLE
Prevent versioned frontend asset 404s

### DIFF
--- a/server.js
+++ b/server.js
@@ -82,19 +82,22 @@ app.use((_req, res, next) => {
 app.use(express.json({ limit: "8mb" }));
 
 const mobileLayoutAssetVersion = "20260730-v2";
-const openSearchStatusAssetVersion = "20260730-opensearch-status-v1";
-const connectionStatusAssetVersion = "20260730-connections-v1";
-app.get(`/assets/${openSearchStatusAssetVersion}/app.js`, (_req, res) => {
-  res.setHeader("Cache-Control", "no-store, max-age=0");
-  res.sendFile(`${process.cwd()}/public/app.js`);
+const versionedApplicationAssets = Object.freeze({
+  "app.js": "public/app.js",
+  "work-center.js": "public/work-center.js",
 });
-app.get(
-  `/assets/${connectionStatusAssetVersion}/work-center.js`,
-  (_req, res) => {
-    res.setHeader("Cache-Control", "no-store, max-age=0");
-    res.sendFile(`${process.cwd()}/public/work-center.js`);
-  },
-);
+const safeAssetVersionPattern = /^[a-z0-9][a-z0-9._-]{0,79}$/iu;
+
+app.get("/assets/:version/:asset", (req, res, next) => {
+  const assetPath = versionedApplicationAssets[req.params.asset];
+  if (!safeAssetVersionPattern.test(req.params.version) || !assetPath) {
+    next();
+    return;
+  }
+
+  res.setHeader("Cache-Control", "no-store, max-age=0");
+  res.sendFile(`${process.cwd()}/${assetPath}`);
+});
 app.get(
   `/assets/${mobileLayoutAssetVersion}/synchron-vision.css`,
   (_req, res) => {

--- a/tests/versionedAssetRoutes.test.js
+++ b/tests/versionedAssetRoutes.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import request from "supertest";
@@ -26,4 +27,36 @@ test("versioned application assets referenced by HTML are served", async () => {
     assert.equal(response.headers["cache-control"], "no-store, max-age=0");
     assert.match(response.headers["content-type"], /javascript/u);
   }
+});
+
+test("a new safe version serves only the current allowlisted application assets", async () => {
+  const [currentApp, currentWorkCenter] = await Promise.all([
+    readFile(new URL("../public/app.js", import.meta.url), "utf8"),
+    readFile(new URL("../public/work-center.js", import.meta.url), "utf8"),
+  ]);
+
+  const appResponse = await request(app).get(
+    "/assets/20991231-future-release/app.js",
+  );
+  assert.equal(appResponse.status, 200);
+  assert.equal(appResponse.text, currentApp);
+  assert.equal(appResponse.headers["cache-control"], "no-store, max-age=0");
+
+  const workCenterResponse = await request(app).get(
+    "/assets/20991231-future-release/work-center.js",
+  );
+  assert.equal(workCenterResponse.status, 200);
+  assert.equal(workCenterResponse.text, currentWorkCenter);
+  assert.equal(
+    workCenterResponse.headers["cache-control"],
+    "no-store, max-age=0",
+  );
+});
+
+test("versioned application asset routes reject unknown files and unsafe versions", async () => {
+  await request(app)
+    .get("/assets/20991231-future-release/unknown.js")
+    .expect(404);
+  await request(app).get("/assets/%21unsafe/app.js").expect(404);
+  await request(app).get("/assets/safe/%2e%2e").expect(404);
 });


### PR DESCRIPTION
Closes #202

## Какво променя

- премахва двойното ръчно поддържане на version стойностите за `app.js` и `work-center.js` между HTML и Express;
- приема бъдещ валиден version сегмент само за двата изрично разрешени application assets;
- винаги сервира текущите canonical файлове от `public/`;
- запазва `Cache-Control: no-store, max-age=0`;
- непознати файлове и невалидни version стойности остават 404.

## Причина

PR #199 промени HTML URL-ите без съответните server routes и production върна 404. PR #201 възстанови старите URL-и, но причината — две места за ръчна синхронизация — остана.

## Проверки

- целеви asset routing тестове: 3/3;
- пълен пакет: 448/448 успешни, 0 неуспешни, 0 пропуснати;
- full dependency audit: 0 уязвимости;
- production dependency audit: 0 уязвимости;
- Prettier и `git diff --check`: успешни.

## Граници

Не се променят AI Core, чат, памет, OpenSearch, authentication, secrets, permissions или production данни.