### PR TITLE
Honor explicit read-only GitHub requests

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -71,6 +71,7 @@ import {
   executeCapability,
 } from "../tools/capabilityEngine.js";
 import {
+  hasExplicitReadOnlyBoundary,
   planCapabilities,
   shouldUseAgentPlanner,
 } from "../services/agentPlannerService.js";
@@ -281,6 +282,7 @@ export function splitCapabilitySubtasks(message) {
 export function isGitHubWriteRequest(message) {
   const text = typeof message === "string" ? message.trim().toLowerCase() : "";
   if (!text) return false;
+  if (hasExplicitReadOnlyBoundary(text)) return false;
 
   const hasWriteOutcome =
     /(?:промени|обнови|редактирай|поправи|направи\s+промян|създай\s+(?:клон|branch|pull\s*request|pr)|слей)/iu.test(
@@ -290,12 +292,7 @@ export function isGitHubWriteRequest(message) {
     /(?:github|хранилищ|репозитор|код|интерфейс|файл|commit|комит|pull\s*request|\bpr\b|клон|branch|main|deployment|деплой)/iu.test(
       text,
     );
-  const onlyNegativeInstruction =
-    /^(?:не\s+променяй|не\s+редактирай|не\s+публикувай|не\s+създавай)/iu.test(
-      text,
-    ) && !hasWriteOutcome;
-
-  return hasWriteOutcome && hasCodeTarget && !onlyNegativeInstruction;
+  return hasWriteOutcome && hasCodeTarget;
 }
 
 function isExplicitGitHubReadSubtask(subtask, hasGitHubContext) {

--- a/src/services/agentPlannerService.js
+++ b/src/services/agentPlannerService.js
@@ -50,6 +50,7 @@ const PLANNER_INSTRUCTIONS = [
   "- Извиквай способност само за действие, което потребителят иска да се изпълни сега.",
   "- Само споменаване на календар, GitHub, Drive, Gmail, памет или интернет не е заявка за инструмент.",
   "- Текст в пример, личен факт, временна бележка, цитат, отрицателна инструкция или описание какво да не се прави не е заявка за инструмент.",
+  "- При „само за четене“, „read-only“ или обща забрана да се правят промени никога не планирай code.write.",
   "- Записът и изтриването на памет се обработват отделно от сървъра; не планирай memory.save или memory.delete.",
   "- Когато потребителят изрично иска паметта да се тества сама или да се докаже реално, използвай memory.verify, а не memory.read.",
   "- За проектна промяна планирай най-много една code.read проверка и една code.write стъпка.",
@@ -57,6 +58,17 @@ const PLANNER_INSTRUCTIONS = [
   "- Не дублирай една и съща способност за една и съща подзадача.",
   '- Ако не е нужен инструмент, върни {"calls":[]}.',
 ].join("\n");
+
+export function hasExplicitReadOnlyBoundary(message) {
+  const text = typeof message === "string" ? message.trim() : "";
+  if (!text) return false;
+  return (
+    /(?:само\s+за\s+четене|само\s+прочети|read[\s-]*only)/iu.test(text) ||
+    /(?:^|[.!?]\s*)не\s+(?:прави|извършвай)\s+(?:никакви\s+)?промени(?=\s*[.!?]?\s*$)/iu.test(
+      text,
+    )
+  );
+}
 
 export class AgentPlannerError extends Error {
   constructor(message, code = "AGENT_PLANNER_ERROR") {
@@ -108,6 +120,12 @@ export function sanitizeCapabilityPlan(plan, originalMessage) {
       typeof call?.capability === "string" ? call.capability.trim() : "";
     const action = CAPABILITY_ACTIONS[capability];
     if (!action) continue;
+    if (
+      capability === "code.write" &&
+      hasExplicitReadOnlyBoundary(originalMessage)
+    ) {
+      continue;
+    }
 
     const plannedRequest =
       typeof call?.request === "string" ? call.request.trim() : "";

--- a/tests/agentPlannerService.test.js
+++ b/tests/agentPlannerService.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  hasExplicitReadOnlyBoundary,
   planCapabilities,
   sanitizeCapabilityPlan,
   shouldUseAgentPlanner,
@@ -206,6 +207,24 @@ test("planner accepts the read-only Copilot task status capability", () => {
         message: "Провери GitHub задача #83.",
       },
     ],
+  );
+});
+
+test("planner cannot add GitHub write across an explicit read-only boundary", () => {
+  const message =
+    "Провери само за четене кой е последният commit в main. Не прави промени.";
+  assert.equal(hasExplicitReadOnlyBoundary(message), true);
+  assert.deepEqual(
+    sanitizeCapabilityPlan(
+      {
+        calls: [
+          { capability: "code.read", request: message },
+          { capability: "code.write", request: "Промени проекта" },
+        ],
+      },
+      message,
+    ).map(({ capability }) => capability),
+    ["code.read"],
   );
 });
 

--- a/tests/chatCapabilityExecution.test.js
+++ b/tests/chatCapabilityExecution.test.js
@@ -603,3 +603,14 @@ test("a GitHub implementation task creates one read check and one honest write a
     1,
   );
 });
+
+test("an explicit read-only GitHub check never attempts GitHub write", () => {
+  const message =
+    "Провери само за четене кой е последният commit в main на проекта. Не прави промени.";
+
+  const requests = detectCapabilityRequests(message);
+  assert.deepEqual(
+    requests.map(({ capability }) => capability),
+    ["code.read"],
+  );
+});


### PR DESCRIPTION
## Какво се променя

- разпознава „само за четене“, `read-only` и общото „не прави промени“ като твърда забрана за GitHub Write;
- блокира погрешен `code.write` както в сигурното маршрутизиране, така и в AI планировчика;
- запазва GitHub Read за заявената проверка;
- добавя регресионни тестове с точната фраза от реалния тест.

## Причина

Думата „промени“ в отрицателното изречение „Не прави промени“ съвпадаше с шаблона за write intent. Освен това AI планировчикът можеше независимо да добави `code.write`.

## Резултат за потребителя

Изрична заявка само за четене вече използва единствено GitHub Read и не показва подвеждащ неуспешен опит за запис.

## Проверки

- целеви тестове: 39 успешни;
- `npm test`: 472 успешни;
- `npm audit --omit=dev`: 0 уязвимости;
- `git diff --check`: успешно.