### PR TITLE
Replace invite signup with normal registration

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -30,7 +30,6 @@ const elements = {
   registerName: document.getElementById("registerName"),
   registerEmail: document.getElementById("registerEmail"),
   registerPassword: document.getElementById("registerPassword"),
-  registerInviteCode: document.getElementById("registerInviteCode"),
   registerBtn: document.getElementById("registerBtn"),
   backToLoginBtn: document.getElementById("backToLoginBtn"),
   authMessage: document.getElementById("authMessage"),
@@ -147,20 +146,6 @@ async function submitAuth(path, body) {
   return data;
 }
 
-function consumeSharedTesterInvite() {
-  const hash = globalThis.location?.hash || "";
-  if (!hash.startsWith("#")) return "";
-  const params = new URLSearchParams(hash.slice(1));
-  const inviteCode = (params.get("tester-invite") || "").trim();
-  if (!inviteCode) return "";
-  globalThis.history?.replaceState?.(
-    null,
-    "",
-    `${globalThis.location.pathname || "/"}${globalThis.location.search || ""}`,
-  );
-  return inviteCode;
-}
-
 async function handleLogin(event) {
   event.preventDefault();
   setAuthBusy(true);
@@ -190,10 +175,8 @@ async function handleRegistration(event) {
       displayName: elements.registerName.value,
       email: elements.registerEmail.value,
       password: elements.registerPassword.value,
-      inviteCode: elements.registerInviteCode.value,
     });
     elements.registerPassword.value = "";
-    elements.registerInviteCode.value = "";
     if (result.confirmationRequired) {
       showLoginForm();
       elements.loginEmail.value = result.user?.email || "";
@@ -207,11 +190,7 @@ async function handleRegistration(event) {
     if (!session.authenticated) throw new Error("Сесията не беше създадена.");
     await startApplication(session.user);
   } catch (error) {
-    setAuthMessage(
-      error.code === "AUTH_INVALID_INVITE_CODE"
-        ? "Поканата вече не е валидна. Отвори новия линк за покана, изпратен от собственика."
-        : error.message,
-    );
+    setAuthMessage(error.message);
   } finally {
     setAuthBusy(false);
   }
@@ -235,7 +214,7 @@ function applyAuthenticatedUser(user) {
     displayName.trim().charAt(0).toLocaleUpperCase("bg-BG") || "П";
   elements.profileRole.textContent = isOwner
     ? "Собственик · настройки"
-    : "Тестов профил";
+    : "Личен профил";
   document.body.dataset.userRole = isOwner ? "owner" : "tester";
   for (const item of document.querySelectorAll("[data-owner-only]")) {
     item.hidden = !isOwner;
@@ -258,19 +237,9 @@ async function init() {
     }
     elements.authGate.hidden = false;
     elements.appShell.hidden = true;
-    const sharedInvite = consumeSharedTesterInvite();
-    if (state.registrationEnabled && sharedInvite) {
-      elements.registerInviteCode.value = sharedInvite;
-      showRegisterForm();
-      setAuthMessage(
-        "Поканата е приложена. Попълни име, имейл и парола.",
-        true,
-      );
-      return;
-    }
     if (!session.configured) {
       setAuthMessage(
-        "Входът за тестови профили още не е активиран. Собственикът може да влезе с GitHub.",
+        "Входът с потребителски профили още не е активиран. Собственикът може да влезе с GitHub.",
       );
     }
   } catch (error) {

--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,7 @@
         <p class="auth-kicker">ЛИЧНА AI СИСТЕМА</p>
         <h1 id="authTitle">Вход в AI CORE</h1>
         <p class="auth-intro">
-          Всеки тестов потребител има собствен профил, разговори и памет.
+          Всеки потребител има собствен профил, разговори и памет.
         </p>
 
         <form id="loginForm" class="auth-form">
@@ -66,7 +66,7 @@
         </form>
 
         <button id="showRegisterBtn" class="auth-link" type="button" hidden>
-          Създай тестов профил
+          Създай профил
         </button>
         <form id="registerForm" class="auth-form" hidden>
           <label for="registerName">Име</label>
@@ -95,15 +95,6 @@
             autocomplete="new-password"
             minlength="8"
             maxlength="128"
-            required
-          />
-          <label for="registerInviteCode">Код за тестов достъп</label>
-          <input
-            id="registerInviteCode"
-            name="inviteCode"
-            type="password"
-            autocomplete="one-time-code"
-            minlength="8"
             required
           />
           <button id="registerBtn" class="auth-primary" type="submit">

--- a/public/work-center.js
+++ b/public/work-center.js
@@ -269,7 +269,7 @@
           connected: Boolean(sessions.googleConnected),
         }),
       },
-      { label: "Тестови профили", state: testerStatus },
+      { label: "Потребителски профили", state: testerStatus },
     ];
   }
 
@@ -499,20 +499,20 @@
       createActionCard({
         title:
           testerAuth?.configured && testerAuth?.registrationEnabled
-            ? "Тестови профили"
-            : "Активирай тестови профили",
+            ? "Потребителски профили"
+            : "Активирай потребителски профили",
         description:
           testerAuth?.configured && testerAuth?.registrationEnabled
-            ? "Входът е свързан със Supabase. Покажи кода за покана."
+            ? "Нормална регистрация с име, имейл и парола."
             : "Добавя четирите защитени production настройки чрез DigitalOcean моста.",
         action:
           testerAuth?.configured && testerAuth?.registrationEnabled
-            ? "show-tester-invite"
+            ? "copy-registration-link"
             : "activate-tester-auth",
         icon: "fa-solid fa-user-plus",
         status:
           testerAuth?.configured && testerAuth?.registrationEnabled
-            ? "Работи · Само за собственика"
+            ? "Работи · Нормална регистрация"
             : "Изисква точно потвърждение",
         statusClass:
           testerAuth?.configured && testerAuth?.registrationEnabled
@@ -520,7 +520,7 @@
             : "warning",
         actionLabel:
           testerAuth?.configured && testerAuth?.registrationEnabled
-            ? "Натисни, за да покажеш кода"
+            ? "Натисни, за да копираш адреса"
             : "Натисни за активиране",
       }),
       createExternalCard({
@@ -566,27 +566,12 @@
     body.appendChild(closeButton);
   }
 
-  function showTesterAuthResult({
-    title: resultTitle,
-    message,
-    inviteCode,
-    anchor,
-  }) {
+  function showTesterAuthResult({ title: resultTitle, message, anchor }) {
     const panel = document.createElement("section");
     panel.className = "work-center-intro";
     panel.dataset.testerAuthResult = "";
     addText(panel, "strong", resultTitle);
     addText(panel, "p", message);
-    if (inviteCode) {
-      const code = addText(panel, "code", inviteCode);
-      code.dataset.testerInviteCode = "";
-      const copyButton = addText(panel, "button", "Копирай кода");
-      copyButton.type = "button";
-      copyButton.dataset.copyTesterInvite = "";
-      const copyLinkButton = addText(panel, "button", "Копирай линк за покана");
-      copyLinkButton.type = "button";
-      copyLinkButton.dataset.copyTesterInviteLink = "";
-    }
     body.querySelector("[data-tester-auth-result]")?.remove();
     if (anchor?.parentNode) {
       anchor.insertAdjacentElement("afterend", panel);
@@ -677,18 +662,6 @@
     return payload;
   }
 
-  async function showTesterInvite() {
-    const payload = await readJson(
-      await fetch("/api/tester-auth/invite-code", { cache: "no-store" }),
-    );
-    showTesterAuthResult({
-      title: "Код за тестов достъп",
-      message:
-        "Дай този код само на човека, на когото разрешаваш да създаде тестов профил.",
-      inviteCode: payload.inviteCode,
-    });
-  }
-
   async function activateTesterAuth(card) {
     card.disabled = true;
     try {
@@ -700,7 +673,11 @@
         }),
       );
       if (prepared.configured) {
-        await showTesterInvite();
+        showTesterAuthResult({
+          title: "Потребителските профили са активни",
+          message: "Регистрацията с име, имейл и парола работи.",
+          anchor: card,
+        });
         return;
       }
       const approved = globalThis.confirm(
@@ -717,9 +694,9 @@
         }),
       );
       showTesterAuthResult({
-        title: "Тестовите профили се активират",
+        title: "Потребителските профили се активират",
         message:
-          "DigitalOcean започва нов deployment. Изчакай публикуването, после отвори отново „Тестови профили“ и копирай актуалния линк за покана.",
+          "DigitalOcean започва нов deployment. След публикуването нормалната регистрация ще бъде достъпна.",
         anchor: card,
       });
     } catch (error) {
@@ -814,27 +791,6 @@
       closeWorkCenter();
       return;
     }
-    const copyInvite = event.target.closest("[data-copy-tester-invite]");
-    if (copyInvite) {
-      const inviteCode = body.querySelector("[data-tester-invite-code]");
-      await globalThis.navigator?.clipboard?.writeText(
-        inviteCode?.textContent || "",
-      );
-      copyInvite.textContent = "Копирано";
-      return;
-    }
-    const copyInviteLink = event.target.closest(
-      "[data-copy-tester-invite-link]",
-    );
-    if (copyInviteLink) {
-      const inviteCode = body.querySelector("[data-tester-invite-code]");
-      const origin =
-        globalThis.location?.origin || "https://synchron.foundation";
-      const inviteUrl = `${origin.replace(/\/$/u, "")}/#tester-invite=${encodeURIComponent(inviteCode?.textContent || "")}`;
-      await globalThis.navigator?.clipboard?.writeText(inviteUrl);
-      copyInviteLink.textContent = "Линкът е копиран";
-      return;
-    }
     const copyMcpUrl = event.target.closest("[data-copy-mcp-url]");
     if (copyMcpUrl) {
       await globalThis.navigator?.clipboard?.writeText(MCP_RESOURCE_URL);
@@ -850,15 +806,17 @@
       await activateTesterAuth(actionCard);
       return;
     }
-    if (actionCard?.dataset.workCenterAction === "show-tester-invite") {
-      try {
-        await showTesterInvite();
-      } catch (error) {
-        showTesterAuthResult({
-          title: "Кодът не е достъпен",
-          message: error.message,
-        });
-      }
+    if (actionCard?.dataset.workCenterAction === "copy-registration-link") {
+      const origin =
+        globalThis.location?.origin || "https://synchron.foundation";
+      await globalThis.navigator?.clipboard?.writeText(
+        `${origin.replace(/\/$/u, "")}/`,
+      );
+      showTesterAuthResult({
+        title: "Адресът за регистрация е копиран",
+        message: "Изпрати го на човека, който иска да създаде профил.",
+        anchor: actionCard,
+      });
       return;
     }
     const internalCard = event.target.closest("[data-work-center-target]");

--- a/src/routes/testerAuthAdminRouter.js
+++ b/src/routes/testerAuthAdminRouter.js
@@ -16,6 +16,7 @@ import {
 import {
   getTesterInviteCode,
   isTesterRegistrationEnabled,
+  isUserRegistrationEnabled,
   isUserAuthConfigured,
 } from "../services/userAuthService.js";
 import { logSafeError, safeErrorCode } from "../utils/safeLogging.js";
@@ -79,7 +80,7 @@ export function createTesterAuthAdminRouter({
   router.get("/status", (_req, res) =>
     res.json({
       configured: isUserAuthConfigured(env),
-      registrationEnabled: isTesterRegistrationEnabled(env),
+      registrationEnabled: isUserRegistrationEnabled(env),
     }),
   );
 
@@ -104,7 +105,7 @@ export function createTesterAuthAdminRouter({
       if (!missingKeys.length) {
         return res.json({
           configured: true,
-          registrationEnabled: isTesterRegistrationEnabled(env),
+          registrationEnabled: isUserRegistrationEnabled(env),
           missingKeys: [],
           readAccessVerified: status.readAccessVerified,
           requiredWriteScope: status.requiredWriteScope,

--- a/src/routes/userAuthRouter.js
+++ b/src/routes/userAuthRouter.js
@@ -2,9 +2,9 @@ import express from "express";
 import {
   clearUserSessionCookie,
   getUserAuthConfigurationStatus,
-  isTesterRegistrationEnabled,
+  isUserRegistrationEnabled,
   isUserAuthConfigured,
-  registerTester,
+  registerUser,
   signInUser,
   signOutUser,
   userSessionCookie,
@@ -35,7 +35,7 @@ router.get("/session", async (req, res) => {
     return res.json({
       configured: isUserAuthConfigured(),
       configuration: getUserAuthConfigurationStatus(),
-      registrationEnabled: isTesterRegistrationEnabled(),
+      registrationEnabled: isUserRegistrationEnabled(),
       authenticated: Boolean(identity),
       user: identity
         ? {
@@ -70,7 +70,7 @@ router.post("/login", async (req, res) => {
 
 router.post("/register", async (req, res) => {
   try {
-    const result = await registerTester(req.body || {});
+    const result = await registerUser(req.body || {});
     if (result.session) {
       res.setHeader("Set-Cookie", userSessionCookie(result.session));
     }

--- a/src/services/userAuthService.js
+++ b/src/services/userAuthService.js
@@ -5,12 +5,10 @@ import {
   createHmac,
   randomBytes,
   scryptSync,
-  timingSafeEqual,
 } from "node:crypto";
 import { TESTER_AUTH_BOOTSTRAP } from "../config/testerAuthBootstrap.js";
 import {
   approveTesterAccess,
-  approveTesterEmail,
   assertTesterAccess,
   TesterAccessError,
 } from "./testerAccessService.js";
@@ -108,6 +106,10 @@ export function isUserAuthConfigured(env = process.env) {
 
 export function isTesterRegistrationEnabled(env = process.env) {
   return getTesterInviteCode(env).length >= 8;
+}
+
+export function isUserRegistrationEnabled(env = process.env) {
+  return isUserAuthConfigured(env);
 }
 
 function requireAuthConfig(env = process.env) {
@@ -383,17 +385,6 @@ function cleanDisplayName(value, email) {
   return displayName || email.split("@")[0];
 }
 
-function inviteCodeMatches(value, env = process.env) {
-  if (!isTesterRegistrationEnabled(env)) return false;
-  const expected = createHash("sha256")
-    .update(getTesterInviteCode(env))
-    .digest();
-  const received = createHash("sha256")
-    .update(typeof value === "string" ? value.trim() : "")
-    .digest();
-  return timingSafeEqual(expected, received);
-}
-
 function mapAuthError(error, fallbackMessage) {
   const status = Number(error?.status);
   if (status === 400 || status === 401) {
@@ -452,32 +443,15 @@ export async function signInUser(
   return { user: data.user, session: sessionPayload(data.session) };
 }
 
-export async function registerTester(
-  { email, password, displayName, inviteCode },
-  {
-    env = process.env,
-    client,
-    approveAccess = approveTesterAccess,
-    approveEmail = approveTesterEmail,
-  } = {},
+export async function registerUser(
+  { email, password, displayName },
+  { env = process.env, client, approveAccess = approveTesterAccess } = {},
 ) {
-  if (!inviteCodeMatches(inviteCode, env)) {
-    throw new UserAuthError(
-      "Кодът за тестов достъп е неправилен.",
-      403,
-      "AUTH_INVALID_INVITE_CODE",
-    );
-  }
   const cleanCredentials = {
     email: cleanEmail(email),
     password: cleanPassword(password),
   };
   const authClient = client || createAuthClient(env);
-  try {
-    await approveEmail(cleanCredentials.email, { env });
-  } catch (error) {
-    throw mapTesterAccessError(error);
-  }
 
   let { data, error } = await authClient.auth.signUp({
     ...cleanCredentials,
@@ -495,6 +469,18 @@ export async function registerTester(
       data = recovered.data;
       error = null;
     }
+  }
+
+  const isObfuscatedExistingUser =
+    !data?.session &&
+    Array.isArray(data?.user?.identities) &&
+    data.user.identities.length === 0;
+  if (isObfuscatedExistingUser) {
+    throw new UserAuthError(
+      "Профилът не можа да бъде създаден. Ако вече имаш профил, върни се към входа.",
+      422,
+      "AUTH_SIGNUP_REJECTED",
+    );
   }
 
   if (error || !data?.user) {

--- a/tests/authUi.test.js
+++ b/tests/authUi.test.js
@@ -18,8 +18,11 @@ test("renders a real login gate before the private application", () => {
   assert.match(css, /\.app-shell\[hidden\]/u);
 });
 
-test("offers invite-only registration without embedding a code", () => {
-  assert.match(html, /id="registerInviteCode"/u);
+test("offers normal registration with name, email, and password", () => {
+  assert.match(html, /id="registerName"/u);
+  assert.match(html, /id="registerEmail"/u);
+  assert.match(html, /id="registerPassword"/u);
+  assert.doesNotMatch(html, /registerInviteCode|Код за тестов достъп/u);
   assert.match(app, /registrationEnabled/u);
   assert.match(app, /\/api\/auth\/register/u);
   assert.doesNotMatch(
@@ -28,16 +31,11 @@ test("offers invite-only registration without embedding a code", () => {
   );
 });
 
-test("accepts a shared tester invite from the URL fragment and removes it", () => {
-  assert.match(app, /params\.get\("tester-invite"\)/u);
-  assert.match(app, /history\?\.replaceState/u);
-  assert.match(app, /elements\.registerInviteCode\.value = sharedInvite/u);
-  assert.match(app, /Поканата е приложена/u);
-});
-
-test("explains an expired or mismatched tester invitation", () => {
-  assert.match(app, /AUTH_INVALID_INVITE_CODE/u);
-  assert.match(app, /Отвори новия линк за покана/u);
+test("registration does not send an invitation code", () => {
+  assert.doesNotMatch(app, /tester-invite|registerInviteCode|inviteCode:/u);
+  assert.match(app, /displayName: elements\.registerName\.value/u);
+  assert.match(app, /email: elements\.registerEmail\.value/u);
+  assert.match(app, /password: elements\.registerPassword\.value/u);
 });
 
 test("hides owner tools for tester profiles and exposes logout", () => {

--- a/tests/userAuthService.test.js
+++ b/tests/userAuthService.test.js
@@ -7,8 +7,9 @@ import {
   getTesterInviteCode,
   getUserAuthConfigurationStatus,
   isTesterRegistrationEnabled,
+  isUserRegistrationEnabled,
   isUserAuthConfigured,
-  registerTester,
+  registerUser,
   resolveUserSession,
   signInUser,
   userSessionCookie,
@@ -35,6 +36,7 @@ function session(suffix = "a") {
 
 test("detects complete auth and closed/open tester registration", () => {
   assert.equal(isUserAuthConfigured(ENV), true);
+  assert.equal(isUserRegistrationEnabled(ENV), true);
   assert.equal(isTesterRegistrationEnabled(ENV), true);
   assert.equal(
     isTesterRegistrationEnabled({
@@ -42,6 +44,13 @@ test("detects complete auth and closed/open tester registration", () => {
       SYNCHRON_TEST_INVITE_CODE: "",
     }),
     false,
+  );
+  assert.equal(
+    isUserRegistrationEnabled({
+      ...ENV,
+      SYNCHRON_TEST_INVITE_CODE: "",
+    }),
+    true,
   );
 });
 
@@ -212,25 +221,7 @@ test("uses the Supabase Auth password endpoint without exposing a service key", 
   assert.ok(result.session.expires_at > Math.floor(Date.now() / 1000));
 });
 
-test("tester registration requires the private invite code", async () => {
-  await assert.rejects(
-    registerTester(
-      {
-        email: "friend@example.com",
-        password: "strong-pass-123",
-        displayName: "Приятел",
-        inviteCode: "wrong-code",
-      },
-      { env: ENV, client: { auth: {} } },
-    ),
-    (error) =>
-      error instanceof UserAuthError &&
-      error.code === "AUTH_INVALID_INVITE_CODE" &&
-      error.status === 403,
-  );
-});
-
-test("successful tester registration creates the application approval", async () => {
+test("normal registration creates the application approval", async () => {
   const fakeSession = session("register");
   let approvedUser = null;
   const client = {
@@ -250,17 +241,15 @@ test("successful tester registration creates the application approval", async ()
     },
   };
 
-  const result = await registerTester(
+  const result = await registerUser(
     {
       email: "friend@example.com",
       password: "strong-pass-123",
       displayName: "Приятел",
-      inviteCode: ENV.SYNCHRON_TEST_INVITE_CODE,
     },
     {
       env: ENV,
       client,
-      approveEmail: async () => {},
       approveAccess: async (user) => {
         approvedUser = user;
       },
@@ -272,7 +261,7 @@ test("successful tester registration creates the application approval", async ()
   assert.deepEqual(result.session, fakeSession);
 });
 
-test("registration pre-approves the email before creating the Supabase user", async () => {
+test("registration approves access after Supabase creates the user", async () => {
   const calls = [];
   const client = {
     auth: {
@@ -289,23 +278,20 @@ test("registration pre-approves the email before creating the Supabase user", as
     },
   };
 
-  await registerTester(
+  await registerUser(
     {
       email: "friend@example.com",
       password: "strong-pass-123",
       displayName: "Приятел",
-      inviteCode: ENV.SYNCHRON_TEST_INVITE_CODE,
     },
     {
       env: ENV,
       client,
-      approveEmail: async (email) => calls.push(`approve-email:${email}`),
       approveAccess: async (user) => calls.push(`approve-user:${user.id}`),
     },
   );
 
   assert.deepEqual(calls, [
-    "approve-email:friend@example.com",
     "signup:friend@example.com",
     "approve-user:preapproved-user",
   ]);
@@ -335,17 +321,15 @@ test("registration recovers an existing invited user with the same password", as
     },
   };
 
-  const result = await registerTester(
+  const result = await registerUser(
     {
       email: "friend@example.com",
       password: "strong-pass-123",
       displayName: "Приятел",
-      inviteCode: ENV.SYNCHRON_TEST_INVITE_CODE,
     },
     {
       env: ENV,
       client,
-      approveEmail: async () => {},
       approveAccess: async (user) => {
         approvedUser = user;
       },
@@ -388,17 +372,15 @@ test("registration recovers an existing invited user from an obfuscated signup r
     },
   };
 
-  const result = await registerTester(
+  const result = await registerUser(
     {
       email: "friend@example.com",
       password: "strong-pass-123",
       displayName: "Приятел",
-      inviteCode: ENV.SYNCHRON_TEST_INVITE_CODE,
     },
     {
       env: ENV,
       client,
-      approveEmail: async () => {},
       approveAccess: async (user) => {
         approvedUser = user;
       },
@@ -409,6 +391,51 @@ test("registration recovers an existing invited user from an obfuscated signup r
   assert.equal(result.user.id, "existing-user");
   assert.deepEqual(result.session, fakeSession);
   assert.equal(result.confirmationRequired, false);
+});
+
+test("registration never approves an obfuscated existing user when recovery fails", async () => {
+  let approvedUser = null;
+  const client = {
+    auth: {
+      async signUp({ email }) {
+        return {
+          data: {
+            user: { id: "obfuscated-user", email, identities: [] },
+            session: null,
+          },
+          error: null,
+        };
+      },
+      async signInWithPassword() {
+        return {
+          data: { user: null, session: null },
+          error: { status: 400, message: "Invalid credentials" },
+        };
+      },
+    },
+  };
+
+  await assert.rejects(
+    registerUser(
+      {
+        email: "friend@example.com",
+        password: "wrong-pass-123",
+        displayName: "Приятел",
+      },
+      {
+        env: ENV,
+        client,
+        approveAccess: async (user) => {
+          approvedUser = user;
+        },
+      },
+    ),
+    (error) =>
+      error instanceof UserAuthError &&
+      error.code === "AUTH_SIGNUP_REJECTED" &&
+      error.status === 422,
+  );
+  assert.equal(approvedUser, null);
 });
 
 test("registration keeps a new unconfirmed user when immediate sign in is unavailable", async () => {
@@ -433,17 +460,15 @@ test("registration keeps a new unconfirmed user when immediate sign in is unavai
     },
   };
 
-  const result = await registerTester(
+  const result = await registerUser(
     {
       email: "new@example.com",
       password: "strong-pass-123",
       displayName: "Нов тестер",
-      inviteCode: ENV.SYNCHRON_TEST_INVITE_CODE,
     },
     {
       env: ENV,
       client,
-      approveEmail: async () => {},
       approveAccess: async (user) => {
         approvedUser = user;
       },

--- a/tests/workCenterUi.test.js
+++ b/tests/workCenterUi.test.js
@@ -76,7 +76,6 @@ function createHarness({
   testerAuth = { configured: false, registrationEnabled: false },
   fetchFails = false,
   testerPrepareResponse = null,
-  testerInviteCode = "current-private-invite",
 } = {}) {
   const dom = new JSDOM(`<!doctype html><body>
     <aside id="sidebar"></aside>
@@ -126,9 +125,7 @@ function createHarness({
               ? { connected: githubConnected }
               : path.includes("/api/tester-auth/status")
                 ? testerAuth
-                : path.includes("/api/tester-auth/invite-code")
-                  ? { inviteCode: testerInviteCode }
-                  : config || {};
+                : config || {};
       return {
         ok: true,
         json: async () => result,
@@ -361,44 +358,39 @@ test("work center shows real connection state instead of claiming everything wor
   assert.match(text, /DigitalOcean Read: работи/u);
   assert.match(text, /Cloudflare Read: не е конфигуриран/u);
   assert.match(text, /Изисква еднократен вход в Google/u);
-  assert.match(text, /Активирай тестови профили/u);
+  assert.match(text, /Активирай потребителски профили/u);
   assert.match(text, /Изисква точно потвърждение/u);
 });
 
-test("work center shows the invite action only after tester auth is active", async () => {
+test("work center shows normal registration after user auth is active", async () => {
   const harness = createHarness({
     testerAuth: { configured: true, registrationEnabled: true },
   });
   await openCenter(harness);
   const card = harness.dom.window.document.querySelector(
-    '[data-work-center-action="show-tester-invite"]',
+    '[data-work-center-action="copy-registration-link"]',
   );
 
-  assert.match(card.textContent, /Тестови профили/u);
-  assert.match(card.textContent, /Работи · Само за собственика/u);
+  assert.match(card.textContent, /Потребителски профили/u);
+  assert.match(card.textContent, /Работи · Нормална регистрация/u);
 });
 
-test("copies a current tester invitation link without manual code entry", async () => {
+test("copies the normal registration address", async () => {
   const harness = createHarness({
     testerAuth: { configured: true, registrationEnabled: true },
-    testerInviteCode: "current/private invite",
   });
   await openCenter(harness);
   const { document } = harness.dom.window;
   document
-    .querySelector('[data-work-center-action="show-tester-invite"]')
+    .querySelector('[data-work-center-action="copy-registration-link"]')
     .click();
-  await new Promise((resolve) => setTimeout(resolve, 0));
-
-  const copyLink = document.querySelector("[data-copy-tester-invite-link]");
-  copyLink.click();
   await new Promise((resolve) => setTimeout(resolve, 0));
 
   assert.equal(
     document.body.dataset.copiedText,
-    "https://synchron.foundation/#tester-invite=current%2Fprivate%20invite",
+    "https://synchron.foundation/",
   );
-  assert.equal(copyLink.textContent, "Линкът е копиран");
+  assert.match(document.body.textContent, /Адресът за регистрация е копиран/u);
 });
 
 test("tester auth action is visibly actionable on mobile", async () => {
@@ -553,7 +545,7 @@ test("current capabilities summary uses only live verified status", async () => 
   assert.match(working.textContent, /Google Drive/u);
   assert.match(working.textContent, /Gmail/u);
   assert.match(working.textContent, /Google Calendar/u);
-  assert.match(working.textContent, /Тестови профили/u);
+  assert.match(working.textContent, /Потребителски профили/u);
 });
 
 test("current capabilities reports GitHub Write as disabled without Copilot", async () => {


### PR DESCRIPTION
## Обобщение
- заменя тестовия код за достъп с нормална регистрация чрез име, имейл и парола
- запазва отделните потребителски профили, изолираната памет и owner-only ограниченията
- премахва поканите от публичния интерфейс и показва директен адрес за регистрация
- предотвратява одобряване на маскиран съществуващ Supabase потребител при грешна парола

## Проверки
- `npm test` — 478/478 успешни
- `git diff --check` — успешно