### PR TITLE
Open registration from a direct link

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -18,6 +18,8 @@ const state = {
   applicationStarted: false,
 };
 
+const REGISTRATION_PATH = "/register";
+
 const elements = {
   authGate: document.getElementById("authGate"),
   appShell: document.getElementById("appShell"),
@@ -121,6 +123,11 @@ function showRegisterForm() {
   elements.showRegisterBtn.hidden = true;
   setAuthMessage();
   elements.registerName.focus();
+}
+
+function isDirectRegistrationPage() {
+  return globalThis.location?.pathname?.replace(/\/+$/u, "") ===
+    REGISTRATION_PATH;
 }
 
 async function readAuthSession() {
@@ -237,6 +244,11 @@ async function init() {
     }
     elements.authGate.hidden = false;
     elements.appShell.hidden = true;
+    if (state.registrationEnabled && isDirectRegistrationPage()) {
+      showRegisterForm();
+      setAuthMessage("Създай профил с име, имейл и парола.", true);
+      return;
+    }
     if (!session.configured) {
       setAuthMessage(
         "Входът с потребителски профили още не е активиран. Собственикът може да влезе с GitHub.",

--- a/public/work-center.js
+++ b/public/work-center.js
@@ -520,7 +520,7 @@
             : "warning",
         actionLabel:
           testerAuth?.configured && testerAuth?.registrationEnabled
-            ? "Натисни, за да копираш адреса"
+            ? "Копирай адреса за регистрация"
             : "Натисни за активиране",
       }),
       createExternalCard({
@@ -810,11 +810,12 @@
       const origin =
         globalThis.location?.origin || "https://synchron.foundation";
       await globalThis.navigator?.clipboard?.writeText(
-        `${origin.replace(/\/$/u, "")}/`,
+        `${origin.replace(/\/$/u, "")}/register`,
       );
       showTesterAuthResult({
         title: "Адресът за регистрация е копиран",
-        message: "Изпрати го на човека, който иска да създаде профил.",
+        message:
+          "Изпрати го на човека, който иска да създаде профил. Адресът отваря директно регистрацията.",
         anchor: actionCard,
       });
       return;

--- a/tests/authUi.test.js
+++ b/tests/authUi.test.js
@@ -38,6 +38,16 @@ test("registration does not send an invitation code", () => {
   assert.match(app, /password: elements\.registerPassword\.value/u);
 });
 
+test("direct registration address opens the registration form", () => {
+  assert.match(app, /const REGISTRATION_PATH = "\/register"/u);
+  assert.match(app, /isDirectRegistrationPage\(\)/u);
+  assert.match(
+    app,
+    /state\.registrationEnabled && isDirectRegistrationPage\(\)/u,
+  );
+  assert.match(app, /showRegisterForm\(\)/u);
+});
+
 test("hides owner tools for tester profiles and exposes logout", () => {
   assert.match(html, /id="toolsBtn"[^>]*data-owner-only/u);
   assert.match(html, /id="workCenterBtn"[^>]*data-owner-only/u);

--- a/tests/workCenterUi.test.js
+++ b/tests/workCenterUi.test.js
@@ -388,9 +388,10 @@ test("copies the normal registration address", async () => {
 
   assert.equal(
     document.body.dataset.copiedText,
-    "https://synchron.foundation/",
+    "https://synchron.foundation/register",
   );
   assert.match(document.body.textContent, /Адресът за регистрация е копиран/u);
+  assert.match(document.body.textContent, /отваря директно регистрацията/u);
 });
 
 test("tester auth action is visibly actionable on mobile", async () => {


### PR DESCRIPTION
## Какво се променя

- добавя директен адрес `/register`, който отваря формата за регистрация за невлезли потребители
- Работният център копира точния адрес `/register`, вместо началната страница
- текстът потвърждава ясно, че адресът води директно към регистрацията
- запазва собственическата сесия: ако собственикът вече е влязъл, приложението продължава нормално

## Причина

Копираният досега адрес водеше към началната страница. Получателят не стигаше до регистрационната форма и изглеждаше, че кодът или регистрацията не работят, въпреки че в Supabase Auth няма подадена заявка.

## Проверки

- 479/479 автоматични теста
- `git diff --check`
- тест за директния `/register` маршрут
- тест за точния адрес, копиран от Работния център