### PR TITLE
Serve the direct registration route

### DIFF
--- a/server.js
+++ b/server.js
@@ -215,7 +215,7 @@ app.get("/opensearch-status", requireOwnerSession, async (req, res) => {
   }
 });
 
-app.get("/", (req, res) => {
+app.get(["/", "/register"], (req, res) => {
   res.sendFile(`${process.cwd()}/public/index.html`);
 });
 

--- a/tests/protectedRoutes.test.js
+++ b/tests/protectedRoutes.test.js
@@ -14,6 +14,8 @@ const { createGitHubSession } =
 
 test("keeps liveness and sign-in routes public", async () => {
   await request(app).get("/health").expect(200);
+  const registration = await request(app).get("/register").expect(200);
+  assert.match(registration.text, /id="registerForm"/u);
   const config = await request(app).get("/api/public-config").expect(200);
   assert.equal(config.body.chatgptWorkUrl, "https://chatgpt.com/");
   const auth = await request(app).get("/api/auth/session").expect(200);


### PR DESCRIPTION
## Какво се променя

- Express обслужва `/register` със същия проверен екран като началната страница
- добавен е HTTP тест, който изисква статус 200 и налична регистрационна форма

## Причина

Интерфейсът вече копираше директния адрес `/register`, но сървърът обслужваше само `/`. Затова production връщаше `Cannot GET /register`.

## Влияние

Копираният адрес вече отваря директно нормалната регистрация. Supabase, профилите, паметта и собственическият вход не се променят.

## Проверки

- 479/479 автоматични теста
- 32/32 целеви теста
- `git diff --check`