### PR TITLE
Open public registration from www

### DIFF
--- a/public/work-center.js
+++ b/public/work-center.js
@@ -2,6 +2,7 @@
   const REPOSITORY_URL =
     "https://github.com/radostinvgeorgiev-commits/sunchron-backend";
   const MCP_RESOURCE_URL = "https://synchron.foundation/mcp";
+  const PUBLIC_REGISTRATION_URL = "https://www.synchron.foundation";
   const CHATGPT_APP_GUIDE_URL =
     "https://developers.openai.com/apps-sdk/deploy/testing";
   const FALLBACK_CONFIG = Object.freeze({
@@ -807,10 +808,8 @@
       return;
     }
     if (actionCard?.dataset.workCenterAction === "copy-registration-link") {
-      const origin =
-        globalThis.location?.origin || "https://synchron.foundation";
       await globalThis.navigator?.clipboard?.writeText(
-        `${origin.replace(/\/$/u, "")}/register`,
+        PUBLIC_REGISTRATION_URL,
       );
       showTesterAuthResult({
         title: "Адресът за регистрация е копиран",

--- a/server.js
+++ b/server.js
@@ -115,6 +115,15 @@ app.get(
 );
 app.use("/", mcpOAuthRouter);
 
+app.get("/", (req, res, next) => {
+  if (req.hostname.toLowerCase() !== "www.synchron.foundation") {
+    next();
+    return;
+  }
+
+  res.redirect(302, "/register");
+});
+
 app.use(
   express.static("public", {
     maxAge: 0,
@@ -215,7 +224,11 @@ app.get("/opensearch-status", requireOwnerSession, async (req, res) => {
   }
 });
 
-app.get(["/", "/register"], (req, res) => {
+app.get("/", (_req, res) => {
+  res.sendFile(`${process.cwd()}/public/index.html`);
+});
+
+app.get("/register", (_req, res) => {
   res.sendFile(`${process.cwd()}/public/index.html`);
 });
 

--- a/tests/protectedRoutes.test.js
+++ b/tests/protectedRoutes.test.js
@@ -14,6 +14,15 @@ const { createGitHubSession } =
 
 test("keeps liveness and sign-in routes public", async () => {
   await request(app).get("/health").expect(200);
+  const publicEntry = await request(app)
+    .get("/")
+    .set("Host", "www.synchron.foundation")
+    .expect(302);
+  assert.equal(publicEntry.headers.location, "/register");
+  await request(app)
+    .get("/")
+    .set("Host", "synchron.foundation")
+    .expect(200);
   const registration = await request(app).get("/register").expect(200);
   assert.match(registration.text, /id="registerForm"/u);
   const config = await request(app).get("/api/public-config").expect(200);

--- a/tests/workCenterUi.test.js
+++ b/tests/workCenterUi.test.js
@@ -388,7 +388,7 @@ test("copies the normal registration address", async () => {
 
   assert.equal(
     document.body.dataset.copiedText,
-    "https://synchron.foundation/register",
+    "https://www.synchron.foundation",
   );
   assert.match(document.body.textContent, /Адресът за регистрация е копиран/u);
   assert.match(document.body.textContent, /отваря директно регистрацията/u);


### PR DESCRIPTION
## Какво се променя

- `www.synchron.foundation` отваря директно публичната регистрация.
- Основният адрес `synchron.foundation` запазва началната страница.
- Бутонът за копиране дава краткия публичен адрес `www.synchron.foundation`.
- Добавени са регресионни проверки за двата хоста и публичния `/register` маршрут.

## Причина

Досегашният адрес за регистрация зависеше от `/register`, а отварянето през `www` не водеше директно до регистрационния екран.

## Проверки

- Целеви тестове: 25/25 успешни.
- Пълен тестов пакет: 479/479 успешни.
- `git diff --check`: успешно.

## Влияние

След сливане и потвърден DNS запис за `www`, всеки посетител на `www.synchron.foundation` ще вижда директно нормалната регистрация.