### PR TITLE
Add confirmed www domain MCP flow

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -173,6 +173,8 @@ jobs:
                     "get_digitalocean_app_status",
                     "get_system_configuration",
                     "get_digitalocean_account_audit",
+                    "prepare_digitalocean_www_domain",
+                    "confirm_digitalocean_www_domain",
                     "get_cloudflare_zone_status",
                     "get_github_copilot_task_status",
                     "prepare_github_merged_branch_cleanup",
@@ -185,12 +187,20 @@ jobs:
                   const trackerScopes = tracker?.securitySchemes?.flatMap(
                     (scheme) => scheme.scopes || [],
                   ) || [];
+                  const confirmWww = tools?.find(
+                    (tool) => tool.name === "confirm_digitalocean_www_domain",
+                  );
+                  const confirmWwwScopes = confirmWww?.securitySchemes?.flatMap(
+                    (scheme) => scheme.scopes || [],
+                  ) || [];
                   const valid =
                     names.length === expected.length &&
                     new Set(names).size === names.length &&
                     expected.every((name) => names.includes(name)) &&
                     tracker?.annotations?.readOnlyHint === true &&
-                    trackerScopes.includes("synchron:read");
+                    trackerScopes.includes("synchron:read") &&
+                    confirmWww?.annotations?.destructiveHint === true &&
+                    confirmWwwScopes.includes("synchron:infrastructure.write");
                   console.log(JSON.stringify({ names, trackerReadOnly: tracker?.annotations?.readOnlyHint }));
                   process.exit(valid ? 0 : 1);
                 } catch {

--- a/docs/BRIDGE_AND_DIAGNOSTICS.md
+++ b/docs/BRIDGE_AND_DIAGNOSTICS.md
@@ -2,8 +2,10 @@
 
 ## Какво работи
 
-SYNCHRON-X има MCP Streamable HTTP адрес `/mcp` и 11 инструмента: 10 само за
-четене и един двустъпков потвърждаван cleanup flow. Основните read инструменти
+SYNCHRON-X има MCP Streamable HTTP адрес `/mcp` и 13 инструмента: 11 само за
+четене и два двустъпкови потвърждавани write flow-а. Освен GitHub cleanup,
+мостът подготвя и потвърждава добавянето само на `www.synchron.foundation`
+към предварително провереното DigitalOcean приложение. Основните read инструменти
 включват:
 
 - `get_personal_context`;

--- a/src/routes/digitalOceanDomainAdminRouter.js
+++ b/src/routes/digitalOceanDomainAdminRouter.js
@@ -1,6 +1,7 @@
 import express from "express";
 import {
   activateDigitalOceanDomainAlias,
+  DIGITALOCEAN_DOMAIN_ACTION,
   inspectDigitalOceanDomainAlias,
   PUBLIC_WWW_DOMAIN,
 } from "../services/digitalOceanService.js";
@@ -15,8 +16,7 @@ import {
 } from "../services/permissionService.js";
 import { logSafeError, safeErrorCode } from "../utils/safeLogging.js";
 
-export const DIGITALOCEAN_DOMAIN_ACTION =
-  "infrastructure.digitalocean:add_www_domain";
+export { DIGITALOCEAN_DOMAIN_ACTION };
 
 async function safeAudit(audit, event) {
   try {

--- a/src/routes/mcpOAuthRouter.js
+++ b/src/routes/mcpOAuthRouter.js
@@ -13,6 +13,11 @@ import {
 
 const formParser = express.urlencoded({ extended: false, limit: "16kb" });
 const passThrough = (_req, _res, next) => next();
+const SCOPE_LABELS = Object.freeze({
+  "synchron:read": "Четене на разрешените данни и системни статуси",
+  "synchron:github.write": "Потвърждавани промени в GitHub",
+  "synchron:infrastructure.write": "Потвърждавани промени в инфраструктурата",
+});
 
 function noStore(res) {
   res.set("Cache-Control", "no-store");
@@ -58,10 +63,13 @@ function consentPage(request, identity, csrfToken) {
     )
     .join("");
   const rights = request.scopes
-    .map((scope) => `<li>${escapeHtml(scope)}</li>`)
+    .map(
+      (scope) =>
+        `<li>${escapeHtml(SCOPE_LABELS[scope] || scope)} <small>(${escapeHtml(scope)})</small></li>`,
+    )
     .join("");
   const callbackHost = new URL(request.redirectUri).hostname;
-  return `<!doctype html><html lang="bg"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>AI CORE OAuth</title><style>body{font-family:system-ui;background:#08111f;color:#eef4ff;display:grid;place-items:center;min-height:100vh;margin:0}.card{max-width:520px;background:#111e31;padding:28px;border-radius:18px}button{font-size:18px;padding:12px 18px;border:0;border-radius:10px;margin-right:8px}.allow{background:#4f8cff;color:white}.deny{background:#26364d;color:white}</style></head><body><main class="card"><h1>Свързване на ChatGPT със AI CORE</h1><p>Влязъл си като <strong>${escapeHtml(identity.displayName || identity.id)}</strong>.</p><p>Клиент: <strong>${escapeHtml(request.clientName || "ChatGPT")}</strong> · callback: <strong>${escapeHtml(callbackHost)}</strong></p><p>ChatGPT иска следните права:</p><ul>${rights}</ul><p>Опасните GitHub действия продължават да изискват отделно точно потвърждение.</p><form method="post" action="/oauth/authorize">${hidden}<button class="allow" name="decision" value="allow" type="submit">Разреши</button><button class="deny" name="decision" value="deny" type="submit">Откажи</button></form></main></body></html>`;
+  return `<!doctype html><html lang="bg"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>AI CORE OAuth</title><style>body{font-family:system-ui;background:#08111f;color:#eef4ff;display:grid;place-items:center;min-height:100vh;margin:0}.card{max-width:520px;background:#111e31;padding:28px;border-radius:18px}button{font-size:18px;padding:12px 18px;border:0;border-radius:10px;margin-right:8px}.allow{background:#4f8cff;color:white}.deny{background:#26364d;color:white}</style></head><body><main class="card"><h1>Свързване на ChatGPT със AI CORE</h1><p>Влязъл си като <strong>${escapeHtml(identity.displayName || identity.id)}</strong>.</p><p>Клиент: <strong>${escapeHtml(request.clientName || "ChatGPT")}</strong> · callback: <strong>${escapeHtml(callbackHost)}</strong></p><p>ChatGPT иска следните права:</p><ul>${rights}</ul><p>Всяко действие за запис продължава да изисква отделно точно потвърждение.</p><form method="post" action="/oauth/authorize">${hidden}<button class="allow" name="decision" value="allow" type="submit">Разреши</button><button class="deny" name="decision" value="deny" type="submit">Откажи</button></form></main></body></html>`;
 }
 
 function loginRequiredPage() {

--- a/src/services/digitalOceanService.js
+++ b/src/services/digitalOceanService.js
@@ -4,6 +4,8 @@ const DEFAULT_API_URL = "https://api.digitalocean.com/v2";
 const DEFAULT_APP_NAME = "sunchron-backend";
 const PRIMARY_PUBLIC_DOMAIN = "synchron.foundation";
 export const PUBLIC_WWW_DOMAIN = "www.synchron.foundation";
+export const DIGITALOCEAN_DOMAIN_ACTION =
+  "infrastructure.digitalocean:add_www_domain";
 export const TESTER_AUTH_ENV_KEYS = Object.freeze([
   "SUPABASE_URL",
   "SUPABASE_PUBLISHABLE_KEY",
@@ -126,9 +128,7 @@ async function request(
         headers: {
           Accept: "application/json",
           Authorization: `Bearer ${token}`,
-          ...(body === undefined
-            ? {}
-            : { "Content-Type": "application/json" }),
+          ...(body === undefined ? {} : { "Content-Type": "application/json" }),
         },
         ...(body === undefined ? {} : { body: JSON.stringify(body) }),
       },

--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -10,740 +10,198 @@ import { getOpenSearchClient } from "../config/opensearch.js";
 export const DEFAULT_MCP_RESOURCE_URL = "https://synchron.foundation/mcp";
 export const MCP_READ_SCOPE = "synchron:read";
 export const MCP_GITHUB_WRITE_SCOPE = "synchron:github.write";
+export const MCP_INFRASTRUCTURE_WRITE_SCOPE = "synchron:infrastructure.write";
 export const MCP_SCOPES = Object.freeze([
   MCP_READ_SCOPE,
   MCP_GITHUB_WRITE_SCOPE,
+  MCP_INFRASTRUCTURE_WRITE_SCOPE,
 ]);
+const MCP_OWNER_ONLY_SCOPES = Object.freeze([
+  MCP_GITHUB_WRITEÛv¶‰ËkºwµçY˜[ÙNÂˆÛÛœİÜİH\›šÜİ˜[YKÓİÙ\Ø\ÙJ
+NÂˆ™]\›ˆ
+ˆÜİOOH˜Ú]Ü˜ÛÛHˆˆÜİ™[™ÕÚ]
+‹˜Ú]Ü˜ÛÛHŠHˆÜİOOH›Ü[˜ZK˜ÛÛHˆˆÜİ™[™ÕÚ]
+‹›Ü[˜ZK˜ÛÛHŠBˆ
+NÂˆHØ]ÚÂˆ™]\›ˆ˜[ÙNÂˆBŸB‚™^Ü\Ş[˜È[˜İ[Ûˆ˜[Y]SXÜ]]Üš^˜][Û”™\]Y\İ
+ˆ[œ]ˆÈ[ˆH›ØÙ\ÜË™[‹™]Ú[\H™]ÚHHßKŠHÂˆÛÛœİ™\Ûİ\˜ÙHH™\ÛÛ™SXÜ™\Ûİ\˜ÙU\›
+[ŠNÂˆÛÛœİÛY[YHİš[™Ê[œ]Ë˜ÛY[ÚYˆŠKš[J
+NÂˆÛÛœİ™Y\™Xİ\šHHİš[™Ê[œ]Ëœ™Y\™Xİİ\šHˆŠKš[J
+NÂˆÛÛœİİ]HHİš[™Ê[œ]Ëœİ]HˆŠKš[J
+NÂˆÛÛœİÛÙPÚ[[™ÙHHİš[™Ê[œ]Ë˜ÛÙWØÚ[[™ÙHˆŠKš[J
+NÂ‚ˆYˆ
+[œ]Ëœ™\ÜÛœÙWİ\HOOH˜ÛÙHŠHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´'ô/´-4-4b´`4-´,4`t-H4`t,4/4/ˆ]]Üš^˜][ÛˆÛÙKˆŠNÂˆBˆYˆ
+Z\Ğ[İÙYÜ[ZPÛY[Y
+ÛY[Y
+JHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´'t-t/ô/´-ô/t,4`ˆĞ]]4.´.ô.4-t/t`‹ˆ‹š[˜[YØÛY[ŠNÂˆBˆYˆ
+\İ]Hİ]K›[™İˆWÌ
+HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´&ô.4/ô`t,´,4,´,4.ô.4-4/t/ˆĞ]]4`tb´`t`´/´cô/t.4-KˆŠNÂˆBˆYˆ
+ˆ[œ]Ë˜ÛÙWØÚ[[™ÙWÛY]ÙOOH”ÌMˆˆˆK×–ĞKV˜K^ŒNWËW^ÍËLIİK\İ
+ÛÙPÚ[[™ÙJBˆ
+HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´&4-ô.4`t.´,´,4`t-HĞÑHÌM‹ˆŠNÂˆBˆYˆ
+İš[™Ê[œ]Ëœ™\Ûİ\˜ÙHˆŠHOOH™\Ûİ\˜ÙJHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´'t-t,´,4.ô.4-4-t/HPÔ™\Ûİ\˜ÙKˆ‹š[˜[Yİ\™Ù]ŠNÂˆB‚ˆ]Y]Y]NÂˆHÂˆÛÛœİ™\ÜÛœÙHH]ØZ]™]Ú[\
+ÛY[YÂˆXY\œÎˆÈXØÙ\ˆ˜\XØ][Û‹ÚœÛÛˆˆKˆ™Y\™Xİˆ™\œ›Üˆ‹ˆÚYÛ˜[ˆX›ÜÚYÛ˜[[Y[İ]
+WÌ
+KˆJNÂˆYˆ
+\™\ÜÛœÙK›ÚÊH›İÈ™]È\œ›ÜŠÓQS•ÓQUQUWÕSURSP“HŠNÂˆY]Y]HH]ØZ]™\ÜÛœÙKšœÛÛŠ
+NÂˆHØ]ÚÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ“Ğ]]4.´.ô.4-t/t`´b´`ˆ4/t-H4/4/´-´-H4-4,4,tb´-4-H4/ô`4/´,´-t`4-t/Kˆ‹ˆˆš[˜[YØÛY[‹ˆ
+NÂˆB‚ˆYˆ
+ˆY]Y]OË˜ÛY[ÚYOOHÛY[Yˆ\[ÙˆY]Y]OË˜ÛY[Û˜[YHOOHœİš[™Èˆˆ[Y]Y]K˜ÛY[Û˜[YKš[J
+HˆP\œ˜^Kš\Ğ\œ˜^JY]Y]Kœ™Y\™Xİİ\š\ÊHˆ[Y]Y]Kœ™Y\™Xİİ\š\Ëš[˜ÛY\Ê™Y\™Xİ\šJHˆJˆY]Y]KÚÙ[—Ù[™Ú[Ø]]ÛY]ÙOOH››Û™HˆˆY]Y]KÚÙ[—Ù[™Ú[Ø]]ÛY]Ù×Üİ\ÜYËš[˜ÛY\ÏËŠ››Û™HŠBˆ
+Bˆ
+HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ“Ğ]]Ø[˜XÚÈ4,4-4`4-t`tb´`ˆ4/t-H4-H4`4,4-ô`4-tb4-t/H4/´`ˆ4.´.ô.4-t/t`´,ˆ‹ˆˆš[˜[YØÛY[‹ˆ
+NÂˆB‚ˆ™]\›ˆÂˆÛY[YˆÛY[˜[YNˆY]Y]K˜ÛY[Û˜[YKš[J
+Kˆ™Y\™Xİ\šKˆİ]KˆÛÙPÚ[[™ÙKˆ™\Ûİ\˜ÙKˆØÛÜ\Îˆ\œÙTØÛÜ\Ê[œ]ËœØÛÜJKˆNÂŸB‚™^Ü[˜İ[ÛˆÜ™X]SXÜ]]Üš^˜][ÛÛÙJˆ™\]Y\İˆY[]Kˆ[ˆH›ØÙ\ÜË™[‹ŠHÂˆYˆ
+ZY[]OËšYZY[]OË›Y[[ÜSİÛ™\’YZY[]OËœ›ÛJHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´&ô.4/ô`t,´,4,´,4.ô.4-4-t/HÖSÒ“Ó‹V4/ô`4/´a4.4.Ëˆ‹JNÂˆBˆYˆ
+™\]Z\™\ÓİÛ™\”›ÛJ™\]Y\İœØÛÜ\ÊH	‰ˆY[]Kœ›ÛHOOH›İÛ™\ˆŠHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ“PÔ4-ô,4/ô.4`tb´`ˆ4-H4-4/´`t`´b´/ô-t/H4`t,4/4/ˆ4-ô,4`t/´,t`t`´,´-t/t.4.´,ˆ‹ˆËˆ˜XØÙ\Ü×Ù[šYY‹ˆ
+NÂˆBˆÛÛœİ›İÈHX]™›ÛÜŠ]K››İÊ
+HÈWÌ
+NÂˆ™]\›ˆ[˜Ü\^[ØY
+ˆœŞXÛÙH‹ˆÂˆ\ˆ˜]]Üš^˜][Û—ØÛÙH‹ˆNˆ˜[™ÛP]\ÊN
+KÔİš[™Ê˜˜\ÙM\›ŠKˆ\ÜÎˆ™\ÛÛ™SXÜ\ÜİY\•\›
+[ŠKˆ]Yˆ™\]Y\İœ™\Ûİ\˜ÙKˆÛY[Yˆ™\]Y\İ˜ÛY[Yˆ™Y\™Xİ\šNˆ™\]Y\İœ™Y\™Xİ\šKˆÛÙPÚ[[™ÙNˆ™\]Y\İ˜ÛÙPÚ[[™ÙKˆØÛÜ\Îˆ™\]Y\İœØÛÜ\ËˆİXš™Xİˆİš[™ÊY[]KšY
+KˆY[[ÜSİÛ™\’Yˆİš[™ÊY[]K›Y[[ÜSİÛ™\’Y
+Kˆ›ÛNˆİš[™ÊY[]Kœ›ÛJKˆX]ˆ›İËˆ^ˆ›İÈ
+ÈUUÔ’VUSÓ—ĞÓÑWÕÔÑPÓÓ‘ËˆKˆÜ˜[ÙXÜ™]
+[ŠKˆ
+NÂŸB‚™[˜İ[ÛˆØY™Tİš[™Ñ\]X[
+YšYÚ
+HÂˆÛÛœİHHY™™\‹™œ›ÛJİš[™ÊY
+K]ŠNÂˆÛÛœİˆHY™™\‹™œ›ÛJİš[™ÊšYÚ
+K]ŠNÂˆ™]\›ˆK›[™İOOH‹›[™İ	‰ˆ[Z[™ÔØY™Q\]X[
+KŠNÂŸB‚™[˜İ[ÛˆØ\ÕÚÙ[ÛÛœİ[YY
+İÜ™KÚÙ[’Y›İÊHÂˆ›Üˆ
+ÛÛœİÜİÜ™YY^\™\Ğ]HÙˆİÜ™JHÂˆYˆ
+^\™\Ğ]H›İÊHİÜ™K™[]JİÜ™YY
+NÂˆBˆ™]\›ˆİÜ™Kš\ÊÚÙ[’Y
+NÂŸB‚™[˜İ[ÛˆX\šÕÚÙ[ÛÛœİ[YY
+İÜ™KÚÙ[’Y^\™\Ğ]
+HÂˆİÜ™KœÙ]
+ÚÙ[’Y^\™\Ğ]
+NÂˆÚ[H
+İÜ™KœÚ^™HˆPVĞÓÓ”ÕSQQÕÒÑS—Ô‘PÓÔ‘ÊHÂˆİÜ™K™[]JİÜ™KšÙ^\Ê
+K›™^
 
-const ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
-const REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
-const AUTHORIZATION_CODE_TTL_SECONDS = 5 * 60;
-const MAX_CONSUMED_TOKEN_RECORDS = 10_000;
-const REPLAY_CLEANUP_INTERVAL_SECONDS = 6 * 60 * 60;
-const MCP_OAUTH_REPLAY_INDEX =
-  process.env.MCP_OAUTH_REPLAY_INDEX || "synchron-mcp-oauth-replay-v1";
-const consumedAuthorizationCodes = new Map();
-const consumedRefreshTokens = new Map();
-let lastReplayCleanupAt = 0;
-let activeReplayCleanup = null;
+K˜[YJNÂˆBŸB‚™[˜İ[Ûˆ™\^TİÜ™JÜ˜[\JHÂˆ™]\›ˆÜ˜[\HOOH˜]]Üš^˜][Û—ØÛÙH‚ˆÈÛÛœİ[YY]]Üš^˜][ÛÛÙ\ÂˆˆÛÛœİ[YY™Yœ™\ÚÚÙ[œÎÂŸB‚™[˜İ[Ûˆ™\^T™XÛÜ™Y
+Ü˜[\KÚÙ[’Y
+HÂˆ™]\›ˆÜ™X]R\Ú
+œÚLMˆŠBˆ\]Jİš[™ÊÜ˜[\JJBˆ\]J—ŠBˆ\]Jİš[™ÊÚÙ[’Y
+JBˆ™YÙ\İ
+š^ŠNÂŸB‚™[˜İ[ÛˆÜ[”ÙX\˜Úİ]\Ê\œ›ÜŠHÂˆ™]\›ˆ\œ›ÜËœİ]\ĞÛÙH\œ›ÜË›Y]OËœİ]\ĞÛÙHÂŸB‚™^Ü[˜İ[Ûˆ™\]Z\™\Ô\œÚ\İ[XÜ™\^QİX\™
+[ˆH›ØÙ\ÜË™[ŠHÂˆ™]\›ˆ[‹““ÑWÑS•ˆOOHœ›ÙXİ[ÛˆÂŸB‚™^Ü\Ş[˜È[˜İ[ÛˆÛX[\^\™YXÜ™\^T™XÛÜ™ÊÂˆÛY[HÙ]Ü[”ÙX\˜ÚÛY[
 
-export class McpOAuthError extends Error {
-  constructor(
-    message,
-    status = 400,
-    code = "invalid_request",
-    description = message,
-  ) {
-    super(message);
-    this.name = "McpOAuthError";
-    this.status = status;
-    this.code = code;
-    this.description = description;
-  }
-}
+Kˆ[ˆH›ØÙ\ÜË™[‹ˆ›İÈHX]™›ÛÜŠ]K››İÊ
+HÈWÌ
+Kˆ›Ü˜ÙHH˜[ÙKŸHHßJHÂˆYˆ
+XÛY[\[ÙˆÛY[™[]PT]Y\HOOH™[˜İ[ÛˆŠH™]\›ˆ˜[ÙNÂˆYˆ
+Xİ]™T™\^PÛX[\
+H™]\›ˆXİ]™T™\^PÛX[\ÂˆYˆ
+ˆY›Ü˜ÙH	‰‚ˆ\İ™\^PÛX[\]ˆ	‰‚ˆ›İÈH\İ™\^PÛX[\]‘TVWĞÓPS•TÒS•T•SÔÑPÓÓ‘Âˆ
+HÂˆ™]\›ˆ˜[ÙNÂˆB‚ˆ\İ™\^PÛX[\]H›İÎÂˆXİ]™T™\^PÛX[\HÛY[ˆ™[]PT]Y\JÂˆ[™^ˆ[‹“PÔÓĞUUÔ‘TVWÒS‘VPÔÓĞUUÔ‘TVWÒS‘VˆÛÛ™›XİÎˆœ›ØÙYY‹ˆ™Yœ™\Úˆ˜[ÙKˆ›ÙNˆÂˆ]Y\NˆÂˆ˜[™ÙNˆÂˆ^\™\Ğ]ˆÈNˆ™]È]J›İÈ
+ˆWÌ
+KÒTÓÔİš[™Ê
+HKˆKˆKˆKˆJBˆ[Š
 
-function normalizeHttpsUrl(value, fallback = "") {
-  try {
-    const url = new URL(String(value || fallback).trim());
-    if (url.protocol !== "https:") return "";
-    url.hash = "";
-    url.search = "";
-    return url.href.replace(/\/$/u, "");
-  } catch {
-    return "";
-  }
-}
+HOˆYJBˆ˜Ø]Ú
 
-export function resolveMcpResourceUrl(env = process.env) {
-  return (
-    normalizeHttpsUrl(env.MCP_RESOURCE_URL) ||
-    normalizeHttpsUrl(DEFAULT_MCP_RESOURCE_URL)
-  );
-}
+\œ›ÜŠHOˆÂˆYˆ
+Ü[”ÙX\˜Úİ]\Ê\œ›ÜŠHOOH
+HÂˆÛÛœÛÛK™\œ›ÜŠ–ÓPÔĞ]]™\^WH^\™Y\™XÛÜ™ÛX[\˜Z[YˆŠNÂˆBˆ™]\›ˆÜ[”ÙX\˜Úİ]\Ê\œ›ÜŠHOOHÂˆJBˆ™š[˜[J
 
-export function resolveMcpIssuerUrl(env = process.env) {
-  return new URL(resolveMcpResourceUrl(env)).origin;
-}
+HOˆÂˆXİ]™T™\^PÛX[\H[ÂˆJNÂ‚ˆ™]\›ˆXİ]™T™\^PÛX[\ÂŸB‚™^Ü\Ş[˜È[˜İ[ÛˆÛÛœİ[YSXÜÜ˜[Û˜ÙJÂˆÜ˜[\KˆÚÙ[’Yˆ^\™\Ğ]ˆ[ˆH›ØÙ\ÜË™[‹ˆÛY[HÙ]Ü[”ÙX\˜ÚÛY[
 
-function deriveOAuthSecret(label, source) {
-  return createHash("sha256").update(`${label}\0`).update(source).digest();
-}
-
-function legacyOAuthSecret(env = process.env) {
-  const source =
-    typeof env.MCP_ACCESS_TOKEN === "string" ? env.MCP_ACCESS_TOKEN.trim() : "";
-  if (source.length < 32) {
-    throw new McpOAuthError(
-      "MCP OAuth Ğ·Ğ°Ñ‰Ğ¸Ñ‚Ğ°Ñ‚Ğ° Ğ½Ğµ Ğµ ĞºĞ¾Ğ½Ñ„Ğ¸Ğ³ÑƒÑ€Ğ¸Ñ€Ğ°Ğ½Ğ°.",
-      503,
-      "temporarily_unavailable",
-    );
-  }
-  return deriveOAuthSecret("synchron-mcp-oauth-v1", source);
-}
-
-function dedicatedOAuthSecret(env = process.env) {
-  const source =
-    typeof env.MCP_OAUTH_SECRET === "string" ? env.MCP_OAUTH_SECRET.trim() : "";
-  if (!source) return null;
-  if (source.length < 32) {
-    throw new McpOAuthError(
-      "ĞÑ‚Ğ´ĞµĞ»Ğ½Ğ¸ÑÑ‚ MCP OAuth ĞºĞ»ÑÑ‡ Ğµ Ğ½ĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½.",
-      503,
-      "temporarily_unavailable",
-    );
-  }
-  return deriveOAuthSecret("synchron-mcp-oauth-dedicated-v1", source);
-}
-
-function oauthSecret(env = process.env) {
-  return dedicatedOAuthSecret(env) || legacyOAuthSecret(env);
-}
-
-function oauthVerificationSecrets(env = process.env) {
-  const dedicated = dedicatedOAuthSecret(env);
-  if (!dedicated) return [legacyOAuthSecret(env)];
-  const secrets = [dedicated];
-  try {
-    const legacy = legacyOAuthSecret(env);
-    if (!legacy.equals(dedicated)) secrets.push(legacy);
-  } catch {
-    // A dedicated key can run OAuth without enabling the legacy bearer.
-  }
-  return secrets;
-}
-
-function deriveGrantSecret(secret) {
-  return createHash("sha256")
-    .update(secret)
-    .update("synchron-mcp-oauth-grants-v2\0")
-    .digest();
-}
-
-function grantSecret(env = process.env) {
-  return deriveGrantSecret(oauthSecret(env));
-}
-
-function grantVerificationSecrets(env = process.env) {
-  return oauthVerificationSecrets(env).map(deriveGrantSecret);
-}
-
-export function getMcpOAuthSecretMode(env = process.env) {
-  if (dedicatedOAuthSecret(env)) return "dedicated";
-  legacyOAuthSecret(env);
-  return "legacy_fallback";
-}
-
-export function isMcpOAuthConfigured(env = process.env) {
-  try {
-    return Boolean(resolveMcpResourceUrl(env) && oauthSecret(env));
-  } catch {
-    return false;
-  }
-}
-
-export function getMcpProtectedResourceMetadata(env = process.env) {
-  const resource = resolveMcpResourceUrl(env);
-  return {
-    resource,
-    authorization_servers: [resolveMcpIssuerUrl(env)],
-    scopes_supported: MCP_SCOPES,
-  };
-}
-
-export function getMcpAuthorizationServerMetadata(env = process.env) {
-  const issuer = resolveMcpIssuerUrl(env);
-  return {
-    issuer,
-    authorization_endpoint: `${issuer}/oauth/authorize`,
-    token_endpoint: `${issuer}/oauth/token`,
-    client_id_metadata_document_supported: true,
-    token_endpoint_auth_methods_supported: ["none"],
-    response_types_supported: ["code"],
-    grant_types_supported: ["authorization_code", "refresh_token"],
-    code_challenge_methods_supported: ["S256"],
-    scopes_supported: MCP_SCOPES,
-  };
-}
-
-export function requiredScopesForMcpTool(name) {
-  return name === "prepare_github_merged_branch_cleanup" ||
-    name === "confirm_github_merged_branch_cleanup"
-    ? [MCP_GITHUB_WRITE_SCOPE]
-    : [MCP_READ_SCOPE];
-}
-
-export function mcpToolSecuritySchemes(name) {
-  return Object.freeze([
-    Object.freeze({
-      type: "oauth2",
-      scopes: Object.freeze(requiredScopesForMcpTool(name)),
-    }),
-  ]);
-}
-
-export function buildMcpAuthenticateChallenge(
-  scopes = [MCP_READ_SCOPE],
-  env = process.env,
-  { error, description } = {},
-) {
-  const safeHeaderValue = (value) =>
-    String(value).replace(/[^\x20-\x7E]|["\\]/gu, "");
-  const origin = resolveMcpIssuerUrl(env);
-  const values = [
-    `resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
-    `scope="${scopes.join(" ")}"`,
-  ];
-  if (error) values.push(`error="${safeHeaderValue(error)}"`);
-  if (description) {
-    values.push(`error_description="${safeHeaderValue(description)}"`);
-  }
-  return `Bearer ${values.join(", ")}`;
-}
-
-function encryptPayload(prefix, payload, key) {
-  const iv = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, iv);
-  const ciphertext = Buffer.concat([
-    cipher.update(JSON.stringify(payload), "utf8"),
-    cipher.final(),
-  ]);
-  return `${prefix}.${Buffer.concat([
-    iv,
-    cipher.getAuthTag(),
-    ciphertext,
-  ]).toString("base64url")}`;
-}
-
-function decryptPayload(value, prefix, key) {
-  if (typeof value !== "string" || !value.startsWith(`${prefix}.`)) return null;
-  try {
-    const data = Buffer.from(value.slice(prefix.length + 1), "base64url");
-    if (data.length < 29) return null;
-    const decipher = createDecipheriv("aes-256-gcm", key, data.subarray(0, 12));
-    decipher.setAuthTag(data.subarray(12, 28));
-    const plaintext = Buffer.concat([
-      decipher.update(data.subarray(28)),
-      decipher.final(),
-    ]).toString("utf8");
-    return JSON.parse(plaintext);
-  } catch {
-    return null;
-  }
-}
-
-function decryptPayloadWithFallback(value, prefix, keys) {
-  for (const key of keys) {
-    const payload = decryptPayload(value, prefix, key);
-    if (payload) return payload;
-  }
-  return null;
-}
-
-function parseScopes(value) {
-  const scopes = [...new Set(String(value || MCP_READ_SCOPE).split(/\s+/u))]
-    .map((scope) => scope.trim())
-    .filter(Boolean);
-  if (
-    scopes.length === 0 ||
-    scopes.some((scope) => !MCP_SCOPES.includes(scope))
-  ) {
-    throw new McpOAuthError(
-      "ĞŸĞ¾Ğ¸ÑĞºĞ°Ğ½Ğ¸Ñ‚Ğµ MCP Ğ¿Ñ€Ğ°Ğ²Ğ° Ğ½Ğµ ÑĞµ Ğ¿Ğ¾Ğ´Ğ´ÑŠÑ€Ğ¶Ğ°Ñ‚.",
-      400,
-      "invalid_scope",
-    );
-  }
-  return scopes;
-}
-
-function isAllowedOpenAiClientId(value) {
-  try {
-    const url = new URL(value);
-    if (url.protocol !== "https:" || url.username || url.password) return false;
-    const host = url.hostname.toLowerCase();
-    return (
-      host === "chatgpt.com" ||
-      host.endsWith(".chatgpt.com") ||
-      host === "openai.com" ||
-      host.endsWith(".openai.com")
-    );
-  } catch {
-    return false;
-  }
-}
-
-export async function validateMcpAuthorizationRequest(
-  input,
-  { env = process.env, fetchImpl = fetch } = {},
-) {
-  const resource = resolveMcpResourceUrl(env);
-  const clientId = String(input?.client_id || "").trim();
-  const redirectUri = String(input?.redirect_uri || "").trim();
-  const state = String(input?.state || "").trim();
-  const codeChallenge = String(input?.code_challenge || "").trim();
-
-  if (input?.response_type !== "code") {
-    throw new McpOAuthError("ĞŸĞ¾Ğ´Ğ´ÑŠÑ€Ğ¶Ğ° ÑĞµ ÑĞ°Ğ¼Ğ¾ authorization code.");
-  }
-  if (!isAllowedOpenAiClientId(clientId)) {
-    throw new McpOAuthError("ĞĞµĞ¿Ğ¾Ğ·Ğ½Ğ°Ñ‚ OAuth ĞºĞ»Ğ¸ĞµĞ½Ñ‚.", 400, "invalid_client");
-  }
-  if (!state || state.length > 1_000) {
-    throw new McpOAuthError("Ğ›Ğ¸Ğ¿ÑĞ²Ğ° Ğ²Ğ°Ğ»Ğ¸Ğ´Ğ½Ğ¾ OAuth ÑÑŠÑÑ‚Ğ¾ÑĞ½Ğ¸Ğµ.");
-  }
-  if (
-    input?.code_challenge_method !== "S256" ||
-    !/^[A-Za-z0-9_-]{43,128}$/u.test(codeChallenge)
-  ) {
-    throw new McpOAuthError("Ğ˜Ğ·Ğ¸ÑĞºĞ²Ğ° ÑĞµ PKCE S256.");
-  }
-  if (String(input?.resource || "") !== resource) {
-    throw new McpOAuthError("ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ MCP resource.", 400, "invalid_target");
-  }
-
-  let metadata;
-  try {
-    const response = await fetchImpl(clientId, {
-      headers: { Accept: "application/json" },
-      redirect: "error",
-      signal: AbortSignal.timeout(5_000),
-    });
-    if (!response.ok) throw new Error("CLIENT_METADATA_UNAVAILABLE");
-    metadata = await response.json();
-  } catch {
-    throw new McpOAuthError(
-      "OAuth ĞºĞ»Ğ¸ĞµĞ½Ñ‚ÑŠÑ‚ Ğ½Ğµ Ğ¼Ğ¾Ğ¶Ğµ Ğ´Ğ° Ğ±ÑŠĞ´Ğµ Ğ¿Ñ€Ğ¾Ğ²ĞµÑ€ĞµĞ½.",
-      400,
-      "invalid_client",
-    );
-  }
-
-  if (
-    metadata?.client_id !== clientId ||
-    typeof metadata?.client_name !== "string" ||
-    !metadata.client_name.trim() ||
-    !Array.isArray(metadata.redirect_uris) ||
-    !metadata.redirect_uris.includes(redirectUri) ||
-    !(
-      metadata.token_endpoint_auth_method === "none" ||
-      metadata.token_endpoint_auth_methods_supported?.includes?.("none")
-    )
-  ) {
-    throw new McpOAuthError(
-      "OAuth callback Ğ°Ğ´Ñ€ĞµÑÑŠÑ‚ Ğ½Ğµ Ğµ Ñ€Ğ°Ğ·Ñ€ĞµÑˆĞµĞ½ Ğ¾Ñ‚ ĞºĞ»Ğ¸ĞµĞ½Ñ‚Ğ°.",
-      400,
-      "invalid_client",
-    );
-  }
-
-  return {
-    clientId,
-    clientName: metadata.client_name.trim(),
-    redirectUri,
-    state,
-    codeChallenge,
-    resource,
-    scopes: parseScopes(input?.scope),
-  };
-}
-
-export function createMcpAuthorizationCode(
-  request,
-  identity,
-  env = process.env,
-) {
-  if (!identity?.id || !identity?.memoryOwnerId || !identity?.role) {
-    throw new McpOAuthError("Ğ›Ğ¸Ğ¿ÑĞ²Ğ° Ğ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ SYNCHRON-X Ğ¿Ñ€Ğ¾Ñ„Ğ¸Ğ».", 401);
-  }
-  if (
-    request.scopes.includes(MCP_GITHUB_WRITE_SCOPE) &&
-    identity.role !== "owner"
-  ) {
-    throw new McpOAuthError(
-      "GitHub Ğ·Ğ°Ğ¿Ğ¸ÑÑŠÑ‚ Ğµ Ğ´Ğ¾ÑÑ‚ÑŠĞ¿ĞµĞ½ ÑĞ°Ğ¼Ğ¾ Ğ·Ğ° ÑĞ¾Ğ±ÑÑ‚Ğ²ĞµĞ½Ğ¸ĞºĞ°.",
-      403,
-      "access_denied",
-    );
-  }
-  const now = Math.floor(Date.now() / 1_000);
-  return encryptPayload(
-    "sx-code",
-    {
-      typ: "authorization_code",
-      jti: randomBytes(18).toString("base64url"),
-      iss: resolveMcpIssuerUrl(env),
-      aud: request.resource,
-      clientId: request.clientId,
-      redirectUri: request.redirectUri,
-      codeChallenge: request.codeChallenge,
-      scopes: request.scopes,
-      subject: String(identity.id),
-      memoryOwnerId: String(identity.memoryOwnerId),
-      role: String(identity.role),
-      iat: now,
-      exp: now + AUTHORIZATION_CODE_TTL_SECONDS,
-    },
-    grantSecret(env),
-  );
-}
-
-function safeStringEqual(left, right) {
-  const a = Buffer.from(String(left), "utf8");
-  const b = Buffer.from(String(right), "utf8");
-  return a.length === b.length && timingSafeEqual(a, b);
-}
-
-function wasTokenConsumed(store, tokenId, now) {
-  for (const [storedId, expiresAt] of store) {
-    if (expiresAt <= now) store.delete(storedId);
-  }
-  return store.has(tokenId);
-}
-
-function markTokenConsumed(store, tokenId, expiresAt) {
-  store.set(tokenId, expiresAt);
-  while (store.size > MAX_CONSUMED_TOKEN_RECORDS) {
-    store.delete(store.keys().next().value);
-  }
-}
-
-function replayStore(grantType) {
-  return grantType === "authorization_code"
-    ? consumedAuthorizationCodes
-    : consumedRefreshTokens;
-}
-
-function replayRecordId(grantType, tokenId) {
-  return createHash("sha256")
-    .update(String(grantType))
-    .update("\0")
-    .update(String(tokenId))
-    .digest("hex");
-}
-
-function openSearchStatus(error) {
-  return error?.statusCode || error?.meta?.statusCode || 0;
-}
-
-export function requiresPersistentMcpReplayGuard(env = process.env) {
-  return env.NODE_ENV === "production";
-}
-
-export async function cleanupExpiredMcpReplayRecords({
-  client = getOpenSearchClient(),
-  env = process.env,
-  now = Math.floor(Date.now() / 1_000),
-  force = false,
-} = {}) {
-  if (!client || typeof client.deleteByQuery !== "function") return false;
-  if (activeReplayCleanup) return activeReplayCleanup;
-  if (
-    !force &&
-    lastReplayCleanupAt > 0 &&
-    now - lastReplayCleanupAt < REPLAY_CLEANUP_INTERVAL_SECONDS
-  ) {
-    return false;
-  }
-
-  lastReplayCleanupAt = now;
-  activeReplayCleanup = client
-    .deleteByQuery({
-      index: env.MCP_OAUTH_REPLAY_INDEX || MCP_OAUTH_REPLAY_INDEX,
-      conflicts: "proceed",
-      refresh: false,
-      body: {
-        query: {
-          range: {
-            expiresAt: { lte: new Date(now * 1_000).toISOString() },
-          },
-        },
-      },
-    })
-    .then(() => true)
-    .catch((error) => {
-      if (openSearchStatus(error) !== 404) {
-        console.error("[MCP OAuth replay] Expired-record cleanup failed.");
-      }
-      return openSearchStatus(error) === 404;
-    })
-    .finally(() => {
-      activeReplayCleanup = null;
-    });
-
-  return activeReplayCleanup;
-}
-
-export async function consumeMcpGrantOnce({
-  grantType,
-  tokenId,
-  expiresAt,
-  env = process.env,
-  client = getOpenSearchClient(),
-}) {
-  const store = replayStore(grantType);
-  const now = Math.floor(Date.now() / 1_000);
-  if (wasTokenConsumed(store, tokenId, now)) return false;
-
-  if (client) {
-    try {
-      const replayIndex = env.MCP_OAUTH_REPLAY_INDEX || MCP_OAUTH_REPLAY_INDEX;
-      await client.create({
-        index: replayIndex,
-        id: replayRecordId(grantType, tokenId),
-        body: {
-          grantType,
-          expiresAt: new Date(expiresAt * 1_000).toISOString(),
-        },
-        refresh: true,
-      });
-      await cleanupExpiredMcpReplayRecords({ client, env, now });
-    } catch (error) {
-      if (openSearchStatus(error) === 409) return false;
-      if (requiresPersistentMcpReplayGuard(env)) {
-        throw new McpOAuthError(
-          "MCP OAuth ĞµĞ´Ğ½Ğ¾ĞºÑ€Ğ°Ñ‚Ğ½Ğ°Ñ‚Ğ° Ğ·Ğ°Ñ‰Ğ¸Ñ‚Ğ° Ğ²Ñ€ĞµĞ¼ĞµĞ½Ğ½Ğ¾ Ğ½Ğµ Ğµ Ğ´Ğ¾ÑÑ‚ÑŠĞ¿Ğ½Ğ°.",
-          503,
-          "temporarily_unavailable",
-        );
-      }
-    }
-  } else if (requiresPersistentMcpReplayGuard(env)) {
-    throw new McpOAuthError(
-      "MCP OAuth ĞµĞ´Ğ½Ğ¾ĞºÑ€Ğ°Ñ‚Ğ½Ğ°Ñ‚Ğ° Ğ·Ğ°Ñ‰Ğ¸Ñ‚Ğ° Ğ½Ğµ Ğµ ĞºĞ¾Ğ½Ñ„Ğ¸Ğ³ÑƒÑ€Ğ¸Ñ€Ğ°Ğ½Ğ°.",
-      503,
-      "temporarily_unavailable",
-    );
-  }
-
-  markTokenConsumed(store, tokenId, expiresAt);
-  return true;
-}
-
-function createAccessAndRefreshTokens(payload, env, now) {
-  const accessToken = encryptPayload(
-    "sx-token",
-    {
-      typ: "access_token",
-      iss: payload.iss,
-      aud: payload.aud,
-      clientId: payload.clientId,
-      scopes: payload.scopes,
-      subject: payload.subject,
-      memoryOwnerId: payload.memoryOwnerId,
-      role: payload.role,
-      iat: now,
-      nbf: now - 5,
-      exp: now + ACCESS_TOKEN_TTL_SECONDS,
-    },
-    oauthSecret(env),
-  );
-  const refreshToken = encryptPayload(
-    "sx-refresh",
-    {
-      typ: "refresh_token",
-      jti: randomBytes(18).toString("base64url"),
-      iss: payload.iss,
-      aud: payload.aud,
-      clientId: payload.clientId,
-      scopes: payload.scopes,
-      subject: payload.subject,
-      memoryOwnerId: payload.memoryOwnerId,
-      role: payload.role,
-      iat: now,
-      exp: now + REFRESH_TOKEN_TTL_SECONDS,
-    },
-    grantSecret(env),
-  );
-  return {
-    access_token: accessToken,
-    refresh_token: refreshToken,
-    token_type: "Bearer",
-    expires_in: ACCESS_TOKEN_TTL_SECONDS,
-    scope: payload.scopes.join(" "),
-  };
-}
-
-export async function exchangeMcpAuthorizationCode(
-  input,
-  env = process.env,
-  { consumeGrant = consumeMcpGrantOnce } = {},
-) {
-  const code = String(input?.code || "");
-  const payload = decryptPayloadWithFallback(
-    code,
-    "sx-code",
-    grantVerificationSecrets(env),
-  );
-  const now = Math.floor(Date.now() / 1_000);
-  if (
-    !payload ||
-    payload.typ !== "authorization_code" ||
-    payload.iss !== resolveMcpIssuerUrl(env) ||
-    payload.aud !== resolveMcpResourceUrl(env) ||
-    payload.exp <= now
-  ) {
-    throw new McpOAuthError(
-      "ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ Ğ¸Ğ»Ğ¸ Ğ¸Ğ·Ñ‚ĞµĞºÑŠĞ» authorization code.",
-      400,
-      "invalid_grant",
-    );
-  }
-  if (
-    input?.grant_type !== "authorization_code" ||
-    !safeStringEqual(input?.client_id, payload.clientId) ||
-    !safeStringEqual(input?.redirect_uri, payload.redirectUri) ||
-    !safeStringEqual(input?.resource, payload.aud)
-  ) {
-    throw new McpOAuthError(
-      "Authorization code Ğ½Ğµ ÑÑŠĞ²Ğ¿Ğ°Ğ´Ğ° ÑÑŠÑ Ğ·Ğ°ÑĞ²ĞºĞ°Ñ‚Ğ°.",
-      400,
-      "invalid_grant",
-    );
-  }
-  const verifier = String(input?.code_verifier || "");
-  if (!/^[A-Za-z0-9._~-]{43,128}$/u.test(verifier)) {
-    throw new McpOAuthError("ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ PKCE verifier.", 400, "invalid_grant");
-  }
-  const challenge = createHash("sha256").update(verifier).digest("base64url");
-  if (!safeStringEqual(challenge, payload.codeChallenge)) {
-    throw new McpOAuthError(
-      "PKCE Ğ¿Ñ€Ğ¾Ğ²ĞµÑ€ĞºĞ°Ñ‚Ğ° Ğµ Ğ½ĞµÑƒÑĞ¿ĞµÑˆĞ½Ğ°.",
-      400,
-      "invalid_grant",
-    );
-  }
-
-  const consumed = await consumeGrant({
-    grantType: "authorization_code",
-    tokenId: payload.jti,
-    expiresAt: payload.exp,
-    env,
-  });
-  if (!consumed) {
-    throw new McpOAuthError(
-      "ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ Ğ¸Ğ»Ğ¸ Ğ¸Ğ·Ñ‚ĞµĞºÑŠĞ» authorization code.",
-      400,
-      "invalid_grant",
-    );
-  }
-  return createAccessAndRefreshTokens(payload, env, now);
-}
-
-export async function exchangeMcpRefreshToken(
-  input,
-  env = process.env,
-  { consumeGrant = consumeMcpGrantOnce } = {},
-) {
-  const payload = decryptPayloadWithFallback(
-    String(input?.refresh_token || ""),
-    "sx-refresh",
-    grantVerificationSecrets(env),
-  );
-  const now = Math.floor(Date.now() / 1_000);
-  if (
-    !payload ||
-    payload.typ !== "refresh_token" ||
-    payload.iss !== resolveMcpIssuerUrl(env) ||
-    payload.aud !== resolveMcpResourceUrl(env) ||
-    payload.exp <= now ||
-    !safeStringEqual(input?.client_id, payload.clientId) ||
-    !safeStringEqual(input?.resource, payload.aud)
-  ) {
-    throw new McpOAuthError(
-      "ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ Ğ¸Ğ»Ğ¸ Ğ¸Ğ·Ñ‚ĞµĞºÑŠĞ» refresh token.",
-      400,
-      "invalid_grant",
-    );
-  }
-  const consumed = await consumeGrant({
-    grantType: "refresh_token",
-    tokenId: payload.jti,
-    expiresAt: payload.exp,
-    env,
-  });
-  if (!consumed) {
-    throw new McpOAuthError(
-      "ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ Ğ¸Ğ»Ğ¸ Ğ¸Ğ·Ñ‚ĞµĞºÑŠĞ» refresh token.",
-      400,
-      "invalid_grant",
-    );
-  }
-  return createAccessAndRefreshTokens(payload, env, now);
-}
-
-export async function exchangeMcpToken(input, env = process.env) {
-  if (input?.grant_type === "authorization_code") {
-    return exchangeMcpAuthorizationCode(input, env);
-  }
-  if (input?.grant_type === "refresh_token") {
-    return exchangeMcpRefreshToken(input, env);
-  }
-  throw new McpOAuthError(
-    "ĞĞµĞ¿Ğ¾Ğ´Ğ´ÑŠÑ€Ğ¶Ğ°Ğ½ OAuth grant.",
-    400,
-    "unsupported_grant_type",
-  );
-}
-
-export function verifyMcpAccessToken(
-  authorizationHeader,
-  requiredScopes = [MCP_READ_SCOPE],
-  env = process.env,
-) {
-  if (
-    typeof authorizationHeader !== "string" ||
-    !authorizationHeader.startsWith("Bearer ")
-  ) {
-    return null;
-  }
-  const payload = decryptPayloadWithFallback(
-    authorizationHeader.slice(7),
-    "sx-token",
-    oauthVerificationSecrets(env),
-  );
-  const now = Math.floor(Date.now() / 1_000);
-  if (
-    !payload ||
-    payload.typ !== "access_token" ||
-    payload.iss !== resolveMcpIssuerUrl(env) ||
-    payload.aud !== resolveMcpResourceUrl(env) ||
-    payload.nbf > now ||
-    payload.exp <= now ||
-    !Array.isArray(payload.scopes) ||
-    !payload.subject ||
-    !payload.memoryOwnerId ||
-    !["owner", "member", "tester"].includes(payload.role)
-  ) {
-    throw new McpOAuthError(
-      "ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ Ğ¸Ğ»Ğ¸ Ğ¸Ğ·Ñ‚ĞµĞºÑŠĞ» MCP token.",
-      401,
-      "invalid_token",
-    );
-  }
-  if (
-    requiredScopes.some((scope) => !payload.scopes.includes(scope)) ||
-    (requiredScopes.includes(MCP_GITHUB_WRITE_SCOPE) &&
-      payload.role !== "owner")
-  ) {
-    throw new McpOAuthError(
-      "MCP token Ğ½ÑĞ¼Ğ° Ğ½ĞµĞ¾Ğ±Ñ…Ğ¾Ğ´Ğ¸Ğ¼Ğ¸Ñ‚Ğµ Ğ¿Ñ€Ğ°Ğ²Ğ°.",
-      403,
-      "insufficient_scope",
-    );
-  }
-  return {
-    id: payload.subject,
-    memoryOwnerId: payload.memoryOwnerId,
-    role: payload.role,
-    scopes: payload.scopes,
-    clientId: payload.clientId,
-  };
-}
-
-export function resetMcpOAuthStateForTests() {
-  consumedAuthorizationCodes.clear();
-  consumedRefreshTokens.clear();
-  lastReplayCleanupAt = 0;
-  activeReplayCleanup = null;
-}
+KŸJHÂˆÛÛœİİÜ™HH™\^TİÜ™JÜ˜[\JNÂˆÛÛœİ›İÈHX]™›ÛÜŠ]K››İÊ
+HÈWÌ
+NÂˆYˆ
+Ø\ÕÚÙ[ÛÛœİ[YY
+İÜ™KÚÙ[’Y›İÊJH™]\›ˆ˜[ÙNÂ‚ˆYˆ
+ÛY[
+HÂˆHÂˆÛÛœİ™\^R[™^H[‹“PÔÓĞUUÔ‘TVWÒS‘VPÔÓĞUUÔ‘TVWÒS‘VÂˆ]ØZ]ÛY[˜Ü™X]JÂˆ[™^ˆ™\^R[™^ˆYˆ™\^T™XÛÜ™Y
+Ü˜[\KÚÙ[’Y
+Kˆ›ÙNˆÂˆÜ˜[\Kˆ^\™\Ğ]ˆ™]È]J^\™\Ğ]
+ˆWÌ
+KÒTÓÔİš[™Ê
+KˆKˆ™Yœ™\ÚˆYKˆJNÂˆ]ØZ]ÛX[\^\™YXÜ™\^T™XÛÜ™ÊÈÛY[[‹›İÈJNÂˆHØ]Ú
+\œ›ÜŠHÂˆYˆ
+Ü[”ÙX\˜Úİ]\Ê\œ›ÜŠHOOHJH™]\›ˆ˜[ÙNÂˆYˆ
+™\]Z\™\Ô\œÚ\İ[XÜ™\^QİX\™
+[ŠJHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ“PÔĞ]]4-t-4/t/´.´`4,4`´/t,4`´,4-ô,4bt.4`´,4,´`4-t/4-t/t/t/ˆ4/t-H4-H4-4/´`t`´b´/ô/t,ˆ‹ˆLËˆ[\Ü˜\š[Wİ[˜]˜Z[X›H‹ˆ
+NÂˆBˆBˆH[ÙHYˆ
+™\]Z\™\Ô\œÚ\İ[XÜ™\^QİX\™
+[ŠJHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ“PÔĞ]]4-t-4/t/´.´`4,4`´/t,4`´,4-ô,4bt.4`´,4/t-H4-H4.´/´/ta4.4,ô`ô`4.4`4,4/t,ˆ‹ˆLËˆ[\Ü˜\š[Wİ[˜]˜Z[X›H‹ˆ
+NÂˆB‚ˆX\šÕÚÙ[ÛÛœİ[YY
+İÜ™KÚÙ[’Y^\™\Ğ]
+NÂˆ™]\›ˆYNÂŸB‚™[˜İ[ÛˆÜ™X]PXØÙ\ÜĞ[™™Yœ™\ÚÚÙ[œÊ^[ØY[‹›İÊHÂˆÛÛœİXØÙ\ÜÕÚÙ[ˆH[˜Ü\^[ØY
+ˆœŞ]ÚÙ[ˆ‹ˆÂˆ\ˆ˜XØÙ\Ü×İÚÙ[ˆ‹ˆ\ÜÎˆ^[ØYš\ÜËˆ]Yˆ^[ØY˜]YˆÛY[Yˆ^[ØY˜ÛY[YˆØÛÜ\Îˆ^[ØYœØÛÜ\ËˆİXš™Xİˆ^[ØYœİXš™XİˆY[[ÜSİÛ™\’Yˆ^[ØY›Y[[ÜSİÛ™\’Yˆ›ÛNˆ^[ØYœ›ÛKˆX]ˆ›İËˆ˜™ˆ›İÈHKˆ^ˆ›İÈ
+ÈPĞÑTÔ×ÕÒÑS—ÕÔÑPÓÓ‘ËˆKˆØ]]ÙXÜ™]
+[ŠKˆ
+NÂˆÛÛœİ™Yœ™\ÚÚÙ[ˆH[˜Ü\^[ØY
+ˆœŞ\™Yœ™\Ú‹ˆÂˆ\ˆœ™Yœ™\ÚİÚÙ[ˆ‹ˆNˆ˜[™ÛP]\ÊN
+KÔİš[™Ê˜˜\ÙM\›ŠKˆ\ÜÎˆ^[ØYš\ÜËˆ]Yˆ^[ØY˜]YˆÛY[Yˆ^[ØY˜ÛY[YˆØÛÜ\Îˆ^[ØYœØÛÜ\ËˆİXš™Xİˆ^[ØYœİXš™XİˆY[[ÜSİÛ™\’Yˆ^[ØY›Y[[ÜSİÛ™\’Yˆ›ÛNˆ^[ØYœ›ÛKˆX]ˆ›İËˆ^ˆ›İÈ
+È‘Q”‘TÒÕÒÑS—ÕÔÑPÓÓ‘ËˆKˆÜ˜[ÙXÜ™]
+[ŠKˆ
+NÂˆ™]\›ˆÂˆXØÙ\Ü×İÚÙ[ˆXØÙ\ÜÕÚÙ[‹ˆ™Yœ™\ÚİÚÙ[ˆ™Yœ™\ÚÚÙ[‹ˆÚÙ[—İ\Nˆ™X\™\ˆ‹ˆ^\™\×Ú[ˆPĞÑTÔ×ÕÒÑS—ÕÔÑPÓÓ‘ËˆØÛÜNˆ^[ØYœØÛÜ\Ëš›Ú[ŠˆŠKˆNÂŸB‚™^Ü\Ş[˜È[˜İ[Ûˆ^Ú[™ÙSXÜ]]Üš^˜][ÛÛÙJˆ[œ]ˆ[ˆH›ØÙ\ÜË™[‹ˆÈÛÛœİ[YQÜ˜[HÛÛœİ[YSXÜÜ˜[Û˜ÙHHHßKŠHÂˆÛÛœİÛÙHHİš[™Ê[œ]Ë˜ÛÙHˆŠNÂˆÛÛœİ^[ØYHXÜ\^[ØYÚ]˜[˜XÚÊˆÛÙKˆœŞXÛÙH‹ˆÜ˜[™\šYšXØ][Û”ÙXÜ™]Ê[ŠKˆ
+NÂˆÛÛœİ›İÈHX]™›ÛÜŠ]K››İÊ
+HÈWÌ
+NÂˆYˆ
+ˆ\^[ØYˆ^[ØY\OOH˜]]Üš^˜][Û—ØÛÙHˆˆ^[ØYš\ÜÈOOH™\ÛÛ™SXÜ\ÜİY\•\›
+[ŠHˆ^[ØY˜]YOOH™\ÛÛ™SXÜ™\Ûİ\˜ÙU\›
+[ŠHˆ^[ØY™^H›İÂˆ
+HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ´'t-t,´,4.ô.4-4-t/H4.4.ô.4.4-ô`´-t.´b´.È]]Üš^˜][ÛˆÛÙKˆ‹ˆˆš[˜[YÙÜ˜[‹ˆ
+NÂˆBˆYˆ
+ˆ[œ]Ë™Ü˜[İ\HOOH˜]]Üš^˜][Û—ØÛÙHˆˆ\ØY™Tİš[™Ñ\]X[
+[œ]Ë˜ÛY[ÚY^[ØY˜ÛY[Y
+Hˆ\ØY™Tİš[™Ñ\]X[
+[œ]Ëœ™Y\™Xİİ\šK^[ØYœ™Y\™Xİ\šJHˆ\ØY™Tİš[™Ñ\]X[
+[œ]Ëœ™\Ûİ\˜ÙK^[ØY˜]Y
+Bˆ
+HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ]]Üš^˜][ÛˆÛÙH4/t-H4`tb´,´/ô,4-4,4`tb´`H4-ô,4cô,´.´,4`´,ˆ‹ˆˆš[˜[YÙÜ˜[‹ˆ
+NÂˆBˆÛÛœİ™\šYšY\ˆHİš[™Ê[œ]Ë˜ÛÙWİ™\šYšY\ˆˆŠNÂˆYˆ
+K×–ĞKV˜K^ŒNK—ß‹W^ÍËLIİK\İ
+™\šYšY\ŠJHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´'t-t,´,4.ô.4-4-t/HĞÑH™\šYšY\‹ˆ‹š[˜[YÙÜ˜[ŠNÂˆBˆÛÛœİÚ[[™ÙHHÜ™X]R\Ú
+œÚLMˆŠK\]J™\šYšY\ŠK™YÙ\İ
+˜˜\ÙM\›ŠNÂˆYˆ
+\ØY™Tİš[™Ñ\]X[
+Ú[[™ÙK^[ØY˜ÛÙPÚ[[™ÙJJHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ”ĞÑH4/ô`4/´,´-t`4.´,4`´,4-H4/t-t`ô`t/ô-tb4/t,ˆ‹ˆˆš[˜[YÙÜ˜[‹ˆ
+NÂˆB‚ˆÛÛœİÛÛœİ[YYH]ØZ]ÛÛœİ[YQÜ˜[
+ÂˆÜ˜[\Nˆ˜]]Üš^˜][Û—ØÛÙH‹ˆÚÙ[’Yˆ^[ØYšKˆ^\™\Ğ]ˆ^[ØY™^ˆ[‹ˆJNÂˆYˆ
+XÛÛœİ[YY
+HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ´'t-t,´,4.ô.4-4-t/H4.4.ô.4.4-ô`´-t.´b´.È]]Üš^˜][ÛˆÛÙKˆ‹ˆˆš[˜[YÙÜ˜[‹ˆ
+NÂˆBˆ™]\›ˆÜ™X]PXØÙ\ÜĞ[™™Yœ™\ÚÚÙ[œÊ^[ØY[‹›İÊNÂŸB‚™^Ü\Ş[˜È[˜İ[Ûˆ^Ú[™ÙSXÜ™Yœ™\ÚÚÙ[Šˆ[œ]ˆ[ˆH›ØÙ\ÜË™[‹ˆÈÛÛœİ[YQÜ˜[HÛÛœİ[YSXÜÜ˜[Û˜ÙHHHßKŠHÂˆÛÛœİ^[ØYHXÜ\^[ØYÚ]˜[˜XÚÊˆİš[™Ê[œ]Ëœ™Yœ™\ÚİÚÙ[ˆˆŠKˆœŞ\™Yœ™\Ú‹ˆÜ˜[™\šYšXØ][Û”ÙXÜ™]Ê[ŠKˆ
+NÂˆÛÛœİ›İÈHX]™›ÛÜŠ]K››İÊ
+HÈWÌ
+NÂˆYˆ
+ˆ\^[ØYˆ^[ØY\OOHœ™Yœ™\ÚİÚÙ[ˆˆˆ^[ØYš\ÜÈOOH™\ÛÛ™SXÜ\ÜİY\•\›
+[ŠHˆ^[ØY˜]YOOH™\ÛÛ™SXÜ™\Ûİ\˜ÙU\›
+[ŠHˆ^[ØY™^H›İÈˆ\ØY™Tİš[™Ñ\]X[
+[œ]Ë˜ÛY[ÚY^[ØY˜ÛY[Y
+Hˆ\ØY™Tİš[™Ñ\]X[
+[œ]Ëœ™\Ûİ\˜ÙK^[ØY˜]Y
+Bˆ
+HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ´'t-t,´,4.ô.4-4-t/H4.4.ô.4.4-ô`´-t.´b´.È™Yœ™\ÚÚÙ[‹ˆ‹ˆˆš[˜[YÙÜ˜[‹ˆ
+NÂˆBˆÛÛœİÛÛœİ[YYH]ØZ]ÛÛœİ[YQÜ˜[
+ÂˆÜ˜[\Nˆœ™Yœ™\ÚİÚÙ[ˆ‹ˆÚÙ[’Yˆ^[ØYšKˆ^\™\Ğ]ˆ^[ØY™^ˆ[‹ˆJNÂˆYˆ
+XÛÛœİ[YY
+HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ´'t-t,´,4.ô.4-4-t/H4.4.ô.4.4-ô`´-t.´b´.È™Yœ™\ÚÚÙ[‹ˆ‹ˆˆš[˜[YÙÜ˜[‹ˆ
+NÂˆBˆ™]\›ˆÜ™X]PXØÙ\ÜĞ[™™Yœ™\ÚÚÙ[œÊ^[ØY[‹›İÊNÂŸB‚™^Ü\Ş[˜È[˜İ[Ûˆ^Ú[™ÙSXÜÚÙ[Š[œ][ˆH›ØÙ\ÜË™[ŠHÂˆYˆ
+[œ]Ë™Ü˜[İ\HOOH˜]]Üš^˜][Û—ØÛÙHŠHÂˆ™]\›ˆ^Ú[™ÙSXÜ]]Üš^˜][ÛÛÙJ[œ][ŠNÂˆBˆYˆ
+[œ]Ë™Ü˜[İ\HOOHœ™Yœ™\ÚİÚÙ[ˆŠHÂˆ™]\›ˆ^Ú[™ÙSXÜ™Yœ™\ÚÚÙ[Š[œ][ŠNÂˆBˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ´'t-t/ô/´-4-4b´`4-´,4/HĞ]]Ü˜[ˆ‹ˆˆ[œİ\ÜYÙÜ˜[İ\H‹ˆ
+NÂŸB‚™^Ü[˜İ[Ûˆ™\šYSXÜXØÙ\ÜÕÚÙ[Šˆ]]Üš^˜][Û’XY\‹ˆ™\]Z\™YØÛÜ\ÈHÓPÔÔ‘PQÔĞÓÔWKˆ[ˆH›ØÙ\ÜË™[‹ŠHÂˆYˆ
+ˆ\[Ùˆ]]Üš^˜][Û’XY\ˆOOHœİš[™ÈˆˆX]]Üš^˜][Û’XY\‹œİ\ÕÚ]
+™X\™\ˆŠBˆ
+HÂˆ™]\›ˆ[ÂˆBˆÛÛœİ^[ØYHXÜ\^[ØYÚ]˜[˜XÚÊˆ]]Üš^˜][Û’XY\‹œÛXÙJÊKˆœŞ]ÚÙ[ˆ‹ˆØ]]™\šYšXØ][Û”ÙXÜ™]Ê[ŠKˆ
+NÂˆÛÛœİ›İÈHX]™›ÛÜŠ]K››İÊ
+HÈWÌ
+NÂˆYˆ
+ˆ\^[ØYˆ^[ØY\OOH˜XØÙ\Ü×İÚÙ[ˆˆˆ^[ØYš\ÜÈOOH™\ÛÛ™SXÜ\ÜİY\•\›
+[ŠHˆ^[ØY˜]YOOH™\ÛÛ™SXÜ™\Ûİ\˜ÙU\›
+[ŠHˆ^[ØY›˜™ˆˆ›İÈˆ^[ØY™^H›İÈˆP\œ˜^Kš\Ğ\œ˜^J^[ØYœØÛÜ\ÊHˆ\^[ØYœİXš™Xİˆ\^[ØY›Y[[ÜSİÛ™\’YˆVÈ›İÛ™\ˆ‹›Y[X™\ˆ‹\İ\ˆ—Kš[˜ÛY\Ê^[ØYœ›ÛJBˆ
+HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ´'t-t,´,4.ô.4-4-t/H4.4.ô.4.4-ô`´-t.´b´.ÈPÔÚÙ[‹ˆ‹ˆKˆš[˜[YİÚÙ[ˆ‹ˆ
+NÂˆBˆYˆ
+ˆ™\]Z\™YØÛÜ\ËœÛÛYJ
+ØÛÜJHOˆ\^[ØYœØÛÜ\Ëš[˜ÛY\ÊØÛÜJJHˆ
+™\]Z\™\ÓİÛ™\”›ÛJ™\]Z\™YØÛÜ\ÊH	‰ˆ^[ØYœ›ÛHOOH›İÛ™\ˆŠBˆ
+HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ“PÔÚÙ[ˆ4/tcô/4,4/t-t/´,tat/´-4.4/4.4`´-H4/ô`4,4,´,ˆ‹ˆËˆš[œİY™šXÚY[ÜØÛÜH‹ˆ
+NÂˆBˆ™]\›ˆÂˆYˆ^[ØYœİXš™XİˆY[[ÜSİÛ™\’Yˆ^[ØY›Y[[ÜSİÛ™\’Yˆ›ÛNˆ^[ØYœ›ÛKˆØÛÜ\Îˆ^[ØYœØÛÜ\ËˆÛY[Yˆ^[ØY˜ÛY[YˆNÂŸB‚™^Ü[˜İ[Ûˆ™\Ù]XÜĞ]]İ]Q›Ü•\İÊ
+HÂˆÛÛœİ[YY]]Üš^˜][ÛÛÙ\Ë˜ÛX\Š
+NÂˆÛÛœİ[YY™Yœ™\ÚÚÙ[œË˜ÛX\Š
+NÂˆ\İ™\^PÛX[\]HÂˆXİ]™T™\^PÛX[\H[ÂŸB

--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -17,191 +17,745 @@ export const MCP_SCOPES = Object.freeze([
   MCP_INFRASTRUCTURE_WRITE_SCOPE,
 ]);
 const MCP_OWNER_ONLY_SCOPES = Object.freeze([
-  MCP_GITHUB_WRITEÛv¶‰ËkºwµçY˜[ÙNÂˆÛÛœİÜİH\›šÜİ˜[YKÓİÙ\Ø\ÙJ
-NÂˆ™]\›ˆ
-ˆÜİOOH˜Ú]Ü˜ÛÛHˆˆÜİ™[™ÕÚ]
-‹˜Ú]Ü˜ÛÛHŠHˆÜİOOH›Ü[˜ZK˜ÛÛHˆˆÜİ™[™ÕÚ]
-‹›Ü[˜ZK˜ÛÛHŠBˆ
-NÂˆHØ]ÚÂˆ™]\›ˆ˜[ÙNÂˆBŸB‚™^Ü\Ş[˜È[˜İ[Ûˆ˜[Y]SXÜ]]Üš^˜][Û”™\]Y\İ
-ˆ[œ]ˆÈ[ˆH›ØÙ\ÜË™[‹™]Ú[\H™]ÚHHßKŠHÂˆÛÛœİ™\Ûİ\˜ÙHH™\ÛÛ™SXÜ™\Ûİ\˜ÙU\›
-[ŠNÂˆÛÛœİÛY[YHİš[™Ê[œ]Ë˜ÛY[ÚYˆŠKš[J
-NÂˆÛÛœİ™Y\™Xİ\šHHİš[™Ê[œ]Ëœ™Y\™Xİİ\šHˆŠKš[J
-NÂˆÛÛœİİ]HHİš[™Ê[œ]Ëœİ]HˆŠKš[J
-NÂˆÛÛœİÛÙPÚ[[™ÙHHİš[™Ê[œ]Ë˜ÛÙWØÚ[[™ÙHˆŠKš[J
-NÂ‚ˆYˆ
-[œ]Ëœ™\ÜÛœÙWİ\HOOH˜ÛÙHŠHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´'ô/´-4-4b´`4-´,4`t-H4`t,4/4/ˆ]]Üš^˜][ÛˆÛÙKˆŠNÂˆBˆYˆ
-Z\Ğ[İÙYÜ[ZPÛY[Y
-ÛY[Y
-JHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´'t-t/ô/´-ô/t,4`ˆĞ]]4.´.ô.4-t/t`‹ˆ‹š[˜[YØÛY[ŠNÂˆBˆYˆ
-\İ]Hİ]K›[™İˆWÌ
-HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´&ô.4/ô`t,´,4,´,4.ô.4-4/t/ˆĞ]]4`tb´`t`´/´cô/t.4-KˆŠNÂˆBˆYˆ
-ˆ[œ]Ë˜ÛÙWØÚ[[™ÙWÛY]ÙOOH”ÌMˆˆˆK×–ĞKV˜K^ŒNWËW^ÍËLIİK\İ
-ÛÙPÚ[[™ÙJBˆ
-HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´&4-ô.4`t.´,´,4`t-HĞÑHÌM‹ˆŠNÂˆBˆYˆ
-İš[™Ê[œ]Ëœ™\Ûİ\˜ÙHˆŠHOOH™\Ûİ\˜ÙJHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´'t-t,´,4.ô.4-4-t/HPÔ™\Ûİ\˜ÙKˆ‹š[˜[Yİ\™Ù]ŠNÂˆB‚ˆ]Y]Y]NÂˆHÂˆÛÛœİ™\ÜÛœÙHH]ØZ]™]Ú[\
-ÛY[YÂˆXY\œÎˆÈXØÙ\ˆ˜\XØ][Û‹ÚœÛÛˆˆKˆ™Y\™Xİˆ™\œ›Üˆ‹ˆÚYÛ˜[ˆX›ÜÚYÛ˜[[Y[İ]
-WÌ
-KˆJNÂˆYˆ
-\™\ÜÛœÙK›ÚÊH›İÈ™]È\œ›ÜŠÓQS•ÓQUQUWÕSURSP“HŠNÂˆY]Y]HH]ØZ]™\ÜÛœÙKšœÛÛŠ
-NÂˆHØ]ÚÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ“Ğ]]4.´.ô.4-t/t`´b´`ˆ4/t-H4/4/´-´-H4-4,4,tb´-4-H4/ô`4/´,´-t`4-t/Kˆ‹ˆˆš[˜[YØÛY[‹ˆ
-NÂˆB‚ˆYˆ
-ˆY]Y]OË˜ÛY[ÚYOOHÛY[Yˆ\[ÙˆY]Y]OË˜ÛY[Û˜[YHOOHœİš[™Èˆˆ[Y]Y]K˜ÛY[Û˜[YKš[J
-HˆP\œ˜^Kš\Ğ\œ˜^JY]Y]Kœ™Y\™Xİİ\š\ÊHˆ[Y]Y]Kœ™Y\™Xİİ\š\Ëš[˜ÛY\Ê™Y\™Xİ\šJHˆJˆY]Y]KÚÙ[—Ù[™Ú[Ø]]ÛY]ÙOOH››Û™HˆˆY]Y]KÚÙ[—Ù[™Ú[Ø]]ÛY]Ù×Üİ\ÜYËš[˜ÛY\ÏËŠ››Û™HŠBˆ
-Bˆ
-HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ“Ğ]]Ø[˜XÚÈ4,4-4`4-t`tb´`ˆ4/t-H4-H4`4,4-ô`4-tb4-t/H4/´`ˆ4.´.ô.4-t/t`´,ˆ‹ˆˆš[˜[YØÛY[‹ˆ
-NÂˆB‚ˆ™]\›ˆÂˆÛY[YˆÛY[˜[YNˆY]Y]K˜ÛY[Û˜[YKš[J
-Kˆ™Y\™Xİ\šKˆİ]KˆÛÙPÚ[[™ÙKˆ™\Ûİ\˜ÙKˆØÛÜ\Îˆ\œÙTØÛÜ\Ê[œ]ËœØÛÜJKˆNÂŸB‚™^Ü[˜İ[ÛˆÜ™X]SXÜ]]Üš^˜][ÛÛÙJˆ™\]Y\İˆY[]Kˆ[ˆH›ØÙ\ÜË™[‹ŠHÂˆYˆ
-ZY[]OËšYZY[]OË›Y[[ÜSİÛ™\’YZY[]OËœ›ÛJHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´&ô.4/ô`t,´,4,´,4.ô.4-4-t/HÖSÒ“Ó‹V4/ô`4/´a4.4.Ëˆ‹JNÂˆBˆYˆ
-™\]Z\™\ÓİÛ™\”›ÛJ™\]Y\İœØÛÜ\ÊH	‰ˆY[]Kœ›ÛHOOH›İÛ™\ˆŠHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ“PÔ4-ô,4/ô.4`tb´`ˆ4-H4-4/´`t`´b´/ô-t/H4`t,4/4/ˆ4-ô,4`t/´,t`t`´,´-t/t.4.´,ˆ‹ˆËˆ˜XØÙ\Ü×Ù[šYY‹ˆ
-NÂˆBˆÛÛœİ›İÈHX]™›ÛÜŠ]K››İÊ
-HÈWÌ
-NÂˆ™]\›ˆ[˜Ü\^[ØY
-ˆœŞXÛÙH‹ˆÂˆ\ˆ˜]]Üš^˜][Û—ØÛÙH‹ˆNˆ˜[™ÛP]\ÊN
-KÔİš[™Ê˜˜\ÙM\›ŠKˆ\ÜÎˆ™\ÛÛ™SXÜ\ÜİY\•\›
-[ŠKˆ]Yˆ™\]Y\İœ™\Ûİ\˜ÙKˆÛY[Yˆ™\]Y\İ˜ÛY[Yˆ™Y\™Xİ\šNˆ™\]Y\İœ™Y\™Xİ\šKˆÛÙPÚ[[™ÙNˆ™\]Y\İ˜ÛÙPÚ[[™ÙKˆØÛÜ\Îˆ™\]Y\İœØÛÜ\ËˆİXš™Xİˆİš[™ÊY[]KšY
-KˆY[[ÜSİÛ™\’Yˆİš[™ÊY[]K›Y[[ÜSİÛ™\’Y
-Kˆ›ÛNˆİš[™ÊY[]Kœ›ÛJKˆX]ˆ›İËˆ^ˆ›İÈ
-ÈUUÔ’VUSÓ—ĞÓÑWÕÔÑPÓÓ‘ËˆKˆÜ˜[ÙXÜ™]
-[ŠKˆ
-NÂŸB‚™[˜İ[ÛˆØY™Tİš[™Ñ\]X[
-YšYÚ
-HÂˆÛÛœİHHY™™\‹™œ›ÛJİš[™ÊY
-K]ŠNÂˆÛÛœİˆHY™™\‹™œ›ÛJİš[™ÊšYÚ
-K]ŠNÂˆ™]\›ˆK›[™İOOH‹›[™İ	‰ˆ[Z[™ÔØY™Q\]X[
-KŠNÂŸB‚™[˜İ[ÛˆØ\ÕÚÙ[ÛÛœİ[YY
-İÜ™KÚÙ[’Y›İÊHÂˆ›Üˆ
-ÛÛœİÜİÜ™YY^\™\Ğ]HÙˆİÜ™JHÂˆYˆ
-^\™\Ğ]H›İÊHİÜ™K™[]JİÜ™YY
-NÂˆBˆ™]\›ˆİÜ™Kš\ÊÚÙ[’Y
-NÂŸB‚™[˜İ[ÛˆX\šÕÚÙ[ÛÛœİ[YY
-İÜ™KÚÙ[’Y^\™\Ğ]
-HÂˆİÜ™KœÙ]
-ÚÙ[’Y^\™\Ğ]
-NÂˆÚ[H
-İÜ™KœÚ^™HˆPVĞÓÓ”ÕSQQÕÒÑS—Ô‘PÓÔ‘ÊHÂˆİÜ™K™[]JİÜ™KšÙ^\Ê
-K›™^
+  MCP_GITHUB_WRITE_SCOPE,
+  MCP_INFRASTRUCTURE_WRITE_SCOPE,
+]);
 
-K˜[YJNÂˆBŸB‚™[˜İ[Ûˆ™\^TİÜ™JÜ˜[\JHÂˆ™]\›ˆÜ˜[\HOOH˜]]Üš^˜][Û—ØÛÙH‚ˆÈÛÛœİ[YY]]Üš^˜][ÛÛÙ\ÂˆˆÛÛœİ[YY™Yœ™\ÚÚÙ[œÎÂŸB‚™[˜İ[Ûˆ™\^T™XÛÜ™Y
-Ü˜[\KÚÙ[’Y
-HÂˆ™]\›ˆÜ™X]R\Ú
-œÚLMˆŠBˆ\]Jİš[™ÊÜ˜[\JJBˆ\]J—ŠBˆ\]Jİš[™ÊÚÙ[’Y
-JBˆ™YÙ\İ
-š^ŠNÂŸB‚™[˜İ[ÛˆÜ[”ÙX\˜Úİ]\Ê\œ›ÜŠHÂˆ™]\›ˆ\œ›ÜËœİ]\ĞÛÙH\œ›ÜË›Y]OËœİ]\ĞÛÙHÂŸB‚™^Ü[˜İ[Ûˆ™\]Z\™\Ô\œÚ\İ[XÜ™\^QİX\™
-[ˆH›ØÙ\ÜË™[ŠHÂˆ™]\›ˆ[‹““ÑWÑS•ˆOOHœ›ÙXİ[ÛˆÂŸB‚™^Ü\Ş[˜È[˜İ[ÛˆÛX[\^\™YXÜ™\^T™XÛÜ™ÊÂˆÛY[HÙ]Ü[”ÙX\˜ÚÛY[
+const ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
+const REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
+const AUTHORIZATION_CODE_TTL_SECONDS = 5 * 60;
+const MAX_CONSUMED_TOKEN_RECORDS = 10_000;
+const REPLAY_CLEANUP_INTERVAL_SECONDS = 6 * 60 * 60;
+const MCP_OAUTH_REPLAY_INDEX =
+  process.env.MCP_OAUTH_REPLAY_INDEX || "synchron-mcp-oauth-replay-v1";
+const consumedAuthorizationCodes = new Map();
+const consumedRefreshTokens = new Map();
+let lastReplayCleanupAt = 0;
+let activeReplayCleanup = null;
 
-Kˆ[ˆH›ØÙ\ÜË™[‹ˆ›İÈHX]™›ÛÜŠ]K››İÊ
-HÈWÌ
-Kˆ›Ü˜ÙHH˜[ÙKŸHHßJHÂˆYˆ
-XÛY[\[ÙˆÛY[™[]PT]Y\HOOH™[˜İ[ÛˆŠH™]\›ˆ˜[ÙNÂˆYˆ
-Xİ]™T™\^PÛX[\
-H™]\›ˆXİ]™T™\^PÛX[\ÂˆYˆ
-ˆY›Ü˜ÙH	‰‚ˆ\İ™\^PÛX[\]ˆ	‰‚ˆ›İÈH\İ™\^PÛX[\]‘TVWĞÓPS•TÒS•T•SÔÑPÓÓ‘Âˆ
-HÂˆ™]\›ˆ˜[ÙNÂˆB‚ˆ\İ™\^PÛX[\]H›İÎÂˆXİ]™T™\^PÛX[\HÛY[ˆ™[]PT]Y\JÂˆ[™^ˆ[‹“PÔÓĞUUÔ‘TVWÒS‘VPÔÓĞUUÔ‘TVWÒS‘VˆÛÛ™›XİÎˆœ›ØÙYY‹ˆ™Yœ™\Úˆ˜[ÙKˆ›ÙNˆÂˆ]Y\NˆÂˆ˜[™ÙNˆÂˆ^\™\Ğ]ˆÈNˆ™]È]J›İÈ
-ˆWÌ
-KÒTÓÔİš[™Ê
-HKˆKˆKˆKˆJBˆ[Š
+export class McpOAuthError extends Error {
+  constructor(
+    message,
+    status = 400,
+    code = "invalid_request",
+    description = message,
+  ) {
+    super(message);
+    this.name = "McpOAuthError";
+    this.status = status;
+    this.code = code;
+    this.description = description;
+  }
+}
 
-HOˆYJBˆ˜Ø]Ú
+function normalizeHttpsUrl(value, fallback = "") {
+  try {
+    const url = new URL(String(value || fallback).trim());
+    if (url.protocol !== "https:") return "";
+    url.hash = "";
+    url.search = "";
+    return url.href.replace(/\/$/u, "");
+  } catch {
+    return "";
+  }
+}
 
-\œ›ÜŠHOˆÂˆYˆ
-Ü[”ÙX\˜Úİ]\Ê\œ›ÜŠHOOH
-HÂˆÛÛœÛÛK™\œ›ÜŠ–ÓPÔĞ]]™\^WH^\™Y\™XÛÜ™ÛX[\˜Z[YˆŠNÂˆBˆ™]\›ˆÜ[”ÙX\˜Úİ]\Ê\œ›ÜŠHOOHÂˆJBˆ™š[˜[J
+export function resolveMcpResourceUrl(env = process.env) {
+  return (
+    normalizeHttpsUrl(env.MCP_RESOURCE_URL) ||
+    normalizeHttpsUrl(DEFAULT_MCP_RESOURCE_URL)
+  );
+}
 
-HOˆÂˆXİ]™T™\^PÛX[\H[ÂˆJNÂ‚ˆ™]\›ˆXİ]™T™\^PÛX[\ÂŸB‚™^Ü\Ş[˜È[˜İ[ÛˆÛÛœİ[YSXÜÜ˜[Û˜ÙJÂˆÜ˜[\KˆÚÙ[’Yˆ^\™\Ğ]ˆ[ˆH›ØÙ\ÜË™[‹ˆÛY[HÙ]Ü[”ÙX\˜ÚÛY[
+export function resolveMcpIssuerUrl(env = process.env) {
+  return new URL(resolveMcpResourceUrl(env)).origin;
+}
 
-KŸJHÂˆÛÛœİİÜ™HH™\^TİÜ™JÜ˜[\JNÂˆÛÛœİ›İÈHX]™›ÛÜŠ]K››İÊ
-HÈWÌ
-NÂˆYˆ
-Ø\ÕÚÙ[ÛÛœİ[YY
-İÜ™KÚÙ[’Y›İÊJH™]\›ˆ˜[ÙNÂ‚ˆYˆ
-ÛY[
-HÂˆHÂˆÛÛœİ™\^R[™^H[‹“PÔÓĞUUÔ‘TVWÒS‘VPÔÓĞUUÔ‘TVWÒS‘VÂˆ]ØZ]ÛY[˜Ü™X]JÂˆ[™^ˆ™\^R[™^ˆYˆ™\^T™XÛÜ™Y
-Ü˜[\KÚÙ[’Y
-Kˆ›ÙNˆÂˆÜ˜[\Kˆ^\™\Ğ]ˆ™]È]J^\™\Ğ]
-ˆWÌ
-KÒTÓÔİš[™Ê
-KˆKˆ™Yœ™\ÚˆYKˆJNÂˆ]ØZ]ÛX[\^\™YXÜ™\^T™XÛÜ™ÊÈÛY[[‹›İÈJNÂˆHØ]Ú
-\œ›ÜŠHÂˆYˆ
-Ü[”ÙX\˜Úİ]\Ê\œ›ÜŠHOOHJH™]\›ˆ˜[ÙNÂˆYˆ
-™\]Z\™\Ô\œÚ\İ[XÜ™\^QİX\™
-[ŠJHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ“PÔĞ]]4-t-4/t/´.´`4,4`´/t,4`´,4-ô,4bt.4`´,4,´`4-t/4-t/t/t/ˆ4/t-H4-H4-4/´`t`´b´/ô/t,ˆ‹ˆLËˆ[\Ü˜\š[Wİ[˜]˜Z[X›H‹ˆ
-NÂˆBˆBˆH[ÙHYˆ
-™\]Z\™\Ô\œÚ\İ[XÜ™\^QİX\™
-[ŠJHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ“PÔĞ]]4-t-4/t/´.´`4,4`´/t,4`´,4-ô,4bt.4`´,4/t-H4-H4.´/´/ta4.4,ô`ô`4.4`4,4/t,ˆ‹ˆLËˆ[\Ü˜\š[Wİ[˜]˜Z[X›H‹ˆ
-NÂˆB‚ˆX\šÕÚÙ[ÛÛœİ[YY
-İÜ™KÚÙ[’Y^\™\Ğ]
-NÂˆ™]\›ˆYNÂŸB‚™[˜İ[ÛˆÜ™X]PXØÙ\ÜĞ[™™Yœ™\ÚÚÙ[œÊ^[ØY[‹›İÊHÂˆÛÛœİXØÙ\ÜÕÚÙ[ˆH[˜Ü\^[ØY
-ˆœŞ]ÚÙ[ˆ‹ˆÂˆ\ˆ˜XØÙ\Ü×İÚÙ[ˆ‹ˆ\ÜÎˆ^[ØYš\ÜËˆ]Yˆ^[ØY˜]YˆÛY[Yˆ^[ØY˜ÛY[YˆØÛÜ\Îˆ^[ØYœØÛÜ\ËˆİXš™Xİˆ^[ØYœİXš™XİˆY[[ÜSİÛ™\’Yˆ^[ØY›Y[[ÜSİÛ™\’Yˆ›ÛNˆ^[ØYœ›ÛKˆX]ˆ›İËˆ˜™ˆ›İÈHKˆ^ˆ›İÈ
-ÈPĞÑTÔ×ÕÒÑS—ÕÔÑPÓÓ‘ËˆKˆØ]]ÙXÜ™]
-[ŠKˆ
-NÂˆÛÛœİ™Yœ™\ÚÚÙ[ˆH[˜Ü\^[ØY
-ˆœŞ\™Yœ™\Ú‹ˆÂˆ\ˆœ™Yœ™\ÚİÚÙ[ˆ‹ˆNˆ˜[™ÛP]\ÊN
-KÔİš[™Ê˜˜\ÙM\›ŠKˆ\ÜÎˆ^[ØYš\ÜËˆ]Yˆ^[ØY˜]YˆÛY[Yˆ^[ØY˜ÛY[YˆØÛÜ\Îˆ^[ØYœØÛÜ\ËˆİXš™Xİˆ^[ØYœİXš™XİˆY[[ÜSİÛ™\’Yˆ^[ØY›Y[[ÜSİÛ™\’Yˆ›ÛNˆ^[ØYœ›ÛKˆX]ˆ›İËˆ^ˆ›İÈ
-È‘Q”‘TÒÕÒÑS—ÕÔÑPÓÓ‘ËˆKˆÜ˜[ÙXÜ™]
-[ŠKˆ
-NÂˆ™]\›ˆÂˆXØÙ\Ü×İÚÙ[ˆXØÙ\ÜÕÚÙ[‹ˆ™Yœ™\ÚİÚÙ[ˆ™Yœ™\ÚÚÙ[‹ˆÚÙ[—İ\Nˆ™X\™\ˆ‹ˆ^\™\×Ú[ˆPĞÑTÔ×ÕÒÑS—ÕÔÑPÓÓ‘ËˆØÛÜNˆ^[ØYœØÛÜ\Ëš›Ú[ŠˆŠKˆNÂŸB‚™^Ü\Ş[˜È[˜İ[Ûˆ^Ú[™ÙSXÜ]]Üš^˜][ÛÛÙJˆ[œ]ˆ[ˆH›ØÙ\ÜË™[‹ˆÈÛÛœİ[YQÜ˜[HÛÛœİ[YSXÜÜ˜[Û˜ÙHHHßKŠHÂˆÛÛœİÛÙHHİš[™Ê[œ]Ë˜ÛÙHˆŠNÂˆÛÛœİ^[ØYHXÜ\^[ØYÚ]˜[˜XÚÊˆÛÙKˆœŞXÛÙH‹ˆÜ˜[™\šYšXØ][Û”ÙXÜ™]Ê[ŠKˆ
-NÂˆÛÛœİ›İÈHX]™›ÛÜŠ]K››İÊ
-HÈWÌ
-NÂˆYˆ
-ˆ\^[ØYˆ^[ØY\OOH˜]]Üš^˜][Û—ØÛÙHˆˆ^[ØYš\ÜÈOOH™\ÛÛ™SXÜ\ÜİY\•\›
-[ŠHˆ^[ØY˜]YOOH™\ÛÛ™SXÜ™\Ûİ\˜ÙU\›
-[ŠHˆ^[ØY™^H›İÂˆ
-HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ´'t-t,´,4.ô.4-4-t/H4.4.ô.4.4-ô`´-t.´b´.È]]Üš^˜][ÛˆÛÙKˆ‹ˆˆš[˜[YÙÜ˜[‹ˆ
-NÂˆBˆYˆ
-ˆ[œ]Ë™Ü˜[İ\HOOH˜]]Üš^˜][Û—ØÛÙHˆˆ\ØY™Tİš[™Ñ\]X[
-[œ]Ë˜ÛY[ÚY^[ØY˜ÛY[Y
-Hˆ\ØY™Tİš[™Ñ\]X[
-[œ]Ëœ™Y\™Xİİ\šK^[ØYœ™Y\™Xİ\šJHˆ\ØY™Tİš[™Ñ\]X[
-[œ]Ëœ™\Ûİ\˜ÙK^[ØY˜]Y
-Bˆ
-HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ]]Üš^˜][ÛˆÛÙH4/t-H4`tb´,´/ô,4-4,4`tb´`H4-ô,4cô,´.´,4`´,ˆ‹ˆˆš[˜[YÙÜ˜[‹ˆ
-NÂˆBˆÛÛœİ™\šYšY\ˆHİš[™Ê[œ]Ë˜ÛÙWİ™\šYšY\ˆˆŠNÂˆYˆ
-K×–ĞKV˜K^ŒNK—ß‹W^ÍËLIİK\İ
-™\šYšY\ŠJHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠ´'t-t,´,4.ô.4-4-t/HĞÑH™\šYšY\‹ˆ‹š[˜[YÙÜ˜[ŠNÂˆBˆÛÛœİÚ[[™ÙHHÜ™X]R\Ú
-œÚLMˆŠK\]J™\šYšY\ŠK™YÙ\İ
-˜˜\ÙM\›ŠNÂˆYˆ
-\ØY™Tİš[™Ñ\]X[
-Ú[[™ÙK^[ØY˜ÛÙPÚ[[™ÙJJHÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ”ĞÑH4/ô`4/´,´-t`4.´,4`´,4-H4/t-t`ô`t/ô-tb4/t,ˆ‹ˆˆš[˜[YÙÜ˜[‹ˆ
-NÂˆB‚ˆÛÛœİÛÛœİ[YYH]ØZ]ÛÛœİ[YQÜ˜[
-ÂˆÜ˜[\Nˆ˜]]Üš^˜][Û—ØÛÙH‹ˆÚÙ[’Yˆ^[ØYšKˆ^\™\Ğ]ˆ^[ØY™^ˆ[‹ˆJNÂˆYˆ
-XÛÛœİ[YY
-HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ´'t-t,´,4.ô.4-4-t/H4.4.ô.4.4-ô`´-t.´b´.È]]Üš^˜][ÛˆÛÙKˆ‹ˆˆš[˜[YÙÜ˜[‹ˆ
-NÂˆBˆ™]\›ˆÜ™X]PXØÙ\ÜĞ[™™Yœ™\ÚÚÙ[œÊ^[ØY[‹›İÊNÂŸB‚™^Ü\Ş[˜È[˜İ[Ûˆ^Ú[™ÙSXÜ™Yœ™\ÚÚÙ[Šˆ[œ]ˆ[ˆH›ØÙ\ÜË™[‹ˆÈÛÛœİ[YQÜ˜[HÛÛœİ[YSXÜÜ˜[Û˜ÙHHHßKŠHÂˆÛÛœİ^[ØYHXÜ\^[ØYÚ]˜[˜XÚÊˆİš[™Ê[œ]Ëœ™Yœ™\ÚİÚÙ[ˆˆŠKˆœŞ\™Yœ™\Ú‹ˆÜ˜[™\šYšXØ][Û”ÙXÜ™]Ê[ŠKˆ
-NÂˆÛÛœİ›İÈHX]™›ÛÜŠ]K››İÊ
-HÈWÌ
-NÂˆYˆ
-ˆ\^[ØYˆ^[ØY\OOHœ™Yœ™\ÚİÚÙ[ˆˆˆ^[ØYš\ÜÈOOH™\ÛÛ™SXÜ\ÜİY\•\›
-[ŠHˆ^[ØY˜]YOOH™\ÛÛ™SXÜ™\Ûİ\˜ÙU\›
-[ŠHˆ^[ØY™^H›İÈˆ\ØY™Tİš[™Ñ\]X[
-[œ]Ë˜ÛY[ÚY^[ØY˜ÛY[Y
-Hˆ\ØY™Tİš[™Ñ\]X[
-[œ]Ëœ™\Ûİ\˜ÙK^[ØY˜]Y
-Bˆ
-HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ´'t-t,´,4.ô.4-4-t/H4.4.ô.4.4-ô`´-t.´b´.È™Yœ™\ÚÚÙ[‹ˆ‹ˆˆš[˜[YÙÜ˜[‹ˆ
-NÂˆBˆÛÛœİÛÛœİ[YYH]ØZ]ÛÛœİ[YQÜ˜[
-ÂˆÜ˜[\Nˆœ™Yœ™\ÚİÚÙ[ˆ‹ˆÚÙ[’Yˆ^[ØYšKˆ^\™\Ğ]ˆ^[ØY™^ˆ[‹ˆJNÂˆYˆ
-XÛÛœİ[YY
-HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ´'t-t,´,4.ô.4-4-t/H4.4.ô.4.4-ô`´-t.´b´.È™Yœ™\ÚÚÙ[‹ˆ‹ˆˆš[˜[YÙÜ˜[‹ˆ
-NÂˆBˆ™]\›ˆÜ™X]PXØÙ\ÜĞ[™™Yœ™\ÚÚÙ[œÊ^[ØY[‹›İÊNÂŸB‚™^Ü\Ş[˜È[˜İ[Ûˆ^Ú[™ÙSXÜÚÙ[Š[œ][ˆH›ØÙ\ÜË™[ŠHÂˆYˆ
-[œ]Ë™Ü˜[İ\HOOH˜]]Üš^˜][Û—ØÛÙHŠHÂˆ™]\›ˆ^Ú[™ÙSXÜ]]Üš^˜][ÛÛÙJ[œ][ŠNÂˆBˆYˆ
-[œ]Ë™Ü˜[İ\HOOHœ™Yœ™\ÚİÚÙ[ˆŠHÂˆ™]\›ˆ^Ú[™ÙSXÜ™Yœ™\ÚÚÙ[Š[œ][ŠNÂˆBˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ´'t-t/ô/´-4-4b´`4-´,4/HĞ]]Ü˜[ˆ‹ˆˆ[œİ\ÜYÙÜ˜[İ\H‹ˆ
-NÂŸB‚™^Ü[˜İ[Ûˆ™\šYSXÜXØÙ\ÜÕÚÙ[Šˆ]]Üš^˜][Û’XY\‹ˆ™\]Z\™YØÛÜ\ÈHÓPÔÔ‘PQÔĞÓÔWKˆ[ˆH›ØÙ\ÜË™[‹ŠHÂˆYˆ
-ˆ\[Ùˆ]]Üš^˜][Û’XY\ˆOOHœİš[™ÈˆˆX]]Üš^˜][Û’XY\‹œİ\ÕÚ]
-™X\™\ˆŠBˆ
-HÂˆ™]\›ˆ[ÂˆBˆÛÛœİ^[ØYHXÜ\^[ØYÚ]˜[˜XÚÊˆ]]Üš^˜][Û’XY\‹œÛXÙJÊKˆœŞ]ÚÙ[ˆ‹ˆØ]]™\šYšXØ][Û”ÙXÜ™]Ê[ŠKˆ
-NÂˆÛÛœİ›İÈHX]™›ÛÜŠ]K››İÊ
-HÈWÌ
-NÂˆYˆ
-ˆ\^[ØYˆ^[ØY\OOH˜XØÙ\Ü×İÚÙ[ˆˆˆ^[ØYš\ÜÈOOH™\ÛÛ™SXÜ\ÜİY\•\›
-[ŠHˆ^[ØY˜]YOOH™\ÛÛ™SXÜ™\Ûİ\˜ÙU\›
-[ŠHˆ^[ØY›˜™ˆˆ›İÈˆ^[ØY™^H›İÈˆP\œ˜^Kš\Ğ\œ˜^J^[ØYœØÛÜ\ÊHˆ\^[ØYœİXš™Xİˆ\^[ØY›Y[[ÜSİÛ™\’YˆVÈ›İÛ™\ˆ‹›Y[X™\ˆ‹\İ\ˆ—Kš[˜ÛY\Ê^[ØYœ›ÛJBˆ
-HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ´'t-t,´,4.ô.4-4-t/H4.4.ô.4.4-ô`´-t.´b´.ÈPÔÚÙ[‹ˆ‹ˆKˆš[˜[YİÚÙ[ˆ‹ˆ
-NÂˆBˆYˆ
-ˆ™\]Z\™YØÛÜ\ËœÛÛYJ
-ØÛÜJHOˆ\^[ØYœØÛÜ\Ëš[˜ÛY\ÊØÛÜJJHˆ
-™\]Z\™\ÓİÛ™\”›ÛJ™\]Z\™YØÛÜ\ÊH	‰ˆ^[ØYœ›ÛHOOH›İÛ™\ˆŠBˆ
-HÂˆ›İÈ™]ÈXÜĞ]]\œ›ÜŠˆ“PÔÚÙ[ˆ4/tcô/4,4/t-t/´,tat/´-4.4/4.4`´-H4/ô`4,4,´,ˆ‹ˆËˆš[œİY™šXÚY[ÜØÛÜH‹ˆ
-NÂˆBˆ™]\›ˆÂˆYˆ^[ØYœİXš™XİˆY[[ÜSİÛ™\’Yˆ^[ØY›Y[[ÜSİÛ™\’Yˆ›ÛNˆ^[ØYœ›ÛKˆØÛÜ\Îˆ^[ØYœØÛÜ\ËˆÛY[Yˆ^[ØY˜ÛY[YˆNÂŸB‚™^Ü[˜İ[Ûˆ™\Ù]XÜĞ]]İ]Q›Ü•\İÊ
-HÂˆÛÛœİ[YY]]Üš^˜][ÛÛÙ\Ë˜ÛX\Š
-NÂˆÛÛœİ[YY™Yœ™\ÚÚÙ[œË˜ÛX\Š
-NÂˆ\İ™\^PÛX[\]HÂˆXİ]™T™\^PÛX[\H[ÂŸB
+function deriveOAuthSecret(label, source) {
+  return createHash("sha256").update(`${label}\0`).update(source).digest();
+}
+
+function legacyOAuthSecret(env = process.env) {
+  const source =
+    typeof env.MCP_ACCESS_TOKEN === "string" ? env.MCP_ACCESS_TOKEN.trim() : "";
+  if (source.length < 32) {
+    throw new McpOAuthError(
+      "MCP OAuth Ğ·Ğ°Ñ‰Ğ¸Ñ‚Ğ°Ñ‚Ğ° Ğ½Ğµ Ğµ ĞºĞ¾Ğ½Ñ„Ğ¸Ğ³ÑƒÑ€Ğ¸Ñ€Ğ°Ğ½Ğ°.",
+      503,
+      "temporarily_unavailable",
+    );
+  }
+  return deriveOAuthSecret("synchron-mcp-oauth-v1", source);
+}
+
+function dedicatedOAuthSecret(env = process.env) {
+  const source =
+    typeof env.MCP_OAUTH_SECRET === "string" ? env.MCP_OAUTH_SECRET.trim() : "";
+  if (!source) return null;
+  if (source.length < 32) {
+    throw new McpOAuthError(
+      "ĞÑ‚Ğ´ĞµĞ»Ğ½Ğ¸ÑÑ‚ MCP OAuth ĞºĞ»ÑÑ‡ Ğµ Ğ½ĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½.",
+      503,
+      "temporarily_unavailable",
+    );
+  }
+  return deriveOAuthSecret("synchron-mcp-oauth-dedicated-v1", source);
+}
+
+function oauthSecret(env = process.env) {
+  return dedicatedOAuthSecret(env) || legacyOAuthSecret(env);
+}
+
+function oauthVerificationSecrets(env = process.env) {
+  const dedicated = dedicatedOAuthSecret(env);
+  if (!dedicated) return [legacyOAuthSecret(env)];
+  const secrets = [dedicated];
+  try {
+    const legacy = legacyOAuthSecret(env);
+    if (!legacy.equals(dedicated)) secrets.push(legacy);
+  } catch {
+    // A dedicated key can run OAuth without enabling the legacy bearer.
+  }
+  return secrets;
+}
+
+function deriveGrantSecret(secret) {
+  return createHash("sha256")
+    .update(secret)
+    .update("synchron-mcp-oauth-grants-v2\0")
+    .digest();
+}
+
+function grantSecret(env = process.env) {
+  return deriveGrantSecret(oauthSecret(env));
+}
+
+function grantVerificationSecrets(env = process.env) {
+  return oauthVerificationSecrets(env).map(deriveGrantSecret);
+}
+
+export function getMcpOAuthSecretMode(env = process.env) {
+  if (dedicatedOAuthSecret(env)) return "dedicated";
+  legacyOAuthSecret(env);
+  return "legacy_fallback";
+}
+
+export function isMcpOAuthConfigured(env = process.env) {
+  try {
+    return Boolean(resolveMcpResourceUrl(env) && oauthSecret(env));
+  } catch {
+    return false;
+  }
+}
+
+export function getMcpProtectedResourceMetadata(env = process.env) {
+  const resource = resolveMcpResourceUrl(env);
+  return {
+    resource,
+    authorization_servers: [resolveMcpIssuerUrl(env)],
+    scopes_supported: MCP_SCOPES,
+  };
+}
+
+export function getMcpAuthorizationServerMetadata(env = process.env) {
+  const issuer = resolveMcpIssuerUrl(env);
+  return {
+    issuer,
+    authorization_endpoint: `${issuer}/oauth/authorize`,
+    token_endpoint: `${issuer}/oauth/token`,
+    client_id_metadata_document_supported: true,
+    token_endpoint_auth_methods_supported: ["none"],
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    code_challenge_methods_supported: ["S256"],
+    scopes_supported: MCP_SCOPES,
+  };
+}
+
+export function requiredScopesForMcpTool(name) {
+  if (
+    name === "prepare_digitalocean_www_domain" ||
+    name === "confirm_digitalocean_www_domain"
+  ) {
+    return [MCP_INFRASTRUCTURE_WRITE_SCOPE];
+  }
+  return name === "prepare_github_merged_branch_cleanup" ||
+    name === "confirm_github_merged_branch_cleanup"
+    ? [MCP_GITHUB_WRITE_SCOPE]
+    : [MCP_READ_SCOPE];
+}
+
+export function mcpToolSecuritySchemes(name) {
+  return Object.freeze([
+    Object.freeze({
+      type: "oauth2",
+      scopes: Object.freeze(requiredScopesForMcpTool(name)),
+    }),
+  ]);
+}
+
+export function buildMcpAuthenticateChallenge(
+  scopes = [MCP_READ_SCOPE],
+  env = process.env,
+  { error, description } = {},
+) {
+  const safeHeaderValue = (value) =>
+    String(value).replace(/[^\x20-\x7E]|["\\]/gu, "");
+  const origin = resolveMcpIssuerUrl(env);
+  const values = [
+    `resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
+    `scope="${scopes.join(" ")}"`,
+  ];
+  if (error) values.push(`error="${safeHeaderValue(error)}"`);
+  if (description) {
+    values.push(`error_description="${safeHeaderValue(description)}"`);
+  }
+  return `Bearer ${values.join(", ")}`;
+}
+
+function encryptPayload(prefix, payload, key) {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(payload), "utf8"),
+    cipher.final(),
+  ]);
+  return `${prefix}.${Buffer.concat([
+    iv,
+    cipher.getAuthTag(),
+    ciphertext,
+  ]).toString("base64url")}`;
+}
+
+function decryptPayload(value, prefix, key) {
+  if (typeof value !== "string" || !value.startsWith(`${prefix}.`)) return null;
+  try {
+    const data = Buffer.from(value.slice(prefix.length + 1), "base64url");
+    if (data.length < 29) return null;
+    const decipher = createDecipheriv("aes-256-gcm", key, data.subarray(0, 12));
+    decipher.setAuthTag(data.subarray(12, 28));
+    const plaintext = Buffer.concat([
+      decipher.update(data.subarray(28)),
+      decipher.final(),
+    ]).toString("utf8");
+    return JSON.parse(plaintext);
+  } catch {
+    return null;
+  }
+}
+
+function decryptPayloadWithFallback(value, prefix, keys) {
+  for (const key of keys) {
+    const payload = decryptPayload(value, prefix, key);
+    if (payload) return payload;
+  }
+  return null;
+}
+
+function parseScopes(value) {
+  const scopes = [...new Set(String(value || MCP_READ_SCOPE).split(/\s+/u))]
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+  if (
+    scopes.length === 0 ||
+    scopes.some((scope) => !MCP_SCOPES.includes(scope))
+  ) {
+    throw new McpOAuthError(
+      "ĞŸĞ¾Ğ¸ÑĞºĞ°Ğ½Ğ¸Ñ‚Ğµ MCP Ğ¿Ñ€Ğ°Ğ²Ğ° Ğ½Ğµ ÑĞµ Ğ¿Ğ¾Ğ´Ğ´ÑŠÑ€Ğ¶Ğ°Ñ‚.",
+      400,
+      "invalid_scope",
+    );
+  }
+  return scopes;
+}
+
+function requiresOwnerRole(scopes = []) {
+  return scopes.some((scope) => MCP_OWNER_ONLY_SCOPES.includes(scope));
+}
+
+function isAllowedOpenAiClientId(value) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || url.username || url.password) return false;
+    const host = url.hostname.toLowerCase();
+    return (
+      host === "chatgpt.com" ||
+      host.endsWith(".chatgpt.com") ||
+      host === "openai.com" ||
+      host.endsWith(".openai.com")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export async function validateMcpAuthorizationRequest(
+  input,
+  { env = process.env, fetchImpl = fetch } = {},
+) {
+  const resource = resolveMcpResourceUrl(env);
+  const clientId = String(input?.client_id || "").trim();
+  const redirectUri = String(input?.redirect_uri || "").trim();
+  const state = String(input?.state || "").trim();
+  const codeChallenge = String(input?.code_challenge || "").trim();
+
+  if (input?.response_type !== "code") {
+    throw new McpOAuthError("ĞŸĞ¾Ğ´Ğ´ÑŠÑ€Ğ¶Ğ° ÑĞµ ÑĞ°Ğ¼Ğ¾ authorization code.");
+  }
+  if (!isAllowedOpenAiClientId(clientId)) {
+    throw new McpOAuthError("ĞĞµĞ¿Ğ¾Ğ·Ğ½Ğ°Ñ‚ OAuth ĞºĞ»Ğ¸ĞµĞ½Ñ‚.", 400, "invalid_client");
+  }
+  if (!state || state.length > 1_000) {
+    throw new McpOAuthError("Ğ›Ğ¸Ğ¿ÑĞ²Ğ° Ğ²Ğ°Ğ»Ğ¸Ğ´Ğ½Ğ¾ OAuth ÑÑŠÑÑ‚Ğ¾ÑĞ½Ğ¸Ğµ.");
+  }
+  if (
+    input?.code_challenge_method !== "S256" ||
+    !/^[A-Za-z0-9_-]{43,128}$/u.test(codeChallenge)
+  ) {
+    throw new McpOAuthError("Ğ˜Ğ·Ğ¸ÑĞºĞ²Ğ° ÑĞµ PKCE S256.");
+  }
+  if (String(input?.resource || "") !== resource) {
+    throw new McpOAuthError("ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ MCP resource.", 400, "invalid_target");
+  }
+
+  let metadata;
+  try {
+    const response = await fetchImpl(clientId, {
+      headers: { Accept: "application/json" },
+      redirect: "error",
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) throw new Error("CLIENT_METADATA_UNAVAILABLE");
+    metadata = await response.json();
+  } catch {
+    throw new McpOAuthError(
+      "OAuth ĞºĞ»Ğ¸ĞµĞ½Ñ‚ÑŠÑ‚ Ğ½Ğµ Ğ¼Ğ¾Ğ¶Ğµ Ğ´Ğ° Ğ±ÑŠĞ´Ğµ Ğ¿Ñ€Ğ¾Ğ²ĞµÑ€ĞµĞ½.",
+      400,
+      "invalid_client",
+    );
+  }
+
+  if (
+    metadata?.client_id !== clientId ||
+    typeof metadata?.client_name !== "string" ||
+    !metadata.client_name.trim() ||
+    !Array.isArray(metadata.redirect_uris) ||
+    !metadata.redirect_uris.includes(redirectUri) ||
+    !(
+      metadata.token_endpoint_auth_method === "none" ||
+      metadata.token_endpoint_auth_methods_supported?.includes?.("none")
+    )
+  ) {
+    throw new McpOAuthError(
+      "OAuth callback Ğ°Ğ´Ñ€ĞµÑÑŠÑ‚ Ğ½Ğµ Ğµ Ñ€Ğ°Ğ·Ñ€ĞµÑˆĞµĞ½ Ğ¾Ñ‚ ĞºĞ»Ğ¸ĞµĞ½Ñ‚Ğ°.",
+      400,
+      "invalid_client",
+    );
+  }
+
+  return {
+    clientId,
+    clientName: metadata.client_name.trim(),
+    redirectUri,
+    state,
+    codeChallenge,
+    resource,
+    scopes: parseScopes(input?.scope),
+  };
+}
+
+export function createMcpAuthorizationCode(
+  request,
+  identity,
+  env = process.env,
+) {
+  if (!identity?.id || !identity?.memoryOwnerId || !identity?.role) {
+    throw new McpOAuthError("Ğ›Ğ¸Ğ¿ÑĞ²Ğ° Ğ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ SYNCHRON-X Ğ¿Ñ€Ğ¾Ñ„Ğ¸Ğ».", 401);
+  }
+  if (requiresOwnerRole(request.scopes) && identity.role !== "owner") {
+    throw new McpOAuthError(
+      "MCP Ğ·Ğ°Ğ¿Ğ¸ÑÑŠÑ‚ Ğµ Ğ´Ğ¾ÑÑ‚ÑŠĞ¿ĞµĞ½ ÑĞ°Ğ¼Ğ¾ Ğ·Ğ° ÑĞ¾Ğ±ÑÑ‚Ğ²ĞµĞ½Ğ¸ĞºĞ°.",
+      403,
+      "access_denied",
+    );
+  }
+  const now = Math.floor(Date.now() / 1_000);
+  return encryptPayload(
+    "sx-code",
+    {
+      typ: "authorization_code",
+      jti: randomBytes(18).toString("base64url"),
+      iss: resolveMcpIssuerUrl(env),
+      aud: request.resource,
+      clientId: request.clientId,
+      redirectUri: request.redirectUri,
+      codeChallenge: request.codeChallenge,
+      scopes: request.scopes,
+      subject: String(identity.id),
+      memoryOwnerId: String(identity.memoryOwnerId),
+      role: String(identity.role),
+      iat: now,
+      exp: now + AUTHORIZATION_CODE_TTL_SECONDS,
+    },
+    grantSecret(env),
+  );
+}
+
+function safeStringEqual(left, right) {
+  const a = Buffer.from(String(left), "utf8");
+  const b = Buffer.from(String(right), "utf8");
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+function wasTokenConsumed(store, tokenId, now) {
+  for (const [storedId, expiresAt] of store) {
+    if (expiresAt <= now) store.delete(storedId);
+  }
+  return store.has(tokenId);
+}
+
+function markTokenConsumed(store, tokenId, expiresAt) {
+  store.set(tokenId, expiresAt);
+  while (store.size > MAX_CONSUMED_TOKEN_RECORDS) {
+    store.delete(store.keys().next().value);
+  }
+}
+
+function replayStore(grantType) {
+  return grantType === "authorization_code"
+    ? consumedAuthorizationCodes
+    : consumedRefreshTokens;
+}
+
+function replayRecordId(grantType, tokenId) {
+  return createHash("sha256")
+    .update(String(grantType))
+    .update("\0")
+    .update(String(tokenId))
+    .digest("hex");
+}
+
+function openSearchStatus(error) {
+  return error?.statusCode || error?.meta?.statusCode || 0;
+}
+
+export function requiresPersistentMcpReplayGuard(env = process.env) {
+  return env.NODE_ENV === "production";
+}
+
+export async function cleanupExpiredMcpReplayRecords({
+  client = getOpenSearchClient(),
+  env = process.env,
+  now = Math.floor(Date.now() / 1_000),
+  force = false,
+} = {}) {
+  if (!client || typeof client.deleteByQuery !== "function") return false;
+  if (activeReplayCleanup) return activeReplayCleanup;
+  if (
+    !force &&
+    lastReplayCleanupAt > 0 &&
+    now - lastReplayCleanupAt < REPLAY_CLEANUP_INTERVAL_SECONDS
+  ) {
+    return false;
+  }
+
+  lastReplayCleanupAt = now;
+  activeReplayCleanup = client
+    .deleteByQuery({
+      index: env.MCP_OAUTH_REPLAY_INDEX || MCP_OAUTH_REPLAY_INDEX,
+      conflicts: "proceed",
+      refresh: false,
+      body: {
+        query: {
+          range: {
+            expiresAt: { lte: new Date(now * 1_000).toISOString() },
+          },
+        },
+      },
+    })
+    .then(() => true)
+    .catch((error) => {
+      if (openSearchStatus(error) !== 404) {
+        console.error("[MCP OAuth replay] Expired-record cleanup failed.");
+      }
+      return openSearchStatus(error) === 404;
+    })
+    .finally(() => {
+      activeReplayCleanup = null;
+    });
+
+  return activeReplayCleanup;
+}
+
+export async function consumeMcpGrantOnce({
+  grantType,
+  tokenId,
+  expiresAt,
+  env = process.env,
+  client = getOpenSearchClient(),
+}) {
+  const store = replayStore(grantType);
+  const now = Math.floor(Date.now() / 1_000);
+  if (wasTokenConsumed(store, tokenId, now)) return false;
+
+  if (client) {
+    try {
+      const replayIndex = env.MCP_OAUTH_REPLAY_INDEX || MCP_OAUTH_REPLAY_INDEX;
+      await client.create({
+        index: replayIndex,
+        id: replayRecordId(grantType, tokenId),
+        body: {
+          grantType,
+          expiresAt: new Date(expiresAt * 1_000).toISOString(),
+        },
+        refresh: true,
+      });
+      await cleanupExpiredMcpReplayRecords({ client, env, now });
+    } catch (error) {
+      if (openSearchStatus(error) === 409) return false;
+      if (requiresPersistentMcpReplayGuard(env)) {
+        throw new McpOAuthError(
+          "MCP OAuth ĞµĞ´Ğ½Ğ¾ĞºÑ€Ğ°Ñ‚Ğ½Ğ°Ñ‚Ğ° Ğ·Ğ°Ñ‰Ğ¸Ñ‚Ğ° Ğ²Ñ€ĞµĞ¼ĞµĞ½Ğ½Ğ¾ Ğ½Ğµ Ğµ Ğ´Ğ¾ÑÑ‚ÑŠĞ¿Ğ½Ğ°.",
+          503,
+          "temporarily_unavailable",
+        );
+      }
+    }
+  } else if (requiresPersistentMcpReplayGuard(env)) {
+    throw new McpOAuthError(
+      "MCP OAuth ĞµĞ´Ğ½Ğ¾ĞºÑ€Ğ°Ñ‚Ğ½Ğ°Ñ‚Ğ° Ğ·Ğ°Ñ‰Ğ¸Ñ‚Ğ° Ğ½Ğµ Ğµ ĞºĞ¾Ğ½Ñ„Ğ¸Ğ³ÑƒÑ€Ğ¸Ñ€Ğ°Ğ½Ğ°.",
+      503,
+      "temporarily_unavailable",
+    );
+  }
+
+  markTokenConsumed(store, tokenId, expiresAt);
+  return true;
+}
+
+function createAccessAndRefreshTokens(payload, env, now) {
+  const accessToken = encryptPayload(
+    "sx-token",
+    {
+      typ: "access_token",
+      iss: payload.iss,
+      aud: payload.aud,
+      clientId: payload.clientId,
+      scopes: payload.scopes,
+      subject: payload.subject,
+      memoryOwnerId: payload.memoryOwnerId,
+      role: payload.role,
+      iat: now,
+      nbf: now - 5,
+      exp: now + ACCESS_TOKEN_TTL_SECONDS,
+    },
+    oauthSecret(env),
+  );
+  const refreshToken = encryptPayload(
+    "sx-refresh",
+    {
+      typ: "refresh_token",
+      jti: randomBytes(18).toString("base64url"),
+      iss: payload.iss,
+      aud: payload.aud,
+      clientId: payload.clientId,
+      scopes: payload.scopes,
+      subject: payload.subject,
+      memoryOwnerId: payload.memoryOwnerId,
+      role: payload.role,
+      iat: now,
+      exp: now + REFRESH_TOKEN_TTL_SECONDS,
+    },
+    grantSecret(env),
+  );
+  return {
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    token_type: "Bearer",
+    expires_in: ACCESS_TOKEN_TTL_SECONDS,
+    scope: payload.scopes.join(" "),
+  };
+}
+
+export async function exchangeMcpAuthorizationCode(
+  input,
+  env = process.env,
+  { consumeGrant = consumeMcpGrantOnce } = {},
+) {
+  const code = String(input?.code || "");
+  const payload = decryptPayloadWithFallback(
+    code,
+    "sx-code",
+    grantVerificationSecrets(env),
+  );
+  const now = Math.floor(Date.now() / 1_000);
+  if (
+    !payload ||
+    payload.typ !== "authorization_code" ||
+    payload.iss !== resolveMcpIssuerUrl(env) ||
+    payload.aud !== resolveMcpResourceUrl(env) ||
+    payload.exp <= now
+  ) {
+    throw new McpOAuthError(
+      "ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ Ğ¸Ğ»Ğ¸ Ğ¸Ğ·Ñ‚ĞµĞºÑŠĞ» authorization code.",
+      400,
+      "invalid_grant",
+    );
+  }
+  if (
+    input?.grant_type !== "authorization_code" ||
+    !safeStringEqual(input?.client_id, payload.clientId) ||
+    !safeStringEqual(input?.redirect_uri, payload.redirectUri) ||
+    !safeStringEqual(input?.resource, payload.aud)
+  ) {
+    throw new McpOAuthError(
+      "Authorization code Ğ½Ğµ ÑÑŠĞ²Ğ¿Ğ°Ğ´Ğ° ÑÑŠÑ Ğ·Ğ°ÑĞ²ĞºĞ°Ñ‚Ğ°.",
+      400,
+      "invalid_grant",
+    );
+  }
+  const verifier = String(input?.code_verifier || "");
+  if (!/^[A-Za-z0-9._~-]{43,128}$/u.test(verifier)) {
+    throw new McpOAuthError("ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ PKCE verifier.", 400, "invalid_grant");
+  }
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  if (!safeStringEqual(challenge, payload.codeChallenge)) {
+    throw new McpOAuthError(
+      "PKCE Ğ¿Ñ€Ğ¾Ğ²ĞµÑ€ĞºĞ°Ñ‚Ğ° Ğµ Ğ½ĞµÑƒÑĞ¿ĞµÑˆĞ½Ğ°.",
+      400,
+      "invalid_grant",
+    );
+  }
+
+  const consumed = await consumeGrant({
+    grantType: "authorization_code",
+    tokenId: payload.jti,
+    expiresAt: payload.exp,
+    env,
+  });
+  if (!consumed) {
+    throw new McpOAuthError(
+      "ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ Ğ¸Ğ»Ğ¸ Ğ¸Ğ·Ñ‚ĞµĞºÑŠĞ» authorization code.",
+      400,
+      "invalid_grant",
+    );
+  }
+  return createAccessAndRefreshTokens(payload, env, now);
+}
+
+export async function exchangeMcpRefreshToken(
+  input,
+  env = process.env,
+  { consumeGrant = consumeMcpGrantOnce } = {},
+) {
+  const payload = decryptPayloadWithFallback(
+    String(input?.refresh_token || ""),
+    "sx-refresh",
+    grantVerificationSecrets(env),
+  );
+  const now = Math.floor(Date.now() / 1_000);
+  if (
+    !payload ||
+    payload.typ !== "refresh_token" ||
+    payload.iss !== resolveMcpIssuerUrl(env) ||
+    payload.aud !== resolveMcpResourceUrl(env) ||
+    payload.exp <= now ||
+    !safeStringEqual(input?.client_id, payload.clientId) ||
+    !safeStringEqual(input?.resource, payload.aud)
+  ) {
+    throw new McpOAuthError(
+      "ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ Ğ¸Ğ»Ğ¸ Ğ¸Ğ·Ñ‚ĞµĞºÑŠĞ» refresh token.",
+      400,
+      "invalid_grant",
+    );
+  }
+  const consumed = await consumeGrant({
+    grantType: "refresh_token",
+    tokenId: payload.jti,
+    expiresAt: payload.exp,
+    env,
+  });
+  if (!consumed) {
+    throw new McpOAuthError(
+      "ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ Ğ¸Ğ»Ğ¸ Ğ¸Ğ·Ñ‚ĞµĞºÑŠĞ» refresh token.",
+      400,
+      "invalid_grant",
+    );
+  }
+  return createAccessAndRefreshTokens(payload, env, now);
+}
+
+export async function exchangeMcpToken(input, env = process.env) {
+  if (input?.grant_type === "authorization_code") {
+    return exchangeMcpAuthorizationCode(input, env);
+  }
+  if (input?.grant_type === "refresh_token") {
+    return exchangeMcpRefreshToken(input, env);
+  }
+  throw new McpOAuthError(
+    "ĞĞµĞ¿Ğ¾Ğ´Ğ´ÑŠÑ€Ğ¶Ğ°Ğ½ OAuth grant.",
+    400,
+    "unsupported_grant_type",
+  );
+}
+
+export function verifyMcpAccessToken(
+  authorizationHeader,
+  requiredScopes = [MCP_READ_SCOPE],
+  env = process.env,
+) {
+  if (
+    typeof authorizationHeader !== "string" ||
+    !authorizationHeader.startsWith("Bearer ")
+  ) {
+    return null;
+  }
+  const payload = decryptPayloadWithFallback(
+    authorizationHeader.slice(7),
+    "sx-token",
+    oauthVerificationSecrets(env),
+  );
+  const now = Math.floor(Date.now() / 1_000);
+  if (
+    !payload ||
+    payload.typ !== "access_token" ||
+    payload.iss !== resolveMcpIssuerUrl(env) ||
+    payload.aud !== resolveMcpResourceUrl(env) ||
+    payload.nbf > now ||
+    payload.exp <= now ||
+    !Array.isArray(payload.scopes) ||
+    !payload.subject ||
+    !payload.memoryOwnerId ||
+    !["owner", "member", "tester"].includes(payload.role)
+  ) {
+    throw new McpOAuthError(
+      "ĞĞµĞ²Ğ°Ğ»Ğ¸Ğ´ĞµĞ½ Ğ¸Ğ»Ğ¸ Ğ¸Ğ·Ñ‚ĞµĞºÑŠĞ» MCP token.",
+      401,
+      "invalid_token",
+    );
+  }
+  if (
+    requiredScopes.some((scope) => !payload.scopes.includes(scope)) ||
+    (requiresOwnerRole(requiredScopes) && payload.role !== "owner")
+  ) {
+    throw new McpOAuthError(
+      "MCP token Ğ½ÑĞ¼Ğ° Ğ½ĞµĞ¾Ğ±Ñ…Ğ¾Ğ´Ğ¸Ğ¼Ğ¸Ñ‚Ğµ Ğ¿Ñ€Ğ°Ğ²Ğ°.",
+      403,
+      "insufficient_scope",
+    );
+  }
+  return {
+    id: payload.subject,
+    memoryOwnerId: payload.memoryOwnerId,
+    role: payload.role,
+    scopes: payload.scopes,
+    clientId: payload.clientId,
+  };
+}
+
+export function resetMcpOAuthStateForTests() {
+  consumedAuthorizationCodes.clear();
+  consumedRefreshTokens.clear();
+  lastReplayCleanupAt = 0;
+  activeReplayCleanup = null;
+}

--- a/src/services/mcpReadService.js
+++ b/src/services/mcpReadService.js
@@ -4,7 +4,10 @@ import {
   listConversationSummaries,
   listProfileMemories,
 } from "./memoryService.js";
-import { recordAuditEvent } from "./permissionService.js";
+import {
+  executeAuditedWriteAction,
+  recordAuditEvent,
+} from "./permissionService.js";
 import {
   createDurableConfirmation,
   markDurableConfirmationUsed,
@@ -15,10 +18,14 @@ import {
   executeMergedBranchCleanup,
 } from "./githubBranchCleanupService.js";
 import {
+  activateDigitalOceanDomainAlias,
+  DIGITALOCEAN_DOMAIN_ACTION,
   formatDigitalOceanAudit,
   formatDigitalOceanStatus,
   getDigitalOceanAccountAudit,
   getDigitalOceanAppStatus,
+  inspectDigitalOceanDomainAlias,
+  PUBLIC_WWW_DOMAIN,
 } from "./digitalOceanService.js";
 import {
   formatCloudflareStatus,
@@ -148,6 +155,35 @@ export const MCP_TOOLS = Object.freeze([
     annotations: READ_ONLY_ANNOTATIONS,
   },
   {
+    name: "prepare_digitalocean_www_domain",
+    title: "Подготви добавянето на www адреса",
+    description:
+      "Проверява DigitalOcean приложението и подготвя еднократно потвърждение само за www.synchron.foundation. Не променя домейни и не стартира deployment.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    securitySchemes: mcpToolSecuritySchemes("prepare_digitalocean_www_domain"),
+    annotations: READ_ONLY_ANNOTATIONS,
+  },
+  {
+    name: "confirm_digitalocean_www_domain",
+    title: "Потвърди добавянето на www адреса",
+    description:
+      "Добавя единствено www.synchron.foundation към предварително провереното DigitalOcean приложение след валидно еднократно потвърждение и устойчив журнал.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        confirmationId: { type: "string", minLength: 1, maxLength: 100 },
+      },
+      required: ["confirmationId"],
+      additionalProperties: false,
+    },
+    securitySchemes: mcpToolSecuritySchemes("confirm_digitalocean_www_domain"),
+    annotations: DESTRUCTIVE_ANNOTATIONS,
+  },
+  {
     name: "get_cloudflare_zone_status",
     title: "Провери Cloudflare и DNS",
     description:
@@ -248,10 +284,13 @@ export function createMcpRequestHandler({
   consumeConfirmation = markDurableConfirmationUsed,
   getDigitalOceanStatus = getDigitalOceanAppStatus,
   getDigitalOceanAudit = getDigitalOceanAccountAudit,
+  inspectDigitalOceanDomain = inspectDigitalOceanDomainAlias,
+  activateDigitalOceanDomain = activateDigitalOceanDomainAlias,
   getCloudflareStatus = getCloudflareZoneStatus,
   getSystemConfiguration = getSystemConfigurationReport,
   getLatestGitHubSession = getLatestAuthorizedGitHubSession,
   getGitHubTaskStatus = getCopilotTaskStatus,
+  executeWrite = executeAuditedWriteAction,
 } = {}) {
   async function callTool(name, args, ownerId) {
     let result;
@@ -292,6 +331,82 @@ export function createMcpRequestHandler({
     } else if (name === "get_digitalocean_account_audit") {
       const auditReport = await getDigitalOceanAudit();
       result = textResult(auditReport, formatDigitalOceanAudit(auditReport));
+    } else if (name === "prepare_digitalocean_www_domain") {
+      const status = await inspectDigitalOceanDomain({
+        domain: PUBLIC_WWW_DOMAIN,
+      });
+      if (status.configured) {
+        result = textResult(
+          {
+            configured: true,
+            domain: status.domain,
+            readAccessVerified: status.readAccessVerified,
+          },
+          `${status.domain} вече е конфигуриран в DigitalOcean.`,
+        );
+      } else {
+        const confirmation = await createConfirmation({
+          sessionId: ownerId,
+          action: DIGITALOCEAN_DOMAIN_ACTION,
+          resource: {
+            appId: status.appId,
+            domain: status.domain,
+          },
+          params: { domain: status.domain },
+        });
+        result = textResult(
+          {
+            configured: false,
+            confirmationId: confirmation.id,
+            expiresAt: new Date(confirmation.expiresAt).toISOString(),
+            domain: status.domain,
+            readAccessVerified: status.readAccessVerified,
+            requiredWriteScope: status.requiredWriteScope,
+          },
+          `DigitalOcean проверката е успешна. Нужно е точно потвърждение за добавяне само на ${status.domain}.`,
+        );
+      }
+    } else if (name === "confirm_digitalocean_www_domain") {
+      const confirmationId =
+        typeof args?.confirmationId === "string"
+          ? args.confirmationId.trim()
+          : "";
+      if (!confirmationId) {
+        throw Object.assign(new Error("Липсва confirmationId."), {
+          code: -32602,
+        });
+      }
+      const confirmation = await validateConfirmation(confirmationId, ownerId);
+      if (
+        confirmation.action !== DIGITALOCEAN_DOMAIN_ACTION ||
+        confirmation.resource?.domain !== PUBLIC_WWW_DOMAIN
+      ) {
+        throw Object.assign(
+          new Error("Потвърждението не е за www.synchron.foundation."),
+          { code: -32602 },
+        );
+      }
+      await consumeConfirmation(confirmationId);
+      const activation = await executeWrite({
+        action: DIGITALOCEAN_DOMAIN_ACTION,
+        capability: "infrastructure.write",
+        actor: "chatgpt-mcp",
+        sessionId: ownerId,
+        confirmationId,
+        resource: confirmation.resource.domain,
+        details: "add_www_domain_alias",
+        execute: () =>
+          activateDigitalOceanDomain({
+            domain: confirmation.resource.domain,
+            expectedAppId: confirmation.resource.appId,
+          }),
+      });
+      result = textResult(
+        activation,
+        activation.updated
+          ? `${activation.domain} е добавен и DigitalOcean стартира deployment.`
+          : `${activation.domain} вече е конфигуриран; не е направена повторна промяна.`,
+      );
     } else if (name === "get_system_configuration") {
       const configuration = await getSystemConfiguration();
       result = textResult(
@@ -369,21 +484,23 @@ export function createMcpRequestHandler({
     await audit({
       actor: "chatgpt-mcp",
       action:
-        name === "get_github_copilot_task_status"
-          ? "github.read"
-          : name.includes("github")
-            ? "github.write"
-            : name.includes("digitalocean") ||
-                name.includes("cloudflare") ||
-                name.includes("system_configuration")
-              ? "infrastructure.read"
-              : "memory.read",
+        name === "confirm_digitalocean_www_domain"
+          ? DIGITALOCEAN_DOMAIN_ACTION
+          : name === "get_github_copilot_task_status"
+            ? "github.read"
+            : name.includes("github")
+              ? "github.write"
+              : name.includes("digitalocean") ||
+                  name.includes("cloudflare") ||
+                  name.includes("system_configuration")
+                ? "infrastructure.read"
+                : "memory.read",
       decision: "allow",
       outcome: "succeeded",
       resource: name,
-      details: name.startsWith("confirm_github")
+      details: name.startsWith("confirm_")
         ? "confirmed-write-mcp"
-        : name.startsWith("prepare_github")
+        : name.startsWith("prepare_")
           ? "write-plan-mcp"
           : "read-only-mcp",
     });

--- a/tests/healthRoutes.test.js
+++ b/tests/healthRoutes.test.js
@@ -160,9 +160,9 @@ test("bridge diagnostics distinguish configuration, response and ChatGPT OAuth r
   assert.equal(result.bridge.reachable, true);
   assert.equal(result.bridge.responding, true);
   assert.equal(result.bridge.readOnly, false);
-  assert.equal(result.bridge.tools, 11);
-  assert.equal(result.bridge.readOnlyTools, 10);
-  assert.equal(result.bridge.destructiveTools, 1);
+  assert.equal(result.bridge.tools, 13);
+  assert.equal(result.bridge.readOnlyTools, 11);
+  assert.equal(result.bridge.destructiveTools, 2);
   assert.equal(result.bridge.authentication.chatgptOAuthReady, true);
   assert.equal(
     result.bridge.authentication.mode,

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -44,7 +44,7 @@ test("MCP initialize and tool discovery work without credentials", async () => {
     .post("/mcp")
     .send({ jsonrpc: "2.0", id: 2, method: "tools/list" })
     .expect(200);
-  assert.equal(listed.body.result.tools.length, 11);
+  assert.equal(listed.body.result.tools.length, 13);
   assert.equal(listed.body.result.tools[0].securitySchemes[0].type, "oauth2");
 });
 
@@ -150,6 +150,8 @@ test("authorization consent issues a code bound to the browser profile", async (
   );
   const consent = await request(app).get("/oauth/authorize").expect(200);
   assert.match(consent.text, /Свързване на ChatGPT със AI CORE/u);
+  assert.match(consent.text, /Четене на разрешените данни/u);
+  assert.match(consent.text, /отделно точно потвърждение/u);
   const csrf = consent.text.match(/name="csrf_token" value="([^"]+)"/u)?.[1];
   assert.ok(csrf);
   const approved = await request(app)

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -13,6 +13,7 @@ import {
   getMcpProtectedResourceMetadata,
   isMcpOAuthConfigured,
   MCP_GITHUB_WRITE_SCOPE,
+  MCP_INFRASTRUCTURE_WRITE_SCOPE,
   MCP_READ_SCOPE,
   requiresPersistentMcpReplayGuard,
   resetMcpOAuthStateForTests,
@@ -89,7 +90,11 @@ test("publishes OAuth 2.1 protected-resource and authorization metadata", () => 
   assert.deepEqual(getMcpProtectedResourceMetadata(ENV), {
     resource: ENV.MCP_RESOURCE_URL,
     authorization_servers: ["https://synchron.foundation"],
-    scopes_supported: [MCP_READ_SCOPE, MCP_GITHUB_WRITE_SCOPE],
+    scopes_supported: [
+      MCP_READ_SCOPE,
+      MCP_GITHUB_WRITE_SCOPE,
+      MCP_INFRASTRUCTURE_WRITE_SCOPE,
+    ],
   });
   const authorization = getMcpAuthorizationServerMetadata(ENV);
   assert.equal(
@@ -134,8 +139,7 @@ test("uses an explicit dedicated or legacy fallback OAuth key mode", () => {
         { id: "owner-id", memoryOwnerId: "primary-user", role: "owner" },
         { ...ENV, MCP_OAUTH_SECRET: "too-short" },
       ),
-    (error) =>
-      error.code === "temporarily_unavailable" && error.status === 503,
+    (error) => error.code === "temporarily_unavailable" && error.status === 503,
   );
 });
 
@@ -342,24 +346,29 @@ test("exchanges a one-time PKCE code for an opaque owner-scoped token", async ()
   );
 });
 
-test("blocks write authorization for a tester identity", async () => {
-  const request = await validateMcpAuthorizationRequest(
-    authorizationInput([MCP_GITHUB_WRITE_SCOPE]),
-    { env: ENV, fetchImpl: clientMetadataFetch },
-  );
-  assert.throws(
-    () =>
-      createMcpAuthorizationCode(
-        request,
-        {
-          id: "tester-id",
-          memoryOwnerId: "supabase:tester-id",
-          role: "tester",
-        },
-        ENV,
-      ),
-    (error) => error.code === "access_denied",
-  );
+test("blocks every write authorization for a tester identity", async () => {
+  for (const scope of [
+    MCP_GITHUB_WRITE_SCOPE,
+    MCP_INFRASTRUCTURE_WRITE_SCOPE,
+  ]) {
+    const request = await validateMcpAuthorizationRequest(
+      authorizationInput([scope]),
+      { env: ENV, fetchImpl: clientMetadataFetch },
+    );
+    assert.throws(
+      () =>
+        createMcpAuthorizationCode(
+          request,
+          {
+            id: "tester-id",
+            memoryOwnerId: "supabase:tester-id",
+            role: "tester",
+          },
+          ENV,
+        ),
+      (error) => error.code === "access_denied",
+    );
+  }
 });
 
 test("distinguishes an invalid token from a valid token without scope", async () => {

--- a/tests/mcpReadService.test.js
+++ b/tests/mcpReadService.test.js
@@ -25,6 +25,8 @@ test("MCP exposes read tools and a two-step cleanup flow", () => {
       "get_digitalocean_app_status",
       "get_system_configuration",
       "get_digitalocean_account_audit",
+      "prepare_digitalocean_www_domain",
+      "confirm_digitalocean_www_domain",
       "get_cloudflare_zone_status",
       "get_github_copilot_task_status",
       "prepare_github_merged_branch_cleanup",
@@ -38,6 +40,14 @@ test("MCP exposes read tools and a two-step cleanup flow", () => {
   assert.equal(confirm.annotations.destructiveHint, true);
   assert.deepEqual(confirm.securitySchemes, [
     { type: "oauth2", scopes: ["synchron:github.write"] },
+  ]);
+  const confirmWww = MCP_TOOLS.find(
+    (tool) => tool.name === "confirm_digitalocean_www_domain",
+  );
+  assert.equal(confirmWww.annotations.readOnlyHint, false);
+  assert.equal(confirmWww.annotations.destructiveHint, true);
+  assert.deepEqual(confirmWww.securitySchemes, [
+    { type: "oauth2", scopes: ["synchron:infrastructure.write"] },
   ]);
   const digitalOceanAudit = MCP_TOOLS.find(
     (tool) => tool.name === "get_digitalocean_account_audit",
@@ -270,4 +280,78 @@ test("MCP cleanup requires the exact one-time confirmation", async () => {
   );
   assert.equal(confirmed.result.structuredContent.count, 1);
   assert.deepEqual(consumed, ["confirmation-1"]);
+});
+
+test("MCP www activation requires the exact one-time confirmation", async () => {
+  const consumed = [];
+  const writes = [];
+  const handle = createMcpRequestHandler({
+    inspectDigitalOceanDomain: async ({ domain }) => ({
+      appId: "app-1",
+      domain,
+      configured: false,
+      readAccessVerified: true,
+      requiredWriteScope: "app:update",
+    }),
+    createConfirmation: async (data) => ({
+      ...data,
+      id: "www-confirmation-1",
+      expiresAt: Date.now() + 60_000,
+    }),
+    validateConfirmation: async (id, ownerId) => ({
+      id,
+      sessionId: ownerId,
+      action: "infrastructure.digitalocean:add_www_domain",
+      resource: {
+        appId: "app-1",
+        domain: "www.synchron.foundation",
+      },
+      params: { domain: "www.synchron.foundation" },
+    }),
+    consumeConfirmation: async (id) => consumed.push(id),
+    executeWrite: async (input) => {
+      writes.push(input);
+      return input.execute();
+    },
+    activateDigitalOceanDomain: async (input) => ({
+      updated: true,
+      appId: input.expectedAppId,
+      domain: input.domain,
+      deploymentId: "deployment-1",
+    }),
+    audit: async () => {},
+  });
+
+  const prepared = await handle(
+    {
+      jsonrpc: "2.0",
+      id: 20,
+      method: "tools/call",
+      params: { name: "prepare_digitalocean_www_domain", arguments: {} },
+    },
+    "primary-user",
+  );
+  assert.equal(
+    prepared.result.structuredContent.confirmationId,
+    "www-confirmation-1",
+  );
+
+  const confirmed = await handle(
+    {
+      jsonrpc: "2.0",
+      id: 21,
+      method: "tools/call",
+      params: {
+        name: "confirm_digitalocean_www_domain",
+        arguments: { confirmationId: "www-confirmation-1" },
+      },
+    },
+    "primary-user",
+  );
+  assert.equal(confirmed.result.structuredContent.updated, true);
+  assert.equal(confirmed.result.structuredContent.deploymentId, "deployment-1");
+  assert.deepEqual(consumed, ["www-confirmation-1"]);
+  assert.equal(writes[0].action, "infrastructure.digitalocean:add_www_domain");
+  assert.equal(writes[0].capability, "infrastructure.write");
+  assert.equal(writes[0].confirmationId, "www-confirmation-1");
 });


### PR DESCRIPTION
## Какво се променя

- добавя MCP инструмент за подготовка на `www.synchron.foundation`;
- добавя отделен destructive инструмент за потвърденото DigitalOcean действие;
- изисква нов owner-only OAuth scope `synchron:infrastructure.write`;
- използва еднократно потвърждение и устойчив журнал;
- актуализира production smoke проверката и документацията.

## Причина

MCP мостът беше онлайн, но можеше само да чете DigitalOcean. За добавянето на www адреса нямаше изпълним защитен инструмент в ChatGPT.

## Сигурност

- разрешен е само `www.synchron.foundation`;
- приложението и текущите домейни се проверяват отново преди запис;
- member/tester профили не могат да получат write scope;
- потвърждението се консумира преди DigitalOcean write;
- съществуващите encrypted secrets се запазват и никога не се връщат.

## Проверки

- Prettier: успешно;
- целеви MCP/DigitalOcean тестове: 57/57;
- пълен тестов пакет: 501/501.
