### PR TITLE
Preserve Work mode projects and agents

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/accessibility.css?v=20260728-font-stepper" />
     <link rel="stylesheet" href="/task-journal.css?v=20260728-task-journal" />
     <link rel="stylesheet" href="/auth.css?v=20260801-profile-actions" />
-    <link rel="stylesheet" href="/work-mode.css?v=20260801-workspace-v2" />
+    <link rel="stylesheet" href="/work-mode.css?v=20260801-workspace-save-v3" />
     <link rel="stylesheet" href="/assets/20260730-v2/synchron-vision.css" />
     <link
       rel="stylesheet"
@@ -461,7 +461,7 @@
     </main>
 
     <script src="/markdown-renderer.js?v=20260728-xss"></script>
-    <script src="/work-mode.js?v=20260801-workspace-v2"></script>
+    <script src="/work-mode.js?v=20260801-workspace-save-v3"></script>
     <script src="/assets/20260801-profile-actions/app.js"></script>
     <script src="/accessibility.js?v=20260728-font-stepper"></script>
     <script src="/assets/20260730-connections-v1/work-center.js"></script>

--- a/public/work-mode.css
+++ b/public/work-mode.css
@@ -143,6 +143,22 @@ body[data-interaction-mode="chat"] .work-pet {
   line-height: 1.45;
 }
 
+.work-save-notice,
+.work-save-error {
+  margin: 0 0 14px;
+  padding: 12px 14px;
+  border-radius: 13px;
+  color: #166534;
+  background: #dcfce7;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.work-save-error {
+  color: #991b1b;
+  background: #fee2e2;
+}
+
 .work-storage-note {
   color: #7c4a03;
   background: #fff4d7;

--- a/public/work-mode.js
+++ b/public/work-mode.js
@@ -19,6 +19,9 @@
   let remoteReady = false;
   let saveTimer = null;
   let syncStatus = "local";
+  let localRevision = 0;
+  let storageAvailable = true;
+  let managerNotice = "";
 
   const elements = {
     chatInput: document.getElementById("chatInput"),
@@ -161,13 +164,41 @@
     }
   }
 
+  function pendingStorageKey() {
+    return `${storageKey}:pending`;
+  }
+
+  function hasPendingRemoteSave() {
+    try {
+      return localStorage.getItem(pendingStorageKey()) === "1";
+    } catch {
+      storageAvailable = false;
+      return false;
+    }
+  }
+
+  function clearPendingRemoteSave() {
+    try {
+      localStorage.removeItem(pendingStorageKey());
+    } catch {
+      storageAvailable = false;
+    }
+  }
+
   function saveState({ remote = true } = {}) {
     try {
       localStorage.setItem(storageKey, JSON.stringify(workState));
+      if (remote) {
+        localStorage.setItem(pendingStorageKey(), "1");
+        localRevision += 1;
+      }
     } catch {
-      // The UI remains usable even when private browsing blocks storage.
+      storageAvailable = false;
+      syncStatus = "error";
+      return false;
     }
     if (remote && remoteReady) queueRemoteSave();
+    return true;
   }
 
   function queueRemoteSave() {
@@ -186,6 +217,7 @@
 
   async function persistRemoteState() {
     const snapshot = normalizeState(workState);
+    const revision = localRevision;
     try {
       const payload = await readJson(
         await fetch(WORKSPACE_ENDPOINT, {
@@ -194,27 +226,38 @@
           body: JSON.stringify({ state: snapshot }),
         }),
       );
-      workState = normalizeState(payload.state);
-      syncStatus = "synced";
-      saveState({ remote: false });
+      if (revision === localRevision) {
+        workState = normalizeState(payload.state);
+        syncStatus = "synced";
+        clearPendingRemoteSave();
+        saveState({ remote: false });
+      } else {
+        queueRemoteSave();
+      }
     } catch {
       syncStatus = "local";
     }
   }
 
   async function syncRemoteState() {
+    const revision = localRevision;
+    const hadPendingSave = hasPendingRemoteSave();
     try {
       const payload = await readJson(
         await fetch(WORKSPACE_ENDPOINT, { cache: "no-store" }),
       );
-      if (payload.persisted) {
-        workState = normalizeState(payload.state);
-        saveState({ remote: false });
-      }
       remoteReady = true;
-      syncStatus = payload.persisted ? "synced" : "saving";
+      if (hadPendingSave || revision !== localRevision) {
+        syncStatus = "saving";
+        await persistRemoteState();
+      } else if (payload.persisted) {
+        workState = normalizeState(payload.state);
+        if (saveState({ remote: false })) syncStatus = "synced";
+      } else {
+        syncStatus = "saving";
+        await persistRemoteState();
+      }
       renderMode();
-      if (!payload.persisted) await persistRemoteState();
     } catch {
       remoteReady = true;
       syncStatus = "local";
@@ -461,6 +504,7 @@
     const objective = document.createElement("textarea");
     objective.id = "newWorkProjectObjective";
     objective.maxLength = 600;
+    objective.required = true;
     form.appendChild(objective);
     const submit = document.createElement("button");
     submit.type = "submit";
@@ -476,9 +520,20 @@
         updatedAt: new Date().toISOString(),
       };
       if (!project.name) return;
+      const previousActiveProjectId = workState.activeProjectId;
       workState.projects.unshift(project);
       workState.activeProjectId = project.id;
-      saveState();
+      if (!saveState()) {
+        workState.projects = workState.projects.filter(
+          (item) => item.id !== project.id,
+        );
+        workState.activeProjectId = previousActiveProjectId;
+        managerNotice =
+          "Проектът не е запазен. Провери дали браузърът позволява съхранение на данни и опитай отново.";
+        openManager();
+        return;
+      }
+      managerNotice = `Проектът „${project.name}“ е създаден и избран.`;
       renderMode();
       openManager();
     });
@@ -509,6 +564,7 @@
     const purpose = document.createElement("textarea");
     purpose.id = "newWorkAgentPurpose";
     purpose.maxLength = 400;
+    purpose.required = true;
     form.appendChild(purpose);
     const submit = document.createElement("button");
     submit.type = "submit";
@@ -523,9 +579,20 @@
         purpose: cleanText(purpose.value, 400),
       };
       if (!agent.name) return;
+      const previousActiveAgentId = workState.activeAgentId;
       workState.agents.unshift(agent);
       workState.activeAgentId = agent.id;
-      saveState();
+      if (!saveState()) {
+        workState.agents = workState.agents.filter(
+          (item) => item.id !== agent.id,
+        );
+        workState.activeAgentId = previousActiveAgentId;
+        managerNotice =
+          "Агентът не е запазен. Провери дали браузърът позволява съхранение на данни и опитай отново.";
+        openManager();
+        return;
+      }
+      managerNotice = `Агентът „${agent.name}“ е създаден и избран.`;
       renderMode();
       openManager();
     });
@@ -553,11 +620,21 @@
     addText(
       elements.drawerBody,
       "p",
-      syncStatus === "synced"
-        ? "Проектите, агентите и задачите са запазени в защитения ти профил."
-        : "Работиш в резервен режим на този браузър. Промените ще се синхронизират при възстановяване на връзката.",
+      !storageAvailable || syncStatus === "error"
+        ? "Браузърът блокира запазването. Данните не са изчистени нарочно — разреши съхранението и опитай отново."
+        : syncStatus === "synced"
+          ? "Проектите, агентите и задачите са запазени в защитения ти профил."
+          : "Работиш в резервен режим на този браузър. Промените ще се синхронизират при възстановяване на връзката.",
       "work-storage-note",
     );
+    if (managerNotice) {
+      addText(
+        elements.drawerBody,
+        "p",
+        managerNotice,
+        syncStatus === "error" ? "work-save-error" : "work-save-notice",
+      );
+    }
 
     const projects = section(elements.drawerBody, "Проекти");
     renderProjectChoices(projects);

--- a/tests/workModeUi.test.js
+++ b/tests/workModeUi.test.js
@@ -3,6 +3,30 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { JSDOM } from "jsdom";
 
+function createWorkModeDom(script, fetchImpl) {
+  const dom = new JSDOM(
+    `<!doctype html><body>
+      <input id="chatInput">
+      <button id="chatModeBtn"></button>
+      <button id="workModeToolbarBtn"></button>
+      <button id="workModeBtn"></button>
+      <button id="workContextBtn"><strong id="workProjectLabel"></strong><small id="workAgentLabel"></small><span id="workPet"></span></button>
+      <aside id="dataDrawer" hidden><h2 id="dataDrawerTitle"></h2><div id="dataDrawerBody"></div></aside>
+      <div id="drawerBackdrop" hidden></div>
+      <nav id="sidebar"></nav><div id="sidebarBackdrop" hidden></div>
+      <nav class="mobile-command-bar"><button data-command="chat"></button><button data-command="work"></button></nav>
+    </body>`,
+    { runScripts: "dangerously", url: "https://synchron.foundation/" },
+  );
+  if (fetchImpl) dom.window.fetch = fetchImpl;
+  dom.window.eval(script);
+  return dom;
+}
+
+function nextTurn() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 test("Chat and Work are available with projects, agents, and pet state", async () => {
   const [html, css, workMode, app] = await Promise.all([
     readFile(new URL("../public/index.html", import.meta.url), "utf8"),
@@ -110,4 +134,150 @@ test("work mode runs in the browser and creates an isolated project payload", as
     "needs-input",
   );
   dom.window.close();
+});
+
+test("a late workspace read cannot erase a project created during startup", async () => {
+  const script = await readFile(
+    new URL("../public/work-mode.js", import.meta.url),
+    "utf8",
+  );
+  let resolveWorkspaceRead;
+  const workspaceRead = new Promise((resolve) => {
+    resolveWorkspaceRead = resolve;
+  });
+  const savedStates = [];
+  const dom = createWorkModeDom(script, (url, options = {}) => {
+    if (options.method === "PUT") {
+      const state = JSON.parse(options.body).state;
+      savedStates.push(state);
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ state }),
+      });
+    }
+    return workspaceRead;
+  });
+
+  dom.window.SynchronWorkMode.init({ id: "race-tester", role: "tester" });
+  dom.window.document.getElementById("workModeToolbarBtn").click();
+  dom.window.SynchronWorkMode.openManager();
+  const projectForm = dom.window.document.querySelectorAll("form")[0];
+  projectForm.querySelector("input").value = "Неподлежащо на загуба";
+  projectForm.querySelector("textarea").value = "Запази локалната промяна";
+  projectForm.dispatchEvent(
+    new dom.window.Event("submit", { bubbles: true, cancelable: true }),
+  );
+
+  resolveWorkspaceRead({
+    ok: true,
+    json: async () => ({
+      persisted: true,
+      state: {
+        mode: "chat",
+        projects: [{ id: "old", name: "Стар сървърен проект" }],
+        agents: [{ id: "old-agent", name: "Стар агент" }],
+      },
+    }),
+  });
+  await nextTurn();
+  await nextTurn();
+
+  assert.equal(
+    dom.window.SynchronWorkMode.getRequestPayload().workContext.project.name,
+    "Неподлежащо на загуба",
+  );
+  assert.ok(
+    savedStates.some((state) =>
+      state.projects.some(
+        (project) => project.name === "Неподлежащо на загуба",
+      ),
+    ),
+  );
+  assert.match(
+    dom.window.document.getElementById("dataDrawerBody").textContent,
+    /Проектът „Неподлежащо на загуба“ е създаден и избран/u,
+  );
+  dom.window.close();
+});
+
+test("a pending local project survives reload and replaces stale remote state", async () => {
+  const script = await readFile(
+    new URL("../public/work-mode.js", import.meta.url),
+    "utf8",
+  );
+  const oldRemoteState = {
+    mode: "work",
+    activeProjectId: "old",
+    activeAgentId: "old-agent",
+    projects: [{ id: "old", name: "Стар сървърен проект" }],
+    agents: [{ id: "old-agent", name: "Стар агент" }],
+  };
+  const firstDom = createWorkModeDom(script, (url, options = {}) => {
+    if (options.method === "PUT") {
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({ error: "Временно недостъпно" }),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ persisted: true, state: oldRemoteState }),
+    });
+  });
+  firstDom.window.SynchronWorkMode.init({ id: "reload-tester" });
+  await nextTurn();
+  firstDom.window.document.getElementById("workModeToolbarBtn").click();
+  firstDom.window.SynchronWorkMode.openManager();
+  const projectForm = firstDom.window.document.querySelectorAll("form")[0];
+  projectForm.querySelector("input").value = "Локален проект";
+  projectForm.querySelector("textarea").value = "Чака синхронизация";
+  projectForm.dispatchEvent(
+    new firstDom.window.Event("submit", { bubbles: true, cancelable: true }),
+  );
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  const localState = firstDom.window.localStorage.getItem(
+    "synchronWorkMode:reload-tester",
+  );
+  const pending = firstDom.window.localStorage.getItem(
+    "synchronWorkMode:reload-tester:pending",
+  );
+  assert.equal(pending, "1");
+  firstDom.window.close();
+
+  const savedStates = [];
+  const secondDom = createWorkModeDom(script, (url, options = {}) => {
+    if (options.method === "PUT") {
+      const state = JSON.parse(options.body).state;
+      savedStates.push(state);
+      return Promise.resolve({ ok: true, json: async () => ({ state }) });
+    }
+    return Promise.resolve({
+      ok: true,
+      json: async () => ({ persisted: true, state: oldRemoteState }),
+    });
+  });
+  secondDom.window.localStorage.setItem(
+    "synchronWorkMode:reload-tester",
+    localState,
+  );
+  secondDom.window.localStorage.setItem(
+    "synchronWorkMode:reload-tester:pending",
+    pending,
+  );
+  secondDom.window.SynchronWorkMode.init({ id: "reload-tester" });
+  await nextTurn();
+  await nextTurn();
+
+  assert.ok(
+    savedStates.some((state) =>
+      state.projects.some((project) => project.name === "Локален проект"),
+    ),
+  );
+  assert.equal(
+    secondDom.window.localStorage.getItem(
+      "synchronWorkMode:reload-tester:pending",
+    ),
+    null,
+  );
+  secondDom.window.close();
 });


### PR DESCRIPTION
## Какво се променя

- пази локалните промени като чакащи, докато сървърната синхронизация успее;
- не позволява на закъснял стар сървърен отговор да изтрие току-що създаден проект или агент;
- не презаписва по-нова локална промяна при успоредно запазване;
- показва ясно потвърждение след създаване и видима грешка при блокирано браузърно хранилище;
- прави целта на проекта и фокуса на агента задължителни;
- обновява версията на браузърните assets, за да не остане стар кеш.

## Причина

Формулярът се прерисуваше след изпращане, но асинхронна синхронизация можеше да върне по-старото състояние и да премахне новите записи. При неуспешен PUT нямаше устойчив маркер, че локалното копие още чака синхронизация.

## Проверки

- `npm test` — 470 теста успешни;
- добавени регресионни тестове за късен GET и възстановяване след неуспешен PUT + reload;
- `npm audit --omit=dev` — 0 уязвимости;
- `git diff --check` — успешно.