### PR TITLE
Fix focused OpenSearch backup checks

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -65,6 +65,7 @@ import {
   ImageServiceError,
   validateImageInput,
 } from "../services/imageService.js";
+import { DigitalOceanError } from "../services/digitalOceanService.js";
 import {
   CapabilityError,
   executeCapability,
@@ -593,6 +594,18 @@ function capabilityLabel(capability) {
 }
 
 function formatCapabilityFailureMessage(error) {
+  if (error instanceof DigitalOceanError) {
+    const messages = {
+      DIGITALOCEAN_TOKEN_INVALID:
+        "DigitalOcean token-ът е невалиден, изтекъл или отнет.",
+      DIGITALOCEAN_FORBIDDEN:
+        "DigitalOcean връзката няма право да прочете тези данни.",
+      DIGITALOCEAN_NOT_CONFIGURED: "DigitalOcean Read не е конфигуриран.",
+      DIGITALOCEAN_APP_NOT_CONFIGURED: "DigitalOcean App ID не е конфигуриран.",
+      DIGITALOCEAN_UPSTREAM_ERROR: "DigitalOcean API временно не отговаря.",
+    };
+    return messages[error.code] || "DigitalOcean временно не е достъпен.";
+  }
   if (
     error instanceof GitHubServiceError ||
     error instanceof GitHubOAuthError ||

--- a/src/services/digitalOceanService.js
+++ b/src/services/digitalOceanService.js
@@ -511,6 +511,20 @@ export async function getDigitalOceanDatabaseBackupInventory(
   );
 }
 
+export async function getDigitalOceanOpenSearchBackupAudit(options = {}) {
+  const data = await request("/databases?per_page=200", options);
+  const databases = safeArray(data?.databases).filter(
+    (database) => database?.engine === "opensearch",
+  );
+  return {
+    checkedAt: new Date().toISOString(),
+    databaseBackups: await getDigitalOceanDatabaseBackupInventory(
+      databases,
+      options,
+    ),
+  };
+}
+
 function regionSlug(resource) {
   return resource?.region?.slug || resource?.region || null;
 }
@@ -1028,6 +1042,33 @@ export function formatDigitalOceanAudit(audit) {
       : "Всички заявени секции са проверени.",
     "Ограничение: това е автоматичен преглед на данните от DigitalOcean API, а не доказателство, че приложението, архивите, тайните и всички настройки за сигурност са правилни.",
     "Не са направени промени.",
+  ].join("\n");
+}
+
+export function formatDigitalOceanOpenSearchBackupAudit(audit) {
+  const backups = safeArray(audit?.databaseBackups);
+  const backupLines = backups.length
+    ? backups.map((backup, index) => {
+        if (backup.status !== "verified") {
+          const reason =
+            backup.errorCode === "DIGITALOCEAN_FORBIDDEN"
+              ? "DigitalOcean token-ът няма право да прочете backup точките"
+              : backup.errorCode === "DIGITALOCEAN_TOKEN_INVALID"
+                ? "DigitalOcean token-ът е невалиден, изтекъл или отнет"
+                : "DigitalOcean API не върна проверими backup данни";
+          return `• OpenSearch база #${index + 1}: не е проверена — ${reason}.`;
+        }
+        const range = backup.backupCount
+          ? `; най-стара ${backup.oldestCreatedAt || "неизвестна"}; най-нова ${backup.newestCreatedAt || "неизвестна"}`
+          : "";
+        return `• OpenSearch база #${index + 1}: ${backup.backupCount} налични restore точки${range}.`;
+      })
+    : ["• Не е открита управлявана OpenSearch база в достъпния акаунт."];
+
+  return [
+    "OpenSearch backup инвентар — проверка само за четене.",
+    ...backupLines,
+    "Не е създаван restore или fork и не са променяни данни.",
   ].join("\n");
 }
 

--- a/src/tools/capabilityEngine.js
+++ b/src/tools/capabilityEngine.js
@@ -38,9 +38,11 @@ import {
 import { checkSupabaseStatus } from "../services/supabaseService.js";
 import {
   formatDigitalOceanAudit,
+  formatDigitalOceanOpenSearchBackupAudit,
   formatDigitalOceanStatus,
   getDigitalOceanAccountAudit,
   getDigitalOceanAppStatus,
+  getDigitalOceanOpenSearchBackupAudit,
 } from "../services/digitalOceanService.js";
 import {
   formatCloudflareStatus,
@@ -59,6 +61,12 @@ export class CapabilityError extends Error {
     this.code = code;
     this.status = status;
   }
+}
+
+export function isDigitalOceanBackupInventoryRequest(message = "") {
+  return /(?:opensearch|open\s*search|опен\s*сърч|backup|backups|архив|restore\s*точ)/iu.test(
+    message,
+  );
 }
 
 function hasEnvironment(env, ...names) {
@@ -407,6 +415,11 @@ const executors = Object.freeze({
     ].join("\n");
   },
   "digitalocean-read": async ({ input }) => {
+    if (isDigitalOceanBackupInventoryRequest(input.message)) {
+      return formatDigitalOceanOpenSearchBackupAudit(
+        await getDigitalOceanOpenSearchBackupAudit(),
+      );
+    }
     const wantsFullAudit =
       /(?:пълен|цял|одит|акаунт|ресурс|droplet|сървър|баз|мреж|firewall|защит|разход|billing|storage|volume|snapshot|kubernetes)/iu.test(
         input.message || "",

--- a/tests/chatCapabilityExecution.test.js
+++ b/tests/chatCapabilityExecution.test.js
@@ -13,6 +13,8 @@ import {
   splitCapabilitySubtasks,
 } from "../src/routes/chat.js";
 import { extractMemoryWriteConfirmationId } from "../src/services/memoryWriteConfirmationService.js";
+import { DigitalOceanError } from "../src/services/digitalOceanService.js";
+import { isDigitalOceanBackupInventoryRequest } from "../src/tools/capabilityEngine.js";
 
 test("memory confirmation keeps the overall task waiting", () => {
   const task = {
@@ -201,6 +203,32 @@ test("recognizes common Bulgarian DigitalOcean spellings as real tool requests",
       ["infrastructure.digitalocean.read"],
     );
   }
+});
+
+test("routes the exact OpenSearch backup request to the focused read-only audit", () => {
+  const message =
+    "Направи само read-only проверка на DigitalOcean и покажи OpenSearch backup инвентара: брой restore точки, най-стара и най-нова дата. Не създавай restore или fork и не променяй данни.";
+  assert.deepEqual(
+    detectCapabilityRequests(message).map(({ capability }) => capability),
+    ["infrastructure.digitalocean.read"],
+  );
+  assert.equal(isDigitalOceanBackupInventoryRequest(message), true);
+});
+
+test("DigitalOcean failures keep a safe actionable reason in chat", () => {
+  const replies = buildCapabilityReplies([
+    {
+      status: "rejected",
+      request: { capability: "infrastructure.digitalocean.read" },
+      error: new DigitalOceanError(
+        "upstream payload must stay hidden",
+        403,
+        "DIGITALOCEAN_FORBIDDEN",
+      ),
+    },
+  ]);
+  assert.match(replies[0], /няма право да прочете тези данни/u);
+  assert.doesNotMatch(replies[0], /upstream payload/u);
 });
 
 test("infrastructure results bypass AI rewriting and stay verified", () => {

--- a/tests/infrastructureBridges.test.js
+++ b/tests/infrastructureBridges.test.js
@@ -4,8 +4,10 @@ import test from "node:test";
 import {
   getDigitalOceanAccountAudit,
   getDigitalOceanDatabaseBackupInventory,
+  getDigitalOceanOpenSearchBackupAudit,
   getDigitalOceanAppStatus,
   formatDigitalOceanAudit,
+  formatDigitalOceanOpenSearchBackupAudit,
   formatDigitalOceanStatus,
 } from "../src/services/digitalOceanService.js";
 import {
@@ -230,6 +232,52 @@ test("database backup inventory distinguishes a verified empty backup list", asy
   assert.equal(inventory[0].backupCount, 0);
   assert.equal(inventory[0].oldestCreatedAt, null);
   assert.equal(inventory[0].newestCreatedAt, null);
+});
+
+test("focused OpenSearch backup audit performs only database and backup reads", async () => {
+  const calls = [];
+  const audit = await getDigitalOceanOpenSearchBackupAudit({
+    env: { DIGITALOCEAN_API_TOKEN: "focused-read-token" },
+    fetchImpl: async (url, options) => {
+      calls.push({ url: String(url), options });
+      if (String(url).endsWith("/databases?per_page=200")) {
+        return Response.json({
+          databases: [
+            { id: "db-search", engine: "opensearch" },
+            { id: "db-postgres", engine: "pg" },
+          ],
+        });
+      }
+      return Response.json({
+        backups: [
+          { created_at: "2026-07-30T02:00:00Z" },
+          { created_at: "2026-07-31T02:00:00Z" },
+        ],
+      });
+    },
+  });
+
+  assert.deepEqual(audit.databaseBackups, [
+    {
+      engine: "opensearch",
+      status: "verified",
+      backupCount: 2,
+      oldestCreatedAt: "2026-07-30T02:00:00.000Z",
+      newestCreatedAt: "2026-07-31T02:00:00.000Z",
+      errorCode: null,
+      errorStatus: null,
+    },
+  ]);
+  assert.deepEqual(
+    calls.map(({ url }) => new URL(url).pathname),
+    ["/v2/databases", "/v2/databases/db-search/backups"],
+  );
+  assert.ok(calls.every(({ options }) => options.method === "GET"));
+  assert.match(
+    formatDigitalOceanOpenSearchBackupAudit(audit),
+    /2 налични restore точки/u,
+  );
+  assert.doesNotMatch(JSON.stringify(audit), /focused-read-token/u);
 });
 
 test("Cloudflare bridge reads zone and DNS without writes", async () => {


### PR DESCRIPTION
Closes #204

## Какво променя

- разпознава `OpenSearch`, `backup`, `архив` и `restore точки` като фокусирана read-only проверка;
- заявява само списъка на управляваните бази и backup metadata за OpenSearch;
- не изпълнява общия account-wide DigitalOcean audit за тази команда;
- връща само провереност, брой restore точки, най-стара и най-нова дата;
- показва безопасна конкретна причина при липсващо право, невалиден token или upstream проблем;
- никога не връща provider payload, token, database id или име.

## Причина

Точната production команда от телефона върна общото „Избраният инструмент временно не е достъпен“, въпреки че Work Center показваше DigitalOcean Read като работещ. Backup заявката нямаше собствен фокусиран път, а `DigitalOceanError` губеше безопасния си код в chat отговора.

## Проверки

- целеви тестове: 35/35;
- пълен пакет: 451/451 успешни, 0 неуспешни, 0 пропуснати;
- full dependency audit: 0 уязвимости;
- production dependency audit: 0 уязвимости;
- Prettier и `git diff --check`: успешни.

## Граници

Само GET заявки. Не се създава restore/fork, не се променят памет, бази, DigitalOcean настройки, secrets или production данни.