### PR TITLE
Fix pet picker button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,10 @@
     <link rel="stylesheet" href="/accessibility.css?v=20260728-font-stepper" />
     <link rel="stylesheet" href="/task-journal.css?v=20260728-task-journal" />
     <link rel="stylesheet" href="/auth.css?v=20260801-profile-actions" />
-    <link rel="stylesheet" href="/work-mode.css?v=20260802-ai-core-pets-v1" />
+    <link
+      rel="stylesheet"
+      href="/work-mode.css?v=20260802-pet-picker-button-v2"
+    />
     <link rel="stylesheet" href="/assets/20260730-v2/synchron-vision.css" />
     <link
       rel="stylesheet"
@@ -278,25 +281,34 @@
               <span>Работа</span>
             </button>
           </div>
-          <button
-            id="workContextBtn"
-            class="work-context-button"
-            type="button"
-            aria-label="Проекти, лични агенти и любимец"
-          >
-            <span class="work-context-copy">
-              <strong id="workProjectLabel">Без активен проект</strong>
-              <small id="workAgentLabel">AI CORE</small>
-            </span>
-            <span
-              id="workPet"
-              class="work-pet"
-              data-pet-state="ready"
-              aria-hidden="true"
-              >🤖</span
+          <div class="work-context-controls">
+            <button
+              id="workPetBtn"
+              class="work-pet-button"
+              type="button"
+              aria-label="Избери любимец"
             >
-            <i class="fa-solid fa-sliders"></i>
-          </button>
+              <span
+                id="workPet"
+                class="work-pet"
+                data-pet-state="ready"
+                aria-hidden="true"
+                >🤖</span
+              >
+            </button>
+            <button
+              id="workContextBtn"
+              class="work-context-button"
+              type="button"
+              aria-label="Проекти и лични агенти"
+            >
+              <span class="work-context-copy">
+                <strong id="workProjectLabel">Без активен проект</strong>
+                <small id="workAgentLabel">AI CORE</small>
+              </span>
+              <i class="fa-solid fa-sliders"></i>
+            </button>
+          </div>
         </div>
 
         <div id="chatMessages" aria-live="polite"></div>
@@ -452,7 +464,7 @@
     </main>
 
     <script src="/markdown-renderer.js?v=20260728-xss"></script>
-    <script src="/work-mode.js?v=20260802-ai-core-pets-v1"></script>
+    <script src="/work-mode.js?v=20260802-pet-picker-button-v2"></script>
     <script src="/assets/20260801-profile-actions/app.js"></script>
     <script src="/accessibility.js?v=20260728-font-stepper"></script>
     <script src="/assets/20260730-connections-v1/work-center.js"></script>

--- a/public/work-mode.css
+++ b/public/work-mode.css
@@ -18,7 +18,8 @@
 }
 
 .interaction-mode-switch button,
-.work-context-button {
+.work-context-button,
+.work-pet-button {
   min-height: 42px;
   border: 0;
   color: #52605b;
@@ -42,9 +43,17 @@
   box-shadow: 0 4px 12px rgba(18, 32, 29, 0.18);
 }
 
-.work-context-button {
+.work-context-controls {
   min-width: 0;
   max-width: 55%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+}
+
+.work-context-button {
+  min-width: 0;
   padding: 4px 8px 4px 12px;
   display: flex;
   align-items: center;
@@ -54,8 +63,21 @@
   border-radius: 14px;
 }
 
+.work-pet-button {
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  padding: 3px;
+  display: grid;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 14px;
+}
+
 .work-context-button:hover,
-.work-context-button:focus-visible {
+.work-context-button:focus-visible,
+.work-pet-button:hover,
+.work-pet-button:focus-visible {
   border-color: #dfe3e8;
   background: #f6f7f7;
   outline: none;
@@ -422,7 +444,7 @@ body[data-interaction-mode="chat"] .work-pet {
     padding: 7px 10px;
   }
 
-  .work-context-button {
+  .work-context-controls {
     max-width: 58%;
   }
 }
@@ -442,9 +464,12 @@ body[data-interaction-mode="chat"] .work-pet {
     justify-content: center;
   }
 
-  .work-context-button {
+  .work-context-controls {
     width: auto;
     max-width: none;
+  }
+
+  .work-context-button {
     padding-left: 6px;
   }
 

--- a/public/work-mode.js
+++ b/public/work-mode.js
@@ -67,6 +67,7 @@
     chatModeBtn: document.getElementById("chatModeBtn"),
     workModeToolbarBtn: document.getElementById("workModeToolbarBtn"),
     workModeBtn: document.getElementById("workModeBtn"),
+    workPetBtn: document.getElementById("workPetBtn"),
     workContextBtn: document.getElementById("workContextBtn"),
     projectLabel: document.getElementById("workProjectLabel"),
     agentLabel: document.getElementById("workAgentLabel"),
@@ -359,7 +360,12 @@
       ready: "Готово за преглед",
       blocked: "Задачата е блокирана",
     };
-    elements.workContextBtn.title = `${pet.label}: ${statusLabels[workState.petState]}. ${pet.description}`;
+    const petTitle = `${pet.label}: ${statusLabels[workState.petState]}. ${pet.description}`;
+    elements.workPetBtn.title = petTitle;
+    elements.workPetBtn.setAttribute(
+      "aria-label",
+      `Избери любимец. ${petTitle}`,
+    );
   }
 
   function setMode(mode) {
@@ -463,7 +469,7 @@
     parent.appendChild(list);
   }
 
-  function renderPetChoices(parent) {
+  function renderPetChoices(parent, reopen = openManager) {
     const grid = document.createElement("div");
     grid.className = "pet-choice-grid";
     for (const pet of PETS) {
@@ -476,7 +482,7 @@
         workState.petId = pet.id;
         saveState();
         renderPet();
-        openManager();
+        reopen();
       });
       addText(button, "span", pet.symbol);
       addText(button, "strong", pet.label);
@@ -766,6 +772,21 @@
     return container;
   }
 
+  function openPetManager() {
+    closeOtherPanels();
+    elements.drawerTitle.textContent = "Избери любимец";
+    elements.drawerBody.replaceChildren();
+    addText(
+      elements.drawerBody,
+      "p",
+      "Избери кой любимец да те придружава в AI CORE.",
+      "work-manager-intro",
+    );
+    renderPetChoices(elements.drawerBody, openPetManager);
+    elements.drawer.hidden = false;
+    elements.drawerBackdrop.hidden = false;
+  }
+
   function openManager() {
     closeOtherPanels();
     elements.drawerTitle.textContent = "Работа, агенти и любимец";
@@ -872,6 +893,7 @@
       setMode("work"),
     );
     elements.workModeBtn?.addEventListener("click", () => setMode("work"));
+    elements.workPetBtn?.addEventListener("click", openPetManager);
     elements.workContextBtn?.addEventListener("click", openManager);
     elements.commandBar?.addEventListener("click", (event) => {
       const command = event.target.closest("[data-command]")?.dataset.command;
@@ -889,6 +911,7 @@
     onError: () => workState?.mode === "work" && setPetState("blocked"),
     onTask,
     openManager,
+    openPetManager,
     setBusy: (busy) => {
       if (busy && workState?.mode === "work") setPetState("running");
     },

--- a/tests/workModeUi.test.js
+++ b/tests/workModeUi.test.js
@@ -10,7 +10,8 @@ function createWorkModeDom(script, fetchImpl) {
       <button id="chatModeBtn"></button>
       <button id="workModeToolbarBtn"></button>
       <button id="workModeBtn"></button>
-      <button id="workContextBtn"><strong id="workProjectLabel"></strong><small id="workAgentLabel"></small><span id="workPet"></span></button>
+      <button id="workPetBtn"><span id="workPet"></span></button>
+      <button id="workContextBtn"><strong id="workProjectLabel"></strong><small id="workAgentLabel"></small></button>
       <aside id="dataDrawer" hidden><h2 id="dataDrawerTitle"></h2><div id="dataDrawerBody"></div></aside>
       <div id="drawerBackdrop" hidden></div>
       <nav id="sidebar"></nav><div id="sidebarBackdrop" hidden></div>
@@ -37,6 +38,7 @@ test("Chat and Work are available with projects, agents, and pet state", async (
 
   assert.match(html, /id="chatModeBtn"/u);
   assert.match(html, /id="workModeToolbarBtn"/u);
+  assert.match(html, /id="workPetBtn"/u);
   assert.match(html, /id="workContextBtn"/u);
   assert.match(html, /id="workPet"/u);
   assert.match(html, /\/work-mode\.js\?v=/u);
@@ -52,6 +54,7 @@ test("Chat and Work are available with projects, agents, and pet state", async (
   assert.match(css, /data-pet-state="running"/u);
   assert.match(css, /data-pet-state="needs-input"/u);
   assert.match(css, /data-pet-state="blocked"/u);
+  assert.match(css, /\.work-pet-button/u);
   assert.match(css, /prefers-reduced-motion/u);
 
   assert.match(workMode, /function getRequestPayload/u);
@@ -103,7 +106,8 @@ test("work mode runs in the browser and creates an isolated project payload", as
       <button id="chatModeBtn"></button>
       <button id="workModeToolbarBtn"></button>
       <button id="workModeBtn"></button>
-      <button id="workContextBtn"><strong id="workProjectLabel"></strong><small id="workAgentLabel"></small><span id="workPet"></span></button>
+      <button id="workPetBtn"><span id="workPet"></span></button>
+      <button id="workContextBtn"><strong id="workProjectLabel"></strong><small id="workAgentLabel"></small></button>
       <aside id="dataDrawer" hidden><h2 id="dataDrawerTitle"></h2><div id="dataDrawerBody"></div></aside>
       <div id="drawerBackdrop" hidden></div>
       <nav id="sidebar"></nav><div id="sidebarBackdrop" hidden></div>
@@ -114,6 +118,16 @@ test("work mode runs in the browser and creates an isolated project payload", as
 
   dom.window.eval(script);
   dom.window.SynchronWorkMode.init({ id: "tester-one", role: "tester" });
+  dom.window.document.getElementById("workPetBtn").click();
+  assert.equal(
+    dom.window.document.getElementById("dataDrawerTitle").textContent,
+    "Избери любимец",
+  );
+  assert.ok(dom.window.document.querySelector('[aria-label="Избери Бухал"]'));
+  assert.doesNotMatch(
+    dom.window.document.getElementById("dataDrawerBody").textContent,
+    /Проекти|Лични агенти/u,
+  );
   dom.window.document.getElementById("workModeToolbarBtn").click();
   dom.window.SynchronWorkMode.openManager();
 


### PR DESCRIPTION
## Какво се променя

- отделя любимеца като самостоятелен бутон;
- натискането му отваря директно „Избери любимец“;
- иконата с плъзгачите остава за проекти и лични агенти;
- обновява версията на статичните файлове, за да не остава стар кеш.

## Причина

Любимецът и работният контекст споделяха един бутон, което на мобилен екран водеше до грешен панел вместо до избора на любимец.

## Проверка

- нов браузърен тест доказва, че бутонът отваря само избора на любимец;
- изборът и запазването на любимец остават работещи;
- пълният тестов пакет е успешен: 506/506.