### PR TITLE
Report protected fallbacks and verified production status

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -787,6 +787,7 @@ function configurationStatus(item) {
   const labels = {
     configured: ["Настроена", "allow"],
     defaulted: ["По подразбиране", "allow"],
+    "protected-fallback": ["Защитен заместител", "allow"],
     "missing-required": ["Липсва", "deny"],
     "optional-missing": ["Незадължителна", "confirm"],
     compatibility: ["Стар резервен път", "confirm"],
@@ -854,8 +855,9 @@ async function openSystemConfigurationDrawer() {
       <div class="permission-default system-summary">
         <strong>${readiness?.status === "ready" ? "Ядрото е готово" : "Ядрото изисква внимание"}</strong>
         <p>${workingTools} от ${tools.length} инструмента са конфигурирани и изпълними.</p>
-        <p>${configuration.summary.configured} настройки са налични; ${configuration.summary.missingRequired} задължителни липсват.</p>
-        <p>DigitalOcean самопроверка: ${configuration.digitalOcean.connected ? "работи" : "не е достъпна"}.</p>
+        <p>${configuration.summary.configured} настройки са налични; ${configuration.summary.protectedFallback || 0} използват защитен заместител; ${configuration.summary.missingRequired} задължителни липсват.</p>
+        <p>Production: ${configuration.production?.status === "ready" ? `готово · commit ${escapeHtml(configuration.production.commit)}` : "не е потвърдено"}.</p>
+        <p>DigitalOcean самопроверка (API): ${configuration.digitalOcean.connected ? "работи" : "не е достъпна"}.</p>
         <small>Тук няма стойности на ключове, пароли или token-и.</small>
       </div>
       <section class="drawer-section">

--- a/src/config/environmentCatalog.js
+++ b/src/config/environmentCatalog.js
@@ -92,7 +92,7 @@ export const ENVIRONMENT_CATALOG = Object.freeze(
       "MEMORY_OWNER_ID",
       "Памет",
       "Стабилен собственик на основната лична памет.",
-      { requiredNow: true },
+      { hasDefault: true },
     ),
     general(
       "MEMORY_INDEX",
@@ -162,13 +162,13 @@ export const ENVIRONMENT_CATALOG = Object.freeze(
       "SUPABASE_SESSION_ENCRYPTION_KEY",
       "Тестови профили",
       "Криптира Supabase сесиите в браузъра.",
-      { requiredNow: true },
+      { requiredNow: true, hasProtectedFallback: true },
     ),
     secret(
       "SYNCHRON_TEST_INVITE_CODE",
       "Тестови профили",
       "Частен код за разрешена регистрация.",
-      { requiredNow: true },
+      { requiredNow: true, hasProtectedFallback: true },
     ),
     general(
       "SYNCHRON_PRIMARY_SUPABASE_USER_ID",

--- a/src/services/systemConfigurationService.js
+++ b/src/services/systemConfigurationService.js
@@ -1,11 +1,22 @@
 import { getEnvironmentCatalog } from "../config/environmentCatalog.js";
 import { getDigitalOceanAppStatus } from "./digitalOceanService.js";
+import {
+  getUserAuthConfigurationStatus,
+  isTesterRegistrationEnabled,
+} from "./userAuthService.js";
+
+const DEFAULT_PRODUCTION_URL = "https://synchron.foundation/health/ready";
 
 function isConfigured(env, key) {
   return typeof env[key] === "string" && env[key].trim().length > 0;
 }
 
-function statusFor(item, runtimeConfigured, digitalOceanDeclared) {
+function statusFor(
+  item,
+  runtimeConfigured,
+  digitalOceanDeclared,
+  protectedFallback,
+) {
   if (item.state === "unused") return "unused";
   if (item.state === "compatibility") {
     return runtimeConfigured || digitalOceanDeclared
@@ -13,6 +24,7 @@ function statusFor(item, runtimeConfigured, digitalOceanDeclared) {
       : "not-needed";
   }
   if (runtimeConfigured) return "configured";
+  if (protectedFallback) return "protected-fallback";
   if (item.managed || item.hasDefault) return "defaulted";
   if (item.requiredNow) return "missing-required";
   return "optional-missing";
@@ -22,6 +34,13 @@ export function buildEnvironmentInventory({
   env = process.env,
   digitalOceanVariables = [],
 } = {}) {
+  const protectedFallbacks = new Set();
+  if (getUserAuthConfigurationStatus(env).sessionProtection) {
+    protectedFallbacks.add("SUPABASE_SESSION_ENCRYPTION_KEY");
+  }
+  if (isTesterRegistrationEnabled(env)) {
+    protectedFallbacks.add("SYNCHRON_TEST_INVITE_CODE");
+  }
   const declared = new Map(
     digitalOceanVariables.map((item) => [item.key, item]),
   );
@@ -29,6 +48,8 @@ export function buildEnvironmentInventory({
     const platform = declared.get(item.key);
     const runtimeConfigured = isConfigured(env, item.key);
     const digitalOceanDeclared = Boolean(platform);
+    const protectedFallback =
+      Boolean(item.hasProtectedFallback) && protectedFallbacks.has(item.key);
     return Object.freeze({
       key: item.key,
       area: item.area,
@@ -37,10 +58,16 @@ export function buildEnvironmentInventory({
       state: item.state,
       requiredNow: Boolean(item.requiredNow),
       runtimeConfigured,
+      protectedFallback,
       digitalOceanDeclared,
       digitalOceanType: platform?.type || null,
       digitalOceanScope: platform?.scope || null,
-      status: statusFor(item, runtimeConfigured, digitalOceanDeclared),
+      status: statusFor(
+        item,
+        runtimeConfigured,
+        digitalOceanDeclared,
+        protectedFallback,
+      ),
     });
   });
 }
@@ -52,6 +79,7 @@ function summarize(items) {
     total: items.length,
     configured: count("configured"),
     defaulted: count("defaulted"),
+    protectedFallback: count("protected-fallback"),
     missingRequired: count("missing-required"),
     optionalMissing: count("optional-missing"),
     compatibility: count("compatibility"),
@@ -59,9 +87,75 @@ function summarize(items) {
   };
 }
 
+function cleanCommit(value) {
+  const commit = typeof value === "string" ? value.trim() : "";
+  return /^[a-f0-9]{7,64}$/iu.test(commit) ? commit : null;
+}
+
+function emptyProductionStatus(errorCode = "PRODUCTION_READINESS_UNAVAILABLE") {
+  return {
+    connected: false,
+    status: "unavailable",
+    commit: null,
+    memoryAcceptance: null,
+    errorCode,
+  };
+}
+
+export async function getProductionReadinessStatus({
+  fetchImpl = globalThis.fetch,
+  url = DEFAULT_PRODUCTION_URL,
+  timeoutMs = 3_000,
+} = {}) {
+  if (typeof fetchImpl !== "function") {
+    return emptyProductionStatus("PRODUCTION_FETCH_UNAVAILABLE");
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      cache: "no-store",
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+    const body = await response.json();
+    const commit = cleanCommit(body?.commit);
+    if (!response.ok || body?.status !== "ready" || !commit) {
+      return emptyProductionStatus("PRODUCTION_NOT_READY");
+    }
+    const acceptance = body?.checks?.memoryAcceptance;
+    return {
+      connected: true,
+      status: "ready",
+      commit,
+      memoryAcceptance: acceptance
+        ? {
+            ready: acceptance.ready === true,
+            status:
+              typeof acceptance.status === "string"
+                ? acceptance.status
+                : "unknown",
+            isolated: acceptance.isolated === true,
+            realMemoryUnchanged: acceptance.realMemoryUnchanged === true,
+            cleanupCompleted: acceptance.cleanupCompleted === true,
+            passedSteps: Number.isInteger(acceptance.passedSteps)
+              ? acceptance.passedSteps
+              : 0,
+          }
+        : null,
+      errorCode: null,
+    };
+  } catch {
+    return emptyProductionStatus();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export async function getSystemConfigurationReport({
   env = process.env,
   getDigitalOceanStatus = getDigitalOceanAppStatus,
+  getProductionStatus = getProductionReadinessStatus,
 } = {}) {
   let digitalOcean = {
     connected: false,
@@ -87,6 +181,13 @@ export async function getSystemConfigurationReport({
     digitalOcean.errorCode = error?.code || "DIGITALOCEAN_UNAVAILABLE";
   }
 
+  let production = emptyProductionStatus();
+  try {
+    production = await getProductionStatus();
+  } catch {
+    production = emptyProductionStatus();
+  }
+
   const environment = buildEnvironmentInventory({
     env,
     digitalOceanVariables: digitalOcean.variables,
@@ -98,6 +199,7 @@ export async function getSystemConfigurationReport({
     summary: summarize(environment),
     environment,
     digitalOcean,
+    production,
   };
 }
 
@@ -109,18 +211,37 @@ export function formatSystemConfigurationReport(report) {
     (item) => item.status === "compatibility",
   );
   const unused = report.environment.filter((item) => item.status === "unused");
+  const protectedFallbacks = report.environment.filter(
+    (item) => item.status === "protected-fallback",
+  );
+  const productionReady = report.production?.status === "ready";
+  const memoryAcceptance = report.production?.memoryAcceptance;
   return [
     "Проверих системната конфигурация без да показвам стойности.",
     `• ${report.summary.configured} настройки са налични в runtime.`,
     `• ${report.summary.defaulted} използват безопасна стойност по подразбиране.`,
+    `• ${protectedFallbacks.length} използват работещ защитен заместител.`,
     `• ${missing.length} задължителни настройки липсват.`,
     `• DigitalOcean самопроверка: ${report.digitalOcean.connected ? "работи" : "не е достъпна"}.`,
+    productionReady
+      ? `• Production /health/ready: готово; commit ${report.production.commit}.`
+      : "• Production /health/ready: не е потвърдено.",
+    ...(memoryAcceptance?.ready
+      ? [
+          `• Постоянна памет: приемателният тест работи; ${memoryAcceptance.passedSteps} проверени стъпки; изолиран=${memoryAcceptance.isolated ? "да" : "не"}; реалната памет е непроменена=${memoryAcceptance.realMemoryUnchanged ? "да" : "не"}.`,
+        ]
+      : []),
     ...(missing.length
       ? [`Липсват: ${missing.map((item) => item.key).join(", ")}.`]
       : []),
     ...(compatibility.length
       ? [
           `Стари резервни настройки: ${compatibility.map((item) => item.key).join(", ")}.`,
+        ]
+      : []),
+    ...(protectedFallbacks.length
+      ? [
+          `Защитени заместители: ${protectedFallbacks.map((item) => item.key).join(", ")}. Те работят и не са блокер.`,
         ]
       : []),
     ...(unused.length

--- a/tests/systemConfigurationService.test.js
+++ b/tests/systemConfigurationService.test.js
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   buildEnvironmentInventory,
   formatSystemConfigurationReport,
+  getProductionReadinessStatus,
   getSystemConfigurationReport,
 } from "../src/services/systemConfigurationService.js";
 
@@ -24,11 +25,13 @@ test("environment inventory exposes metadata and never values", () => {
   });
   const openAi = inventory.find((item) => item.key === "OPENAI_API_KEY");
   const logicCore = inventory.find((item) => item.key === "LOGIC_CORE_URL");
+  const memoryOwner = inventory.find((item) => item.key === "MEMORY_OWNER_ID");
 
   assert.equal(openAi.runtimeConfigured, true);
   assert.equal(openAi.digitalOceanDeclared, true);
   assert.equal(openAi.status, "configured");
   assert.equal(logicCore.status, "unused");
+  assert.equal(memoryOwner.status, "defaulted");
   assert.equal(JSON.stringify(inventory).includes(secretValue), false);
 });
 
@@ -40,12 +43,31 @@ test("system report tolerates a missing DigitalOcean bridge", async () => {
         code: "DIGITALOCEAN_NOT_CONFIGURED",
       });
     },
+    getProductionStatus: async () => ({
+      connected: true,
+      status: "ready",
+      commit: "965765f947fb62742a5e5c05a69f22696328ac72",
+      memoryAcceptance: {
+        ready: true,
+        status: "works",
+        isolated: true,
+        realMemoryUnchanged: true,
+        cleanupCompleted: true,
+        passedSteps: 9,
+      },
+      errorCode: null,
+    }),
   });
 
   assert.equal(report.digitalOcean.connected, false);
   assert.equal(report.digitalOcean.errorCode, "DIGITALOCEAN_NOT_CONFIGURED");
   assert.equal(report.secretsExposed, false);
   assert.ok(report.summary.missingRequired > 0);
+  assert.match(
+    formatSystemConfigurationReport(report),
+    /Production \/health\/ready: готово/u,
+  );
+  assert.match(formatSystemConfigurationReport(report), /9 проверени стъпки/u);
   assert.match(formatSystemConfigurationReport(report), /не се връщат/u);
 });
 
@@ -69,6 +91,13 @@ test("system report merges the live DigitalOcean variable inventory", async () =
       activeDeployment: { id: "deployment-1", phase: "ACTIVE" },
       inProgressDeployment: null,
     }),
+    getProductionStatus: async () => ({
+      connected: false,
+      status: "unavailable",
+      commit: null,
+      memoryAcceptance: null,
+      errorCode: "PRODUCTION_READINESS_UNAVAILABLE",
+    }),
   });
 
   const openAi = report.environment.find(
@@ -77,4 +106,51 @@ test("system report merges the live DigitalOcean variable inventory", async () =
   assert.equal(report.digitalOcean.connected, true);
   assert.equal(openAi.digitalOceanDeclared, true);
   assert.equal(JSON.stringify(report).includes("configured-secret"), false);
+});
+
+test("derived tester secrets are reported as protected fallbacks, not missing", () => {
+  const inventory = buildEnvironmentInventory({
+    env: {
+      GITHUB_SESSION_ENCRYPTION_KEY:
+        "a-strong-owner-session-secret-that-never-leaves-runtime",
+    },
+  });
+  const session = inventory.find(
+    (item) => item.key === "SUPABASE_SESSION_ENCRYPTION_KEY",
+  );
+  const invite = inventory.find(
+    (item) => item.key === "SYNCHRON_TEST_INVITE_CODE",
+  );
+
+  assert.equal(session.status, "protected-fallback");
+  assert.equal(invite.status, "protected-fallback");
+});
+
+test("production readiness keeps only safe proof fields", async () => {
+  const report = await getProductionReadinessStatus({
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({
+        status: "ready",
+        commit: "965765f947fb62742a5e5c05a69f22696328ac72",
+        secret: "must-not-survive",
+        checks: {
+          memoryAcceptance: {
+            ready: true,
+            status: "works",
+            isolated: true,
+            realMemoryUnchanged: true,
+            cleanupCompleted: true,
+            passedSteps: 9,
+            privateFact: "must-not-survive",
+          },
+        },
+      }),
+    }),
+  });
+
+  assert.equal(report.status, "ready");
+  assert.equal(report.commit, "965765f947fb62742a5e5c05a69f22696328ac72");
+  assert.equal(report.memoryAcceptance.passedSteps, 9);
+  assert.doesNotMatch(JSON.stringify(report), /must-not-survive/u);
 });

--- a/tests/systemConfigurationUi.test.js
+++ b/tests/systemConfigurationUi.test.js
@@ -13,6 +13,8 @@ test("owner interface exposes a protected system configuration panel", () => {
   assert.match(app, /\/api\/system\/configuration/u);
   assert.match(app, /Тайна стойност · никога не се показва/u);
   assert.match(app, /DigitalOcean самопроверка/u);
+  assert.match(app, /Защитен заместител/u);
+  assert.match(app, /configuration\.production/u);
   assert.match(styles, /\.configuration-group/u);
 });
 


### PR DESCRIPTION
## Какво се променя

- отличава работещите защитени заместители от действително липсващите настройки
- отчита `MEMORY_OWNER_ID` като безопасна стойност по подразбиране
- проверява production независимо през `/health/ready`, дори когато DigitalOcean API не е достъпно
- показва точния публикуван commit и безопасното доказателство от теста на паметта
- обновява системния екран без да връща стойности на тайни

## Причина

Личният агент погрешно представяше защитените заместители като блокери и не можеше да потвърди production без DigitalOcean самопроверка.

## Проверки

- 475/475 теста успешни
- 64/64 целеви теста успешни
- `npm audit --omit=dev`: 0 уязвимости
- `git diff --check`: успешно