### PR TITLE
Protect AI CORE and workspace production smoke

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -66,7 +66,7 @@ jobs:
           echo "Production did not stably deploy commit ${EXPECTED_COMMIT} within the verification window." >&2
           exit 1
 
-      - name: Check public site
+      - name: Check AI CORE public shell
         shell: bash
         run: |
           set -euo pipefail
@@ -74,7 +74,9 @@ jobs:
             --retry 3 --retry-delay 10 --retry-all-errors \
             --max-time 30 \
             https://synchron.foundation/)"
-          grep -qi "Synchron" <<< "${page}"
+          grep -q '<title>AI CORE' <<< "${page}"
+          grep -q 'href="/ai-core-mark.png"' <<< "${page}"
+          grep -q 'src="/work-mode.js?' <<< "${page}"
 
       - name: Check application health
         shell: bash
@@ -260,6 +262,30 @@ jobs:
               }
             });
           '
+
+      - name: Check workspace authentication boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          response_file="$(mktemp)"
+          trap 'rm -f "${response_file}"' EXIT
+          status_code="$(curl --silent --show-error \
+            --retry 3 --retry-delay 10 --retry-all-errors \
+            --max-time 30 \
+            --output "${response_file}" \
+            --write-out '%{http_code}' \
+            https://synchron.foundation/api/workspaces)"
+
+          if [ "${status_code}" != "401" ]; then
+            echo "Workspace API returned ${status_code}; expected the unauthenticated boundary." >&2
+            exit 1
+          fi
+
+          node -e '
+            const fs = require("node:fs");
+            const response = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            if (response.code !== "AUTH_REQUIRED") process.exit(1);
+          ' "${response_file}"
 
       - name: Publish production verification status
         if: always()

--- a/tests/productionSmokeWorkflow.test.js
+++ b/tests/productionSmokeWorkflow.test.js
@@ -17,10 +17,16 @@ test("production smoke publishes a readable commit status without a custom secre
   assert.match(workflow, /consecutive_matches=\$\(\(consecutive_matches \+ 1\)\)/u);
   assert.match(workflow, /deployment-check=\$\{GITHUB_RUN_ID\}-\$\{attempt\}/u);
   assert.match(workflow, /Cache-Control: no-cache/u);
+  assert.match(workflow, /Check AI CORE public shell/u);
+  assert.match(workflow, /<title>AI CORE/u);
+  assert.match(workflow, /ai-core-mark\.png/u);
   assert.match(workflow, /Check MCP tool catalog and OAuth challenge/u);
   assert.match(workflow, /get_github_copilot_task_status/u);
   assert.match(workflow, /names\.length === expected\.length/u);
   assert.match(workflow, /mcp\/www_authenticate/u);
   assert.match(workflow, /synchron:read/u);
+  assert.match(workflow, /Check workspace authentication boundary/u);
+  assert.match(workflow, /\/api\/workspaces/u);
+  assert.match(workflow, /AUTH_REQUIRED/u);
   assert.doesNotMatch(workflow, /secrets\./u);
 });


### PR DESCRIPTION
## Какво се променя

- production smoke проверява точния публичен бранд **AI CORE**;
- проверява, че `ai-core-mark.png` и Work режимът присъстват в живата страница;
- проверява, че `/api/workspaces` отказва неоторизиран достъп с `401` и `AUTH_REQUIRED`;
- добавя regression assertions за тези production граници.

## Защо

Новите постоянни работни области и международното име вече са публикувани, но досегашният smoke проверяваше само общ текст `Synchron`. Тази промяна затваря пропуска без потребителски вход, записи или лични данни.

## Проверки

- чисто `npm ci`: успешно
- `npm test`: 467 passed, 0 failed
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities
- live read-only проверки: AI CORE shell, лого, Work script и workspace auth boundary