### PR TITLE
Route www domain through DigitalOcean

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,5 +1,11 @@
 name: sunchron-backend
 
+domains:
+  - domain: synchron.foundation
+    type: PRIMARY
+  - domain: www.synchron.foundation
+    type: ALIAS
+
 services:
   - name: web
     github:


### PR DESCRIPTION
## Какво се променя

- добавя `synchron.foundation` като основен домейн в App Platform спецификацията;
- добавя `www.synchron.foundation` като alias към същото приложение.

## Причина

Cloudflare изпраща `www.synchron.foundation` към DigitalOcean, но App Platform не разпознава hostname-а и връща origin 404. Основният домейн работи.

## Риск

Нисък и обратим. Променя се само домейн маршрутизацията; приложението, данните, паметта и профилите не се променят.

## Проверка

- diff: само `.do/app.yaml`, 6 добавени реда;
- синтаксисът следва официалната DigitalOcean App Spec структура `domains` с `PRIMARY` и `ALIAS`.