### PR TITLE
Restore working public registration link

### DIFF
--- a/public/work-center.js
+++ b/public/work-center.js
@@ -2,7 +2,7 @@
   const REPOSITORY_URL =
     "https://github.com/radostinvgeorgiev-commits/sunchron-backend";
   const MCP_RESOURCE_URL = "https://synchron.foundation/mcp";
-  const PUBLIC_REGISTRATION_URL = "https://www.synchron.foundation";
+  const PUBLIC_REGISTRATION_URL = "https://synchron.foundation/register";
   const CHATGPT_APP_GUIDE_URL =
     "https://developers.openai.com/apps-sdk/deploy/testing";
   const FALLBACK_CONFIG = Object.freeze({

--- a/tests/workCenterUi.test.js
+++ b/tests/workCenterUi.test.js
@@ -388,7 +388,7 @@ test("copies the normal registration address", async () => {
 
   assert.equal(
     document.body.dataset.copiedText,
-    "https://www.synchron.foundation",
+    "https://synchron.foundation/register",
   );
   assert.match(document.body.textContent, /Адресът за регистрация е копиран/u);
   assert.match(document.body.textContent, /отваря директно регистрацията/u);


### PR DESCRIPTION
## Какво се променя

- Връща публичния адрес за регистрация към работещия `https://synchron.foundation/register`.
- Актуализира автоматичния тест за копирания адрес.

## Причина

След последното публикуване приложението на основния домейн работи, но `www.synchron.foundation` връща 502 от DNS/прокси слоя. Бутонът в Работния център разпространяваше този неработещ адрес и за потребителя изглеждаше като бял екран.

## Ефект

Новите потребители отново получават работеща директна регистрация. Това е временна безопасна мярка до отделното оправяне на `www` DNS/проксито.

## Проверки

- `node --test tests/workCenterUi.test.js tests/protectedRoutes.test.js` — 25/25 успешни
- `npm test` — 479/479 успешни
- `git diff --check` — успешно