### PR TITLE
Make DigitalOcean status resilient

### DIFF
--- a/src/services/digitalOceanService.js
+++ b/src/services/digitalOceanService.js
@@ -159,6 +159,42 @@ async function request(
   }
 }
 
+function isTransientDigitalOceanError(error) {
+  return (
+    error instanceof DigitalOceanError &&
+    ["DIGITALOCEAN_NETWORK_ERROR", "DIGITALOCEAN_UPSTREAM_ERROR"].includes(
+      error.code,
+    )
+  );
+}
+
+async function requestWithTransientRetry(path, options = {}) {
+  const retryDelaysMs = Array.isArray(options.retryDelaysMs)
+    ? options.retryDelaysMs
+    : [200, 500];
+  const sleepImpl =
+    options.sleepImpl ||
+    ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)));
+  let lastError;
+
+  for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
+    try {
+      return await request(path, options);
+    } catch (error) {
+      lastError = error;
+      if (
+        !isTransientDigitalOceanError(error) ||
+        attempt >= retryDelaysMs.length
+      ) {
+        throw error;
+      }
+      await sleepImpl(retryDelaysMs[attempt]);
+    }
+  }
+
+  throw lastError;
+}
+
 function normalizeTesterAuthConfig({ projectUrl, publishableKey }) {
   let url;
   try {
@@ -603,13 +639,19 @@ export function listDigitalOceanEnvironmentVariables(spec = {}) {
 
 export async function getDigitalOceanAppStatus(options = {}) {
   const { appId } = requiredAppConfig(options.env);
-  const [appData, deploymentsData] = await Promise.all([
-    request(`/apps/${encodeURIComponent(appId)}`, options),
-    request(
-      `/apps/${encodeURIComponent(appId)}/deployments?page=1&per_page=5`,
-      options,
-    ),
-  ]);
+  const appPath = `/apps/${encodeURIComponent(appId)}`;
+  const deploymentsPath = `${appPath}/deployments?page=1&per_page=5`;
+  const appData = await requestWithTransientRetry(appPath, options);
+  let deploymentsData = { deployments: [] };
+  let deploymentsAvailable = true;
+  let deploymentsErrorCode = null;
+  try {
+    deploymentsData = await requestWithTransientRetry(deploymentsPath, options);
+  } catch (error) {
+    if (!isTransientDigitalOceanError(error)) throw error;
+    deploymentsAvailable = false;
+    deploymentsErrorCode = error.code;
+  }
   const app = appData.app || {};
   const deployments = (deploymentsData.deployments || []).slice(0, 5);
   return {
@@ -631,6 +673,8 @@ export async function getDigitalOceanAppStatus(options = {}) {
         }
       : null,
     environmentVariables: listDigitalOceanEnvironmentVariables(app.spec),
+    deploymentsAvailable,
+    deploymentsErrorCode,
     deployments: deployments.map((deployment) => ({
       id: deployment.id,
       phase: deployment.phase,
@@ -1300,7 +1344,9 @@ export function formatDigitalOceanStatus(status) {
       : "Няма текущ деплой.",
     status.liveUrl ? `Адрес: ${status.liveUrl}` : null,
     `Environment variables: ${status.environmentVariables?.length || 0} имена; стойностите не се връщат.`,
-    `Последни деплои: ${status.deployments.length}.`,
+    status.deploymentsAvailable === false
+      ? "Историята на последните деплои временно не е достъпна; основният статус на приложението е проверен."
+      : `Последни деплои: ${status.deployments.length}.`,
   ]
     .filter(Boolean)
     .join("\n");

--- a/tests/infrastructureBridges.test.js
+++ b/tests/infrastructureBridges.test.js
@@ -49,6 +49,91 @@ test("DigitalOcean bridge reads app and deployment status without writes", async
   assert.doesNotMatch(JSON.stringify(status), /secret/u);
 });
 
+test("DigitalOcean app status retries a transient app read", async () => {
+  let appCalls = 0;
+  const fetchImpl = async (url) => {
+    if (String(url).includes("/deployments")) {
+      return Response.json({ deployments: [] });
+    }
+    appCalls += 1;
+    if (appCalls === 1) throw new Error("temporary network failure");
+    return Response.json({
+      app: {
+        id: "app-1",
+        spec: { name: "sunchron-backend" },
+        active_deployment: { id: "dep-1", phase: "ACTIVE" },
+      },
+    });
+  };
+
+  const status = await getDigitalOceanAppStatus({
+    env: { DIGITALOCEAN_API_TOKEN: "secret", DIGITALOCEAN_APP_ID: "app-1" },
+    fetchImpl,
+    retryDelaysMs: [0],
+    sleepImpl: async () => {},
+  });
+
+  assert.equal(appCalls, 2);
+  assert.equal(status.activeDeployment.phase, "ACTIVE");
+  assert.equal(status.deploymentsAvailable, true);
+});
+
+test("DigitalOcean app status keeps verified app data when deployment history is temporarily unavailable", async () => {
+  let deploymentCalls = 0;
+  const fetchImpl = async (url) => {
+    if (String(url).includes("/deployments")) {
+      deploymentCalls += 1;
+      return Response.json({ message: "temporary failure" }, { status: 503 });
+    }
+    return Response.json({
+      app: {
+        id: "app-1",
+        spec: { name: "sunchron-backend" },
+        live_url: "https://synchron.foundation",
+        active_deployment: { id: "dep-1", phase: "ACTIVE" },
+      },
+    });
+  };
+
+  const status = await getDigitalOceanAppStatus({
+    env: { DIGITALOCEAN_API_TOKEN: "secret", DIGITALOCEAN_APP_ID: "app-1" },
+    fetchImpl,
+    retryDelaysMs: [0, 0],
+    sleepImpl: async () => {},
+  });
+
+  assert.equal(deploymentCalls, 3);
+  assert.equal(status.activeDeployment.phase, "ACTIVE");
+  assert.equal(status.deploymentsAvailable, false);
+  assert.equal(status.deploymentsErrorCode, "DIGITALOCEAN_UPSTREAM_ERROR");
+  assert.match(
+    formatDigitalOceanStatus(status),
+    /основният статус на приложението е проверен/u,
+  );
+});
+
+test("DigitalOcean app status never hides token errors from deployment history", async () => {
+  const fetchImpl = async (url) => {
+    if (String(url).includes("/deployments")) {
+      return Response.json({ message: "unauthorized" }, { status: 401 });
+    }
+    return Response.json({ app: { id: "app-1", spec: {} } });
+  };
+
+  await assert.rejects(
+    getDigitalOceanAppStatus({
+      env: {
+        DIGITALOCEAN_API_TOKEN: "secret",
+        DIGITALOCEAN_APP_ID: "app-1",
+      },
+      fetchImpl,
+      retryDelaysMs: [0],
+      sleepImpl: async () => {},
+    }),
+    (error) => error.code === "DIGITALOCEAN_TOKEN_INVALID",
+  );
+});
+
 test("DigitalOcean full audit reads account resources without writes or secrets", async () => {
   const calls = [];
   const fetchImpl = async (url, options) => {


### PR DESCRIPTION
## Какво се променя

- добавя два ограничени повторни опита само при временна DigitalOcean мрежова/5xx грешка;
- връща проверения основен app статус, ако само историята на deployments временно липсва;
- запазва 401/403 като твърди грешки и не прикрива проблеми с токена или правата.

## Причина

AI CORE възпроизведе два пъти отказ на DigitalOcean Read, въпреки че защитената проверка на самото приложение работеше. Агрегираният статус отказваше целия резултат при временен проблем на endpoint-а за deployment историята.

## Проверки

- целеви инфраструктурни тестове: 12/12;
- пълен тестов пакет: 504/504;
- Prettier за променените файлове: успешно;
- remote tree SHA е проверен и съвпада точно с локалния tree.
