### PR TITLE
Add original AI Core personal pets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
     <link rel="stylesheet" href="/accessibility.css?v=20260728-font-stepper" />
     <link rel="stylesheet" href="/task-journal.css?v=20260728-task-journal" />
     <link rel="stylesheet" href="/auth.css?v=20260801-profile-actions" />
-    <link rel="stylesheet" href="/work-mode.css?v=20260801-agent-edit-v4" />
+    <link rel="stylesheet" href="/work-mode.css?v=20260802-ai-core-pets-v1" />
     <link rel="stylesheet" href="/assets/20260730-v2/synchron-vision.css" />
     <link
       rel="stylesheet"
@@ -452,7 +452,7 @@
     </main>
 
     <script src="/markdown-renderer.js?v=20260728-xss"></script>
-    <script src="/work-mode.js?v=20260801-agent-edit-v5"></script>
+    <script src="/work-mode.js?v=20260802-ai-core-pets-v1"></script>
     <script src="/assets/20260801-profile-actions/app.js"></script>
     <script src="/accessibility.js?v=20260728-font-stepper"></script>
     <script src="/assets/20260730-connections-v1/work-center.js"></script>

--- a/public/work-mode.css
+++ b/public/work-mode.css
@@ -120,6 +120,26 @@ body[data-interaction-mode="chat"] .work-pet {
   filter: grayscale(0.45);
 }
 
+.work-pet[data-pet-state="ready"][data-pet-id="drop"] {
+  background: #dff6ff;
+}
+
+.work-pet[data-pet-state="ready"][data-pet-id="spark"] {
+  background: #fff0df;
+}
+
+.work-pet[data-pet-state="ready"][data-pet-id="owl"] {
+  background: #f2e9ff;
+}
+
+.work-pet[data-pet-state="ready"][data-pet-id="rock"] {
+  background: #eceff1;
+}
+
+.work-pet[data-pet-state="ready"][data-pet-id="cat"] {
+  background: #fff1f5;
+}
+
 @keyframes work-pet-running {
   to {
     transform: translateY(-5px) rotate(3deg);
@@ -347,18 +367,19 @@ body[data-interaction-mode="chat"] .work-pet {
 
 .pet-choice-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
 }
 
 .pet-choice {
-  min-height: 76px;
+  min-height: 108px;
   padding: 8px;
   border-radius: 13px;
   text-align: center;
 }
 
 .pet-choice span,
+.pet-choice strong,
 .pet-choice small {
   display: block;
 }
@@ -367,10 +388,16 @@ body[data-interaction-mode="chat"] .work-pet {
   font-size: 30px;
 }
 
+.pet-choice strong {
+  margin-top: 4px;
+  font-size: 12px;
+}
+
 .pet-choice small {
-  margin-top: 3px;
+  margin-top: 4px;
   color: #64748b;
   font-size: 10px;
+  line-height: 1.3;
 }
 
 .work-pet-status {

--- a/public/work-mode.js
+++ b/public/work-mode.js
@@ -2,10 +2,42 @@
   const STORAGE_VERSION = 2;
   const WORKSPACE_ENDPOINT = "/api/workspaces";
   const PETS = Object.freeze([
-    { id: "robot", symbol: "🤖", label: "Робот" },
-    { id: "cat", symbol: "🐈", label: "Котка" },
-    { id: "owl", symbol: "🦉", label: "Сова" },
-    { id: "spark", symbol: "✨", label: "Искра" },
+    {
+      id: "robot",
+      symbol: "🤖",
+      label: "Кори",
+      description: "Технически и точен помощник.",
+    },
+    {
+      id: "drop",
+      symbol: "💧",
+      label: "Капка",
+      description: "Спокоен спътник за фокус.",
+    },
+    {
+      id: "spark",
+      symbol: "🔥",
+      label: "Искра",
+      description: "Енергия за бърза работа.",
+    },
+    {
+      id: "owl",
+      symbol: "🦉",
+      label: "Бухал",
+      description: "Наблюдателен и прецизен.",
+    },
+    {
+      id: "rock",
+      symbol: "🪨",
+      label: "Скала",
+      description: "Стабилен при трудни задачи.",
+    },
+    {
+      id: "cat",
+      symbol: "🐈",
+      label: "Мяу",
+      description: "Любопитен и гъвкав спътник.",
+    },
   ]);
   const ROLE_LABELS = Object.freeze({
     general: "Универсален помощник",
@@ -319,6 +351,7 @@
   function renderPet() {
     const pet = selectedPet();
     elements.pet.textContent = pet.symbol;
+    elements.pet.dataset.petId = pet.id;
     elements.pet.dataset.petState = workState.petState;
     const statusLabels = {
       running: "Работи по задачата",
@@ -326,7 +359,7 @@
       ready: "Готово за преглед",
       blocked: "Задачата е блокирана",
     };
-    elements.workContextBtn.title = `${pet.label}: ${statusLabels[workState.petState]}`;
+    elements.workContextBtn.title = `${pet.label}: ${statusLabels[workState.petState]}. ${pet.description}`;
   }
 
   function setMode(mode) {
@@ -438,6 +471,7 @@
       button.type = "button";
       button.className = "pet-choice";
       button.classList.toggle("active", pet.id === workState.petId);
+      button.setAttribute("aria-label", `Избери ${pet.label}`);
       button.addEventListener("click", () => {
         workState.petId = pet.id;
         saveState();
@@ -445,14 +479,15 @@
         openManager();
       });
       addText(button, "span", pet.symbol);
-      addText(button, "small", pet.label);
+      addText(button, "strong", pet.label);
+      addText(button, "small", pet.description);
       grid.appendChild(button);
     }
     parent.appendChild(grid);
     addText(
       parent,
       "p",
-      "Любимецът показва: работи, чака решение, готов е или е блокиран. Той не променя правата на AI.",
+      "Личният любимец се запазва в защитения ти профил и показва: работи, чака решение, готов е или е блокиран. Той не променя правата на AI.",
       "work-pet-status",
     );
   }
@@ -772,7 +807,7 @@
     if (editingAgent) createEditAgentForm(agents, editingAgent);
     else createAgentForm(agents);
 
-    const pets = section(elements.drawerBody, "Домашен любимец");
+    const pets = section(elements.drawerBody, "Личен любимец");
     renderPetChoices(pets);
 
     const activity = section(elements.drawerBody, "Последни задачи");

--- a/src/services/workspaceStateService.js
+++ b/src/services/workspaceStateService.js
@@ -12,7 +12,7 @@ const VALID_MODELS = new Set([
   "gpt-5.6-terra",
   "gpt-5.6-luna",
 ]);
-const VALID_PETS = new Set(["robot", "cat", "owl", "spark"]);
+const VALID_PETS = new Set(["robot", "drop", "spark", "owl", "rock", "cat"]);
 
 export class WorkspaceStateError extends Error {
   constructor(message, status = 503, code = "WORKSPACE_STATE_UNAVAILABLE") {

--- a/tests/workModeUi.test.js
+++ b/tests/workModeUi.test.js
@@ -58,7 +58,12 @@ test("Chat and Work are available with projects, agents, and pet state", async (
   assert.match(workMode, /function createProjectForm/u);
   assert.match(workMode, /function createAgentForm/u);
   assert.match(workMode, /function createEditAgentForm/u);
-  assert.match(workMode, /Любимецът показва/u);
+  assert.match(workMode, /Личният любимец/u);
+  assert.match(workMode, /label: "Кори"/u);
+  assert.match(workMode, /label: "Капка"/u);
+  assert.match(workMode, /label: "Искра"/u);
+  assert.match(workMode, /label: "Бухал"/u);
+  assert.match(workMode, /label: "Скала"/u);
   assert.match(workMode, /\/api\/workspaces/u);
   assert.match(workMode, /защитения ти профил/u);
   assert.match(workMode, /function recordActivity/u);
@@ -180,6 +185,22 @@ test("work mode runs in the browser and creates an isolated project payload", as
   assert.equal(
     dom.window.document.getElementById("workPet").dataset.petState,
     "needs-input",
+  );
+
+  dom.window.SynchronWorkMode.openManager();
+  const sparkPet = dom.window.document.querySelector(
+    '[aria-label="Избери Искра"]',
+  );
+  assert.ok(sparkPet);
+  sparkPet.click();
+  assert.equal(dom.window.document.getElementById("workPet").textContent, "🔥");
+  assert.equal(
+    dom.window.document.getElementById("workPet").dataset.petId,
+    "spark",
+  );
+  assert.match(
+    dom.window.localStorage.getItem("synchronWorkMode:tester-one"),
+    /"petId":"spark"/u,
   );
   dom.window.close();
 });

--- a/tests/workspaceStateService.test.js
+++ b/tests/workspaceStateService.test.js
@@ -61,6 +61,12 @@ test("workspace document id is stable and does not expose the owner id", () => {
   assert.doesNotMatch(first, /user-123/u);
 });
 
+test("workspace keeps a supported personal pet", () => {
+  const state = normalizeWorkspaceState({ petId: "drop" });
+
+  assert.equal(state.petId, "drop");
+});
+
 test("workspace state is saved in an isolated hashed document", async () => {
   let indexed = null;
   const client = {


### PR DESCRIPTION
## Какво се променя

- добавя шест оригинални AI CORE любимци: Кори, Капка, Искра, Бухал, Скала и Мяу;
- всеки има собствено описание и визуален цвят при готов статус;
- изборът се запазва в защитеното потребителско workspace състояние;
- любимецът продължава да показва `работи`, `чака решение`, `готово` и `блокирано`;
- обновява cache версията на клиентските файлове.

## Граница

Използвани са оригинални AI CORE имена и емоджи символи. Не се копират изображенията или имената на вградените ChatGPT Pets. Любимецът не променя разрешенията и не дава нови права на AI.

## Проверки

- целеви pet/workspace тестове: 10/10;
- пълен тестов пакет: 505/505;
- Prettier: успешно;
- remote tree SHA съвпада точно с локално тестваното дърво.