### PR TITLE
Fix tester invitation registration flow

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -140,9 +140,25 @@ async function submitAuth(path, body) {
   });
   const data = await response.json().catch(() => null);
   if (!response.ok) {
-    throw new Error(data?.error || "Входът не беше успешен.");
+    const error = new Error(data?.error || "Входът не беше успешен.");
+    error.code = data?.code || "AUTH_REQUEST_FAILED";
+    throw error;
   }
   return data;
+}
+
+function consumeSharedTesterInvite() {
+  const hash = globalThis.location?.hash || "";
+  if (!hash.startsWith("#")) return "";
+  const params = new URLSearchParams(hash.slice(1));
+  const inviteCode = (params.get("tester-invite") || "").trim();
+  if (!inviteCode) return "";
+  globalThis.history?.replaceState?.(
+    null,
+    "",
+    `${globalThis.location.pathname || "/"}${globalThis.location.search || ""}`,
+  );
+  return inviteCode;
 }
 
 async function handleLogin(event) {
@@ -191,7 +207,11 @@ async function handleRegistration(event) {
     if (!session.authenticated) throw new Error("Сесията не беше създадена.");
     await startApplication(session.user);
   } catch (error) {
-    setAuthMessage(error.message);
+    setAuthMessage(
+      error.code === "AUTH_INVALID_INVITE_CODE"
+        ? "Поканата вече не е валидна. Отвори новия линк за покана, изпратен от собственика."
+        : error.message,
+    );
   } finally {
     setAuthBusy(false);
   }
@@ -238,6 +258,16 @@ async function init() {
     }
     elements.authGate.hidden = false;
     elements.appShell.hidden = true;
+    const sharedInvite = consumeSharedTesterInvite();
+    if (state.registrationEnabled && sharedInvite) {
+      elements.registerInviteCode.value = sharedInvite;
+      showRegisterForm();
+      setAuthMessage(
+        "Поканата е приложена. Попълни име, имейл и парола.",
+        true,
+      );
+      return;
+    }
     if (!session.configured) {
       setAuthMessage(
         "Входът за тестови профили още не е активиран. Собственикът може да влезе с GitHub.",

--- a/public/work-center.js
+++ b/public/work-center.js
@@ -583,6 +583,9 @@
       const copyButton = addText(panel, "button", "Копирай кода");
       copyButton.type = "button";
       copyButton.dataset.copyTesterInvite = "";
+      const copyLinkButton = addText(panel, "button", "Копирай линк за покана");
+      copyLinkButton.type = "button";
+      copyLinkButton.dataset.copyTesterInviteLink = "";
     }
     body.querySelector("[data-tester-auth-result]")?.remove();
     if (anchor?.parentNode) {
@@ -716,8 +719,7 @@
       showTesterAuthResult({
         title: "Тестовите профили се активират",
         message:
-          "DigitalOcean започва нов deployment. След публикуването бутонът „Създай тестов профил“ ще се появи.",
-        inviteCode: result.inviteCode,
+          "DigitalOcean започва нов deployment. Изчакай публикуването, после отвори отново „Тестови профили“ и копирай актуалния линк за покана.",
         anchor: card,
       });
     } catch (error) {
@@ -819,6 +821,18 @@
         inviteCode?.textContent || "",
       );
       copyInvite.textContent = "Копирано";
+      return;
+    }
+    const copyInviteLink = event.target.closest(
+      "[data-copy-tester-invite-link]",
+    );
+    if (copyInviteLink) {
+      const inviteCode = body.querySelector("[data-tester-invite-code]");
+      const origin =
+        globalThis.location?.origin || "https://synchron.foundation";
+      const inviteUrl = `${origin.replace(/\/$/u, "")}/#tester-invite=${encodeURIComponent(inviteCode?.textContent || "")}`;
+      await globalThis.navigator?.clipboard?.writeText(inviteUrl);
+      copyInviteLink.textContent = "Линкът е копиран";
       return;
     }
     const copyMcpUrl = event.target.closest("[data-copy-mcp-url]");

--- a/tests/authUi.test.js
+++ b/tests/authUi.test.js
@@ -28,6 +28,18 @@ test("offers invite-only registration without embedding a code", () => {
   );
 });
 
+test("accepts a shared tester invite from the URL fragment and removes it", () => {
+  assert.match(app, /params\.get\("tester-invite"\)/u);
+  assert.match(app, /history\?\.replaceState/u);
+  assert.match(app, /elements\.registerInviteCode\.value = sharedInvite/u);
+  assert.match(app, /Поканата е приложена/u);
+});
+
+test("explains an expired or mismatched tester invitation", () => {
+  assert.match(app, /AUTH_INVALID_INVITE_CODE/u);
+  assert.match(app, /Отвори новия линк за покана/u);
+});
+
 test("hides owner tools for tester profiles and exposes logout", () => {
   assert.match(html, /id="toolsBtn"[^>]*data-owner-only/u);
   assert.match(html, /id="workCenterBtn"[^>]*data-owner-only/u);

--- a/tests/workCenterUi.test.js
+++ b/tests/workCenterUi.test.js
@@ -76,6 +76,7 @@ function createHarness({
   testerAuth = { configured: false, registrationEnabled: false },
   fetchFails = false,
   testerPrepareResponse = null,
+  testerInviteCode = "current-private-invite",
 } = {}) {
   const dom = new JSDOM(`<!doctype html><body>
     <aside id="sidebar"></aside>
@@ -104,6 +105,7 @@ function createHarness({
       },
     },
     location: {
+      origin: "https://synchron.foundation",
       assign: (url) => {
         dom.window.document.body.dataset.redirectedTo = url;
       },
@@ -124,7 +126,9 @@ function createHarness({
               ? { connected: githubConnected }
               : path.includes("/api/tester-auth/status")
                 ? testerAuth
-                : config || {};
+                : path.includes("/api/tester-auth/invite-code")
+                  ? { inviteCode: testerInviteCode }
+                  : config || {};
       return {
         ok: true,
         json: async () => result,
@@ -372,6 +376,29 @@ test("work center shows the invite action only after tester auth is active", asy
 
   assert.match(card.textContent, /Тестови профили/u);
   assert.match(card.textContent, /Работи · Само за собственика/u);
+});
+
+test("copies a current tester invitation link without manual code entry", async () => {
+  const harness = createHarness({
+    testerAuth: { configured: true, registrationEnabled: true },
+    testerInviteCode: "current/private invite",
+  });
+  await openCenter(harness);
+  const { document } = harness.dom.window;
+  document
+    .querySelector('[data-work-center-action="show-tester-invite"]')
+    .click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const copyLink = document.querySelector("[data-copy-tester-invite-link]");
+  copyLink.click();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(
+    document.body.dataset.copiedText,
+    "https://synchron.foundation/#tester-invite=current%2Fprivate%20invite",
+  );
+  assert.equal(copyLink.textContent, "Линкът е копиран");
 });
 
 test("tester auth action is visibly actionable on mobile", async () => {


### PR DESCRIPTION
## Какво поправя
- добавя готов линк за тестова покана вместо ръчно въвеждане на кода;
- при отваряне кодът се попълва автоматично и се премахва от адреса;
- не показва бъдещ код преди DigitalOcean deployment да е завършил;
- показва ясна грешка при стар или невалиден линк.

## Проверка
- `npm test`: 479/479 успешни;
- целеви UI тестове: 29/29 успешни;
- `git diff --check`: успешно.

Не променя пароли, Supabase потребители или съществуващи разрешения.