### PR TITLE
Edit existing personal agents

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/accessibility.css?v=20260728-font-stepper" />
     <link rel="stylesheet" href="/task-journal.css?v=20260728-task-journal" />
     <link rel="stylesheet" href="/auth.css?v=20260801-profile-actions" />
-    <link rel="stylesheet" href="/work-mode.css?v=20260801-workspace-save-v3" />
+    <link rel="stylesheet" href="/work-mode.css?v=20260801-agent-edit-v4" />
     <link rel="stylesheet" href="/assets/20260730-v2/synchron-vision.css" />
     <link
       rel="stylesheet"
@@ -461,7 +461,7 @@
     </main>
 
     <script src="/markdown-renderer.js?v=20260728-xss"></script>
-    <script src="/work-mode.js?v=20260801-agent-model-v4"></script>
+    <script src="/work-mode.js?v=20260801-agent-edit-v5"></script>
     <script src="/assets/20260801-profile-actions/app.js"></script>
     <script src="/accessibility.js?v=20260728-font-stepper"></script>
     <script src="/assets/20260730-connections-v1/work-center.js"></script>

--- a/public/work-mode.css
+++ b/public/work-mode.css
@@ -179,6 +179,26 @@ body[data-interaction-mode="chat"] .work-pet {
   gap: 8px;
 }
 
+.work-agent-choice {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 7px;
+  align-items: stretch;
+}
+
+.work-agent-edit {
+  min-width: 92px;
+  padding: 9px 11px;
+  border: 1px solid #cbd5e1;
+  border-radius: 13px;
+  color: #0f5132;
+  background: #f8faf9;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
 .work-choice-card,
 .pet-choice {
   width: 100%;
@@ -223,6 +243,27 @@ body[data-interaction-mode="chat"] .work-pet {
   background: #fafbfb;
 }
 
+.work-manager-form h4 {
+  margin: 0 0 3px;
+  font-size: 15px;
+}
+
+.work-agent-edit-form {
+  border-color: #86c89f;
+  background: #f3fbf6;
+}
+
+.work-form-actions {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 8px;
+}
+
+.work-manager-form .work-form-cancel {
+  color: #17212b;
+  background: #e8edf0;
+}
+
 .work-manager-form label {
   font-size: 12px;
   font-weight: 800;
@@ -238,6 +279,16 @@ body[data-interaction-mode="chat"] .work-pet {
   color: #17212b;
   background: #fff;
   font: inherit;
+}
+
+@media (max-width: 520px) {
+  .work-agent-choice {
+    grid-template-columns: 1fr;
+  }
+
+  .work-agent-edit {
+    width: 100%;
+  }
 }
 
 .work-manager-form textarea {

--- a/public/work-mode.js
+++ b/public/work-mode.js
@@ -28,6 +28,7 @@
   let localRevision = 0;
   let storageAvailable = true;
   let managerNotice = "";
+  let editingAgentId = null;
 
   const elements = {
     chatInput: document.getElementById("chatInput"),
@@ -392,6 +393,8 @@
     const list = document.createElement("div");
     list.className = "work-choice-list";
     for (const agent of workState.agents) {
+      const item = document.createElement("article");
+      item.className = "work-agent-choice";
       const button = document.createElement("button");
       button.type = "button";
       button.className = "work-choice-card";
@@ -408,7 +411,21 @@
         "small",
         `${ROLE_LABELS[agent.role]} · ${MODEL_OPTIONS[agent.model]}${agent.purpose ? ` · ${agent.purpose}` : ""}`,
       );
-      list.appendChild(button);
+      item.appendChild(button);
+      const edit = document.createElement("button");
+      edit.type = "button";
+      edit.className = "work-agent-edit";
+      edit.textContent = "Редактирай";
+      edit.setAttribute("aria-label", `Редактирай ${agent.name}`);
+      edit.addEventListener("click", () => {
+        editingAgentId = agent.id;
+        workState.activeAgentId = agent.id;
+        saveState();
+        renderMode();
+        openManager();
+      });
+      item.appendChild(edit);
+      list.appendChild(item);
     }
     parent.appendChild(list);
   }
@@ -620,6 +637,92 @@
     parent.appendChild(form);
   }
 
+  function createEditAgentForm(parent, agent) {
+    const form = document.createElement("form");
+    form.className = "work-manager-form work-agent-edit-form";
+    addText(form, "h4", `Редактиране: ${agent.name}`);
+    addText(form, "label", "Име на агента").htmlFor = "editWorkAgentName";
+    const name = document.createElement("input");
+    name.id = "editWorkAgentName";
+    name.maxLength = 50;
+    name.required = true;
+    name.value = agent.name;
+    form.appendChild(name);
+    addText(form, "label", "Роля").htmlFor = "editWorkAgentRole";
+    const role = document.createElement("select");
+    role.id = "editWorkAgentRole";
+    for (const [id, label] of Object.entries(ROLE_LABELS)) {
+      const option = document.createElement("option");
+      option.value = id;
+      option.textContent = label;
+      role.appendChild(option);
+    }
+    role.value = agent.role;
+    form.appendChild(role);
+    addText(form, "label", "Модел").htmlFor = "editWorkAgentModel";
+    const model = document.createElement("select");
+    model.id = "editWorkAgentModel";
+    for (const [id, label] of Object.entries(MODEL_OPTIONS)) {
+      const option = document.createElement("option");
+      option.value = id;
+      option.textContent = label;
+      model.appendChild(option);
+    }
+    model.value = agent.model;
+    form.appendChild(model);
+    addText(form, "label", "Допълнителен фокус").htmlFor =
+      "editWorkAgentPurpose";
+    const purpose = document.createElement("textarea");
+    purpose.id = "editWorkAgentPurpose";
+    purpose.maxLength = 400;
+    purpose.required = true;
+    purpose.value = agent.purpose;
+    form.appendChild(purpose);
+
+    const actions = document.createElement("div");
+    actions.className = "work-form-actions";
+    const cancel = document.createElement("button");
+    cancel.type = "button";
+    cancel.className = "work-form-cancel";
+    cancel.textContent = "Отказ";
+    cancel.addEventListener("click", () => {
+      editingAgentId = null;
+      openManager();
+    });
+    actions.appendChild(cancel);
+    const submit = document.createElement("button");
+    submit.type = "submit";
+    submit.textContent = "Запази агента";
+    actions.appendChild(submit);
+    form.appendChild(actions);
+
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const next = {
+        name: cleanText(name.value, 50),
+        role: Object.hasOwn(ROLE_LABELS, role.value) ? role.value : "general",
+        model: Object.hasOwn(MODEL_OPTIONS, model.value) ? model.value : "auto",
+        purpose: cleanText(purpose.value, 400),
+      };
+      if (!next.name || !next.purpose) return;
+      const previous = { ...agent };
+      Object.assign(agent, next);
+      workState.activeAgentId = agent.id;
+      if (!saveState()) {
+        Object.assign(agent, previous);
+        managerNotice =
+          "Промените по агента не са запазени. Провери дали браузърът позволява съхранение на данни и опитай отново.";
+        openManager();
+        return;
+      }
+      editingAgentId = null;
+      managerNotice = `Агентът „${agent.name}“ е обновен и избран.`;
+      renderMode();
+      openManager();
+    });
+    parent.appendChild(form);
+  }
+
   function section(parent, title) {
     const container = document.createElement("section");
     container.className = "work-manager-section";
@@ -663,7 +766,11 @@
 
     const agents = section(elements.drawerBody, "Лични агенти");
     renderAgentChoices(agents);
-    createAgentForm(agents);
+    const editingAgent = workState.agents.find(
+      (agent) => agent.id === editingAgentId,
+    );
+    if (editingAgent) createEditAgentForm(agents, editingAgent);
+    else createAgentForm(agents);
 
     const pets = section(elements.drawerBody, "Домашен любимец");
     renderPetChoices(pets);

--- a/tests/workModeUi.test.js
+++ b/tests/workModeUi.test.js
@@ -57,6 +57,7 @@ test("Chat and Work are available with projects, agents, and pet state", async (
   assert.match(workMode, /function getRequestPayload/u);
   assert.match(workMode, /function createProjectForm/u);
   assert.match(workMode, /function createAgentForm/u);
+  assert.match(workMode, /function createEditAgentForm/u);
   assert.match(workMode, /Любимецът показва/u);
   assert.match(workMode, /\/api\/workspaces/u);
   assert.match(workMode, /защитения ти профил/u);
@@ -140,6 +141,35 @@ test("work mode runs in the browser and creates an isolated project payload", as
   const agentPayload = dom.window.SynchronWorkMode.getRequestPayload();
   assert.equal(agentPayload.workContext.agent.name, "Тестов ръководител");
   assert.equal(agentPayload.workContext.agent.model, "gpt-5.6-sol");
+
+  const editAgent = [...dom.window.document.querySelectorAll("button")].find(
+    (button) =>
+      button.getAttribute("aria-label") === "Редактирай Тестов ръководител",
+  );
+  assert.ok(editAgent);
+  editAgent.click();
+  const editForm = dom.window.document.querySelector(".work-agent-edit-form");
+  editForm.querySelector("#editWorkAgentName").value = "Обновен ръководител";
+  editForm.querySelector("#editWorkAgentRole").value = "builder";
+  editForm.querySelector("#editWorkAgentModel").value = "gpt-5.6-terra";
+  editForm.querySelector("#editWorkAgentPurpose").value =
+    "Строи и проверява резултата";
+  editForm.dispatchEvent(
+    new dom.window.Event("submit", { bubbles: true, cancelable: true }),
+  );
+
+  const editedPayload = dom.window.SynchronWorkMode.getRequestPayload();
+  assert.equal(editedPayload.workContext.agent.name, "Обновен ръководител");
+  assert.equal(editedPayload.workContext.agent.role, "builder");
+  assert.equal(editedPayload.workContext.agent.model, "gpt-5.6-terra");
+  assert.equal(
+    editedPayload.workContext.agent.purpose,
+    "Строи и проверява резултата",
+  );
+  assert.match(
+    dom.window.document.getElementById("dataDrawerBody").textContent,
+    /Агентът „Обновен ръководител“ е обновен и избран/u,
+  );
 
   dom.window.SynchronWorkMode.setBusy(true);
   assert.equal(


### PR DESCRIPTION
## Какво се променя

- добавя действие „Редактирай“ към всеки личен агент;
- позволява промяна на име, роля, модел и допълнителен фокус;
- запазва същия идентификатор на агента, активния избор и постоянния профил;
- показва ясно потвърждение след успешно запазване;
- не добавя изтриване.

## Защо

Личният агент вече може да бъде донастройван след създаването му, без да се създават дубликати и без загуба на проекта или избрания модел.

## Проверки

- целеви UI тестове: 19/19;
- пълен тестов набор: 475/475;
- `npm audit --omit=dev`: 0 уязвимости;
- `git diff --check`: успешно.