### PR TITLE
Allow the confirmed www domain action

### DIFF
--- a/src/services/confirmationService.js
+++ b/src/services/confirmationService.js
@@ -16,6 +16,7 @@ const ALLOWED_ACTIONS = new Set([
   "github.copilot:start_task",
   "github.write:delete_merged_branches",
   "infrastructure.digitalocean:activate_tester_auth",
+  "infrastructure.digitalocean:add_www_domain",
   "calendar.write:create_event",
   "memory.write:save_profile",
   "memory.delete:profile",

--- a/tests/confirmationService.test.js
+++ b/tests/confirmationService.test.js
@@ -36,6 +36,17 @@ test("rejects unknown actions", () => {
   assert.equal(isAllowedAction(""), false);
 });
 
+test("allows only the exact confirmed DigitalOcean www domain action", () => {
+  assert.equal(
+    isAllowedAction("infrastructure.digitalocean:add_www_domain"),
+    true,
+  );
+  assert.equal(
+    isAllowedAction("infrastructure.digitalocean:add_other_domain"),
+    false,
+  );
+});
+
 test("blocks every legacy direct GitHub write action", () => {
   for (const action of [
     "github.write:create_file",


### PR DESCRIPTION
## Какво се променя

- добавя само `infrastructure.digitalocean:add_www_domain` към изричния allowlist за еднократни потвърждения;
- запазва блокирани всички други непознати инфраструктурни действия;
- не извършва DigitalOcean или DNS запис.

## Причина

Production върна `UNKNOWN_ACTION` преди да извика DigitalOcean. Новият owner-only поток беше защитен и потвърден, но точният му action липсваше в deny-by-default регистъра.

## Проверки

- 25 насочени теста: успешно;
- пълен `npm test`: 499/499 успешно;
- `git diff --check`: успешно.