### PR TITLE
Add clear profile actions menu

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -45,6 +45,9 @@ const elements = {
   removeAttachmentBtn: document.getElementById("removeAttachmentBtn"),
   newChatBtn: document.getElementById("newChatBtn"),
   toggleStatusBtn: document.getElementById("toggleStatusBtn"),
+  profileActions: document.getElementById("profileActions"),
+  profileStatusBtn: document.getElementById("profileStatusBtn"),
+  sidebarLogoutBtn: document.getElementById("sidebarLogoutBtn"),
   closeContextBtn: document.getElementById("closeContextBtn"),
   statusPanel: document.getElementById("statusPanel"),
   agentStatusDot: document.getElementById("agentStatusDot"),
@@ -267,7 +270,9 @@ async function startApplication(user) {
     }
   });
   elements.newChatBtn.addEventListener("click", startNewChat);
-  elements.toggleStatusBtn.addEventListener("click", openStatus);
+  elements.toggleStatusBtn.addEventListener("click", toggleProfileActions);
+  elements.profileStatusBtn.addEventListener("click", openStatus);
+  elements.sidebarLogoutBtn.addEventListener("click", handleLogout);
   elements.closeContextBtn.addEventListener("click", closeStatus);
   elements.chatMessages.addEventListener("click", handleMessageAction);
   elements.conversationList.addEventListener("click", handleConversationClick);
@@ -448,6 +453,18 @@ function closeSidebar() {
   elements.sidebar.classList.remove("mobile-visible");
   elements.sidebarBackdrop.hidden = true;
   elements.mobileMenuBtn.setAttribute("aria-expanded", "false");
+  closeProfileActions();
+}
+
+function toggleProfileActions() {
+  const shouldOpen = elements.profileActions.hidden;
+  elements.profileActions.hidden = !shouldOpen;
+  elements.toggleStatusBtn.setAttribute("aria-expanded", String(shouldOpen));
+}
+
+function closeProfileActions() {
+  elements.profileActions.hidden = true;
+  elements.toggleStatusBtn.setAttribute("aria-expanded", "false");
 }
 
 function openImagePicker() {

--- a/public/auth.css
+++ b/public/auth.css
@@ -195,6 +195,46 @@
   font-weight: 800;
 }
 
+.profile-actions {
+  padding: 6px;
+  display: grid;
+  gap: 4px;
+  border: 1px solid rgba(18, 32, 29, 0.1);
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 10px 28px rgba(18, 32, 29, 0.1);
+}
+
+.profile-actions[hidden] {
+  display: none;
+}
+
+.profile-actions button {
+  min-height: 46px;
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-radius: 10px;
+  font: inherit;
+  font-weight: 800;
+}
+
+.profile-actions button:hover,
+.profile-actions button:focus-visible {
+  background: #edf4f1;
+  outline: none;
+}
+
+.profile-actions .profile-action-logout {
+  color: #9f2f1c;
+}
+
+.profile-actions .profile-action-logout:hover,
+.profile-actions .profile-action-logout:focus-visible {
+  background: #fff4f0;
+}
+
 @media (max-width: 520px) {
   .auth-card {
     padding: 24px 20px;

--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="/modules.css?v=20260726-modules" />
     <link rel="stylesheet" href="/accessibility.css?v=20260728-font-stepper" />
     <link rel="stylesheet" href="/task-journal.css?v=20260728-task-journal" />
-    <link rel="stylesheet" href="/auth.css?v=20260730-test-users-v1" />
+    <link rel="stylesheet" href="/auth.css?v=20260801-profile-actions" />
     <link rel="stylesheet" href="/work-mode.css?v=20260801-workspace-v2" />
     <link rel="stylesheet" href="/assets/20260730-v2/synchron-vision.css" />
     <link
@@ -138,6 +138,8 @@
           id="toggleStatusBtn"
           class="profile-button profile-button-visible"
           type="button"
+          aria-expanded="false"
+          aria-controls="profileActions"
         >
           <span class="profile-avatar" id="profileAvatar">Р</span>
           <span
@@ -146,6 +148,20 @@
           >
           <i class="fa-solid fa-ellipsis"></i>
         </button>
+        <div id="profileActions" class="profile-actions" hidden>
+          <button id="profileStatusBtn" type="button">
+            <i class="fa-solid fa-sliders"></i>
+            <span>Състояние и настройки</span>
+          </button>
+          <button
+            id="sidebarLogoutBtn"
+            class="profile-action-logout"
+            type="button"
+          >
+            <i class="fa-solid fa-arrow-right-from-bracket"></i>
+            <span>Излез от профила</span>
+          </button>
+        </div>
         <button id="newChatBtn" class="new-chat" type="button">
           <i class="fa-regular fa-pen-to-square"></i>
           <span>Нов разговор</span>
@@ -446,7 +462,7 @@
 
     <script src="/markdown-renderer.js?v=20260728-xss"></script>
     <script src="/work-mode.js?v=20260801-workspace-v2"></script>
-    <script src="/assets/20260730-opensearch-status-v1/app.js"></script>
+    <script src="/assets/20260801-profile-actions/app.js"></script>
     <script src="/accessibility.js?v=20260728-font-stepper"></script>
     <script src="/assets/20260730-connections-v1/work-center.js"></script>
     <script src="/task-journal.js?v=20260728-task-journal"></script>

--- a/tests/authUi.test.js
+++ b/tests/authUi.test.js
@@ -37,6 +37,24 @@ test("hides owner tools for tester profiles and exposes logout", () => {
   assert.match(app, /\/api\/auth\/logout/u);
 });
 
+test("the profile ellipsis opens clear status and logout actions", () => {
+  assert.match(
+    html,
+    /id="toggleStatusBtn"[\s\S]*aria-controls="profileActions"/u,
+  );
+  assert.match(html, /id="profileStatusBtn"[\s\S]*Състояние и настройки/u);
+  assert.match(html, /id="sidebarLogoutBtn"[\s\S]*Излез от профила/u);
+  assert.match(
+    app,
+    /toggleStatusBtn\.addEventListener\("click", toggleProfileActions\)/u,
+  );
+  assert.match(
+    app,
+    /sidebarLogoutBtn\.addEventListener\("click", handleLogout\)/u,
+  );
+  assert.match(css, /\.profile-actions\[hidden\]/u);
+});
+
 test("shows the authenticated profile before the long navigation list", () => {
   const profilePosition = html.indexOf('id="toggleStatusBtn"');
   const navigationPosition = html.indexOf('class="sidebar-nav"');

--- a/tests/dataControlsUi.test.js
+++ b/tests/dataControlsUi.test.js
@@ -49,5 +49,5 @@ test("application exposes working memory and permission controls", async () => {
     /Кодовият мост е запазен, но е изключен в текущия режим без Copilot/u,
   );
   assert.doesNotMatch(script, /fetch\(["']\/opensearch-status["']/u);
-  assert.match(html, /\/assets\/20260730-opensearch-status-v1\/app\.js/u);
+  assert.match(html, /\/assets\/20260801-profile-actions\/app\.js/u);
 });

--- a/tests/versionedAssetRoutes.test.js
+++ b/tests/versionedAssetRoutes.test.js
@@ -17,7 +17,7 @@ test("versioned application assets referenced by HTML are served", async () => {
     ),
   ].map((match) => match[1]);
   assert.deepEqual(assetUrls, [
-    "/assets/20260730-opensearch-status-v1/app.js",
+    "/assets/20260801-profile-actions/app.js",
     "/assets/20260730-connections-v1/work-center.js",
   ]);
 

--- a/tests/workModeUi.test.js
+++ b/tests/workModeUi.test.js
@@ -18,7 +18,7 @@ test("Chat and Work are available with projects, agents, and pet state", async (
   assert.match(html, /\/work-mode\.js\?v=/u);
   assert.ok(
     html.indexOf("/work-mode.js") <
-      html.indexOf("/assets/20260730-opensearch-status-v1/app.js"),
+      html.indexOf("/assets/20260801-profile-actions/app.js"),
   );
   assert.doesNotMatch(
     html.match(/<button[^>]+id="workModeBtn"[^>]*>/u)?.[0] || "",


### PR DESCRIPTION
## Какво се променя

- трите точки до профила отварят истинско меню;
- „Състояние и настройки“ запазва досегашния системен панел;
- „Излез от профила“ вече е достъпно веднага, без дълго превъртане;
- добавени са regression проверки и нова версия на клиентския asset.

## Причина

При реалния мобилен тест изходът от профила се оказа скрит в дъното на дълъг панел. Това затруднява смяната към изолиран тестов профил.

## Проверки

- `npm test`: 468 passed, 0 failed
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities
- `git diff --check`: успешно