### PR TITLE
Resolve DigitalOcean app names safely

### DIFF
--- a/src/services/digitalOceanService.js
+++ b/src/services/digitalOceanService.js
@@ -296,7 +296,7 @@ function appMatchesPublicProject(app, configuredValue) {
   );
 }
 
-async function resolveDomainAppConfig({
+async function resolveDigitalOceanAppConfig({
   env = process.env,
   fetchImpl = fetch,
 }) {
@@ -368,7 +368,10 @@ async function loadDomainAliasActivation({
   env = process.env,
   fetchImpl = fetch,
 } = {}) {
-  const { token, appId } = await resolveDomainAppConfig({ env, fetchImpl });
+  const { token, appId } = await resolveDigitalOceanAppConfig({
+    env,
+    fetchImpl,
+  });
   if (expectedAppId && expectedAppId !== appId) {
     throw new DigitalOceanError(
       "Потвърждението е за друго DigitalOcean приложение.",
@@ -638,15 +641,28 @@ export function listDigitalOceanEnvironmentVariables(spec = {}) {
 }
 
 export async function getDigitalOceanAppStatus(options = {}) {
-  const { appId } = requiredAppConfig(options.env);
+  const { token, appId } = await resolveDigitalOceanAppConfig({
+    env: options.env,
+    fetchImpl: options.fetchImpl,
+  });
+  const requestOptions = {
+    ...options,
+    env: {
+      ...(options.env || process.env),
+      DIGITALOCEAN_API_TOKEN: token,
+    },
+  };
   const appPath = `/apps/${encodeURIComponent(appId)}`;
   const deploymentsPath = `${appPath}/deployments?page=1&per_page=5`;
-  const appData = await requestWithTransientRetry(appPath, options);
+  const appData = await requestWithTransientRetry(appPath, requestOptions);
   let deploymentsData = { deployments: [] };
   let deploymentsAvailable = true;
   let deploymentsErrorCode = null;
   try {
-    deploymentsData = await requestWithTransientRetry(deploymentsPath, options);
+    deploymentsData = await requestWithTransientRetry(
+      deploymentsPath,
+      requestOptions,
+    );
   } catch (error) {
     if (!isTransientDigitalOceanError(error)) throw error;
     deploymentsAvailable = false;

--- a/tests/digitalOceanEnvironmentVariables.test.js
+++ b/tests/digitalOceanEnvironmentVariables.test.js
@@ -5,6 +5,8 @@ import {
   listDigitalOceanEnvironmentVariables,
 } from "../src/services/digitalOceanService.js";
 
+const TEST_APP_ID = "6e6fdc40-2ef5-4534-8906-8a6414b089b5";
+
 test("DigitalOcean environment inventory returns metadata without values", () => {
   const inventory = listDigitalOceanEnvironmentVariables({
     name: "sunchron-backend",
@@ -54,10 +56,10 @@ test("DigitalOcean environment inventory returns metadata without values", () =>
 test("DigitalOcean app status exposes only safe environment metadata", async () => {
   const responses = new Map([
     [
-      "/apps/app-1",
+      `/apps/${TEST_APP_ID}`,
       {
         app: {
-          id: "app-1",
+          id: TEST_APP_ID,
           spec: {
             name: "sunchron-backend",
             services: [
@@ -77,7 +79,7 @@ test("DigitalOcean app status exposes only safe environment metadata", async () 
         },
       },
     ],
-    ["/apps/app-1/deployments?page=1&per_page=5", { deployments: [] }],
+    [`/apps/${TEST_APP_ID}/deployments?page=1&per_page=5`, { deployments: [] }],
   ]);
   const fetchImpl = async (url) => {
     const parsed = new URL(url);
@@ -91,7 +93,7 @@ test("DigitalOcean app status exposes only safe environment metadata", async () 
   const status = await getDigitalOceanAppStatus({
     env: {
       DIGITALOCEAN_API_TOKEN: "token",
-      DIGITALOCEAN_APP_ID: "app-1",
+      DIGITALOCEAN_APP_ID: TEST_APP_ID,
     },
     fetchImpl,
   });

--- a/tests/infrastructureBridges.test.js
+++ b/tests/infrastructureBridges.test.js
@@ -16,6 +16,8 @@ import {
 } from "../src/services/cloudflareService.js";
 import { detectCapabilityRequests } from "../src/routes/chat.js";
 
+const TEST_APP_ID = "6e6fdc40-2ef5-4534-8906-8a6414b089b5";
+
 test("DigitalOcean bridge reads app and deployment status without writes", async () => {
   const calls = [];
   const fetchImpl = async (url, options) => {
@@ -27,7 +29,7 @@ test("DigitalOcean bridge reads app and deployment status without writes", async
     }
     return Response.json({
       app: {
-        id: "app-1",
+        id: TEST_APP_ID,
         spec: { name: "sunchron-backend" },
         live_url: "https://synchron.foundation",
         active_deployment: { id: "dep-1", phase: "ACTIVE" },
@@ -35,7 +37,10 @@ test("DigitalOcean bridge reads app and deployment status without writes", async
     });
   };
   const status = await getDigitalOceanAppStatus({
-    env: { DIGITALOCEAN_API_TOKEN: "secret", DIGITALOCEAN_APP_ID: "app-1" },
+    env: {
+      DIGITALOCEAN_API_TOKEN: "secret",
+      DIGITALOCEAN_APP_ID: TEST_APP_ID,
+    },
     fetchImpl,
   });
   assert.equal(status.activeDeployment.phase, "ACTIVE");
@@ -49,6 +54,49 @@ test("DigitalOcean bridge reads app and deployment status without writes", async
   assert.doesNotMatch(JSON.stringify(status), /secret/u);
 });
 
+test("DigitalOcean app status resolves a configured app name to its real id", async () => {
+  const calls = [];
+  const appId = TEST_APP_ID;
+  const fetchImpl = async (url) => {
+    const parsed = new URL(String(url));
+    calls.push(`${parsed.pathname}${parsed.search}`);
+    if (parsed.pathname === "/v2/apps") {
+      return Response.json({
+        apps: [{ id: appId, spec: { name: "sunchron-backend" } }],
+      });
+    }
+    if (parsed.pathname.endsWith("/deployments")) {
+      return Response.json({ deployments: [] });
+    }
+    return Response.json({
+      app: {
+        id: appId,
+        spec: { name: "sunchron-backend" },
+        active_deployment: { id: "dep-1", phase: "ACTIVE" },
+      },
+    });
+  };
+
+  const status = await getDigitalOceanAppStatus({
+    env: {
+      DIGITALOCEAN_API_TOKEN: "secret",
+      DIGITALOCEAN_APP_ID: "sunchron-backend",
+    },
+    fetchImpl,
+  });
+
+  assert.equal(status.id, appId);
+  assert.deepEqual(calls, [
+    "/v2/apps?per_page=200",
+    `/v2/apps/${appId}`,
+    `/v2/apps/${appId}/deployments?page=1&per_page=5`,
+  ]);
+  assert.equal(
+    calls.some((path) => path.includes("/apps/sunchron-backend")),
+    false,
+  );
+});
+
 test("DigitalOcean app status retries a transient app read", async () => {
   let appCalls = 0;
   const fetchImpl = async (url) => {
@@ -59,7 +107,7 @@ test("DigitalOcean app status retries a transient app read", async () => {
     if (appCalls === 1) throw new Error("temporary network failure");
     return Response.json({
       app: {
-        id: "app-1",
+        id: TEST_APP_ID,
         spec: { name: "sunchron-backend" },
         active_deployment: { id: "dep-1", phase: "ACTIVE" },
       },
@@ -67,7 +115,10 @@ test("DigitalOcean app status retries a transient app read", async () => {
   };
 
   const status = await getDigitalOceanAppStatus({
-    env: { DIGITALOCEAN_API_TOKEN: "secret", DIGITALOCEAN_APP_ID: "app-1" },
+    env: {
+      DIGITALOCEAN_API_TOKEN: "secret",
+      DIGITALOCEAN_APP_ID: TEST_APP_ID,
+    },
     fetchImpl,
     retryDelaysMs: [0],
     sleepImpl: async () => {},
@@ -87,7 +138,7 @@ test("DigitalOcean app status keeps verified app data when deployment history is
     }
     return Response.json({
       app: {
-        id: "app-1",
+        id: TEST_APP_ID,
         spec: { name: "sunchron-backend" },
         live_url: "https://synchron.foundation",
         active_deployment: { id: "dep-1", phase: "ACTIVE" },
@@ -96,7 +147,10 @@ test("DigitalOcean app status keeps verified app data when deployment history is
   };
 
   const status = await getDigitalOceanAppStatus({
-    env: { DIGITALOCEAN_API_TOKEN: "secret", DIGITALOCEAN_APP_ID: "app-1" },
+    env: {
+      DIGITALOCEAN_API_TOKEN: "secret",
+      DIGITALOCEAN_APP_ID: TEST_APP_ID,
+    },
     fetchImpl,
     retryDelaysMs: [0, 0],
     sleepImpl: async () => {},
@@ -117,14 +171,14 @@ test("DigitalOcean app status never hides token errors from deployment history",
     if (String(url).includes("/deployments")) {
       return Response.json({ message: "unauthorized" }, { status: 401 });
     }
-    return Response.json({ app: { id: "app-1", spec: {} } });
+    return Response.json({ app: { id: TEST_APP_ID, spec: {} } });
   };
 
   await assert.rejects(
     getDigitalOceanAppStatus({
       env: {
         DIGITALOCEAN_API_TOKEN: "secret",
-        DIGITALOCEAN_APP_ID: "app-1",
+        DIGITALOCEAN_APP_ID: TEST_APP_ID,
       },
       fetchImpl,
       retryDelaysMs: [0],


### PR DESCRIPTION
## Какво се променя

- DigitalOcean Read вече използва същото безопасно намиране на приложението като Работния център;
- приема както реален UUID, така и конфигурирано име на приложението;
- след намиране използва проверения app id за статуса и deployment историята;
- не променя DigitalOcean и не връща тайни.

## Причина

Работният център намираше приложението по име, но чат инструментът използваше `DIGITALOCEAN_APP_ID` директно като UUID. Когато стойността е име, DigitalOcean връща грешка и чатът показва „API временно не отговаря“.

## Проверки

- целеви DigitalOcean тестове: 25/25;
- пълен тестов пакет: 505/505;
- Prettier за променените файлове: успешно;
- remote tree SHA съвпада точно с локалния tree.
