### PR TITLE
Add specialized AI agents with linked pets

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -464,7 +464,7 @@
     </main>
 
     <script src="/markdown-renderer.js?v=20260728-xss"></script>
-    <script src="/work-mode.js?v=20260802-codex-project-loop-v1"></script>
+    <script src="/work-mode.js?v=20260802-specialized-agents-v1"></script>
     <script src="/assets/20260801-profile-actions/app.js"></script>
     <script src="/accessibility.js?v=20260728-font-stepper"></script>
     <script src="/assets/20260730-connections-v1/work-center.js"></script>

--- a/public/work-mode.js
+++ b/public/work-mode.js
@@ -1,5 +1,5 @@
 (() => {
-  const STORAGE_VERSION = 4;
+  const STORAGE_VERSION = 5;
   const WORKSPACE_ENDPOINT = "/api/workspaces";
   const PETS = Object.freeze([
     {
@@ -43,6 +43,7 @@
     general: "Универсален помощник",
     researcher: "Изследовател",
     organizer: "Организатор",
+    documents: "Документи и поща",
     builder: "Създател на проекти",
     coder: "Codex разработчик",
   });
@@ -56,6 +57,62 @@
     "gpt-5.6-terra": "GPT-5.6 Terra · балансиран",
     "gpt-5.6-luna": "GPT-5.6 Luna · бърз",
   });
+
+  const DEFAULT_AGENTS = Object.freeze([
+    Object.freeze({
+      id: "synchron-builder",
+      name: "AI CORE",
+      role: "builder",
+      model: "auto",
+      purpose: "Подготвя реален резултат и показва какво е проверено.",
+      engine: "ai-core",
+      petId: "robot",
+    }),
+    Object.freeze({
+      id: "research-agent",
+      name: "Изследовател",
+      role: "researcher",
+      model: "auto",
+      purpose: "Проверява актуални източници и отделя фактите от изводите.",
+      engine: "ai-core",
+      petId: "owl",
+    }),
+    Object.freeze({
+      id: "organizer-agent",
+      name: "Организатор",
+      role: "organizer",
+      model: "auto",
+      purpose: "Подрежда задачи и календар, като спира преди външни промени.",
+      engine: "ai-core",
+      petId: "rock",
+    }),
+    Object.freeze({
+      id: "documents-agent",
+      name: "Документи",
+      role: "documents",
+      model: "auto",
+      purpose: "Работи с разрешени файлове, документи и поща.",
+      engine: "ai-core",
+      petId: "cat",
+    }),
+    Object.freeze({
+      id: "codex-agent",
+      name: "Codex",
+      role: "coder",
+      model: "gpt-5.6-terra",
+      purpose: "Анализира кода без запис и без интернет.",
+      engine: "codex",
+      petId: "spark",
+    }),
+  ]);
+
+  function agentPetId(agent) {
+    if (PETS.some((pet) => pet.id === agent?.petId)) return agent.petId;
+    return (
+      DEFAULT_AGENTS.find((defaultAgent) => defaultAgent.id === agent?.id)
+        ?.petId || "robot"
+    );
+  }
 
   let storageKey = "synchronWorkMode:anonymous";
   let workState = null;
@@ -113,24 +170,7 @@
           run: null,
         },
       ],
-      agents: [
-        {
-          id: "synchron-builder",
-          name: "AI CORE",
-          role: "builder",
-          model: "auto",
-          purpose: "Подготвя реален резултат и показва какво е проверено.",
-          engine: "ai-core",
-        },
-        {
-          id: "codex-agent",
-          name: "Codex",
-          role: "coder",
-          model: "gpt-5.6-terra",
-          purpose: "Анализира кода без запис и без интернет.",
-          engine: "codex",
-        },
-      ],
+      agents: DEFAULT_AGENTS.map((agent) => ({ ...agent })),
       activities: [],
     };
   }
@@ -198,6 +238,7 @@
           engine: Object.hasOwn(ENGINE_OPTIONS, agent?.engine)
             ? agent.engine
             : "ai-core",
+          petId: agentPetId(agent),
         }))
       : fallback.agents;
     const activities = Array.isArray(value.activities)
@@ -225,21 +266,39 @@
     ) {
       agents.push(fallback.agents.find((agent) => agent.engine === "codex"));
     }
+    if ((Number.parseInt(value.version, 10) || 0) < STORAGE_VERSION) {
+      for (const defaultAgent of fallback.agents) {
+        if (agents.length >= 12) break;
+        if (!agents.some((agent) => agent.id === defaultAgent.id)) {
+          agents.push({ ...defaultAgent });
+        }
+      }
+    }
+
+    const activeProjectId = projects.some(
+      (project) => project.id === value.activeProjectId,
+    )
+      ? value.activeProjectId
+      : projects[0].id;
+    const activeAgentId = agents.some(
+      (agent) => agent.id === value.activeAgentId,
+    )
+      ? value.activeAgentId
+      : agents[0].id;
+    const petId = PETS.some((pet) => pet.id === value.petId)
+      ? value.petId
+      : fallback.petId;
+    if ((Number.parseInt(value.version, 10) || 0) < STORAGE_VERSION) {
+      const activeAgent = agents.find((agent) => agent.id === activeAgentId);
+      if (activeAgent) activeAgent.petId = petId;
+    }
 
     return {
       version: STORAGE_VERSION,
       mode: value.mode === "work" ? "work" : "chat",
-      activeProjectId: projects.some(
-        (project) => project.id === value.activeProjectId,
-      )
-        ? value.activeProjectId
-        : projects[0].id,
-      activeAgentId: agents.some((agent) => agent.id === value.activeAgentId)
-        ? value.activeAgentId
-        : agents[0].id,
-      petId: PETS.some((pet) => pet.id === value.petId)
-        ? value.petId
-        : fallback.petId,
+      activeProjectId,
+      activeAgentId,
+      petId,
       petState: ["ready", "running", "needs-input", "blocked"].includes(
         value.petState,
       )
@@ -495,11 +554,13 @@
       button.classList.toggle("active", agent.id === workState.activeAgentId);
       button.addEventListener("click", () => {
         workState.activeAgentId = agent.id;
+        workState.petId = agent.petId;
         saveState();
         renderMode();
         openManager();
       });
-      addText(button, "strong", agent.name);
+      const agentPet = PETS.find((pet) => pet.id === agent.petId) || PETS[0];
+      addText(button, "strong", `${agentPet.symbol} ${agent.name}`);
       addText(
         button,
         "small",
@@ -514,6 +575,7 @@
       edit.addEventListener("click", () => {
         editingAgentId = agent.id;
         workState.activeAgentId = agent.id;
+        workState.petId = agent.petId;
         saveState();
         renderMode();
         openManager();
@@ -535,6 +597,8 @@
       button.setAttribute("aria-label", `Избери ${pet.label}`);
       button.addEventListener("click", () => {
         workState.petId = pet.id;
+        const agent = activeAgent();
+        if (agent) agent.petId = pet.id;
         saveState();
         renderPet();
         reopen();
@@ -710,6 +774,17 @@
       engine.appendChild(option);
     }
     form.appendChild(engine);
+    addText(form, "label", "Любимец на агента").htmlFor =
+      "newWorkAgentPet";
+    const pet = document.createElement("select");
+    pet.id = "newWorkAgentPet";
+    for (const item of PETS) {
+      const option = document.createElement("option");
+      option.value = item.id;
+      option.textContent = `${item.symbol} ${item.label}`;
+      pet.appendChild(option);
+    }
+    form.appendChild(pet);
     const submit = document.createElement("button");
     submit.type = "submit";
     submit.textContent = "Създай и избери агента";
@@ -725,11 +800,15 @@
         engine: Object.hasOwn(ENGINE_OPTIONS, engine.value)
           ? engine.value
           : "ai-core",
+        petId: PETS.some((item) => item.id === pet.value)
+          ? pet.value
+          : "robot",
       };
       if (!agent.name) return;
       const previousActiveAgentId = workState.activeAgentId;
       workState.agents.unshift(agent);
       workState.activeAgentId = agent.id;
+      workState.petId = agent.petId;
       if (!saveState()) {
         workState.agents = workState.agents.filter(
           (item) => item.id !== agent.id,
@@ -799,6 +878,18 @@
     }
     engine.value = agent.engine;
     form.appendChild(engine);
+    addText(form, "label", "Любимец на агента").htmlFor =
+      "editWorkAgentPet";
+    const pet = document.createElement("select");
+    pet.id = "editWorkAgentPet";
+    for (const item of PETS) {
+      const option = document.createElement("option");
+      option.value = item.id;
+      option.textContent = `${item.symbol} ${item.label}`;
+      pet.appendChild(option);
+    }
+    pet.value = agent.petId;
+    form.appendChild(pet);
 
     const actions = document.createElement("div");
     actions.className = "work-form-actions";
@@ -827,11 +918,15 @@
         engine: Object.hasOwn(ENGINE_OPTIONS, engine.value)
           ? engine.value
           : "ai-core",
+        petId: PETS.some((item) => item.id === pet.value)
+          ? pet.value
+          : "robot",
       };
       if (!next.name || !next.purpose) return;
       const previous = { ...agent };
       Object.assign(agent, next);
       workState.activeAgentId = agent.id;
+      workState.petId = agent.petId;
       if (!saveState()) {
         Object.assign(agent, previous);
         managerNotice =
@@ -940,6 +1035,7 @@
           model: agent?.model || "auto",
           purpose: agent?.purpose || "",
           engine: agent?.engine || "ai-core",
+          petId: agent?.petId || "robot",
         },
       },
     };

--- a/src/services/workModeService.js
+++ b/src/services/workModeService.js
@@ -1,4 +1,12 @@
 const WORK_MODES = new Set(["chat", "work"]);
+const WORK_PETS = Object.freeze({
+  robot: "Кори",
+  drop: "Капка",
+  spark: "Искра",
+  owl: "Бухал",
+  rock: "Скала",
+  cat: "Мяу",
+});
 
 const AGENT_ROLES = Object.freeze({
   general: {
@@ -14,7 +22,12 @@ const AGENT_ROLES = Object.freeze({
   organizer: {
     label: "Организатор",
     guidance:
-      "Разделяй работата на малки стъпки, следи напредъка и спирай преди рисково външно действие.",
+      "Разделяй работата на малки стъпки, използвай календара само когато задачата го изисква, следи напредъка и спирай преди рисково външно действие.",
+  },
+  documents: {
+    label: "Документи и поща",
+    guidance:
+      "Работи прецизно с разрешените файлове, документи и съобщения. Разграничавай прочетеното съдържание от предложенията и не изпращай нищо без потвърждение.",
   },
   builder: {
     label: "Създател на проекти",
@@ -113,6 +126,9 @@ export function sanitizeWorkContext(value) {
     engine: Object.hasOwn(AGENT_ENGINES, cleanText(value.agent?.engine, 30))
       ? cleanText(value.agent?.engine, 30)
       : "ai-core",
+    petId: Object.hasOwn(WORK_PETS, cleanText(value.agent?.petId, 20))
+      ? cleanText(value.agent?.petId, 20)
+      : "robot",
   };
 
   if (!project.name && !project.objective && !agent.purpose) return null;
@@ -149,6 +165,7 @@ export function buildWorkModeContext(value) {
     `Избран личен агент: ${context.agent.name}`,
     `Изпълнител: ${AGENT_ENGINES[context.agent.engine].label}`,
     `Роля: ${role.label}`,
+    `Любимец на агента: ${WORK_PETS[context.agent.petId]}`,
     `Модел: ${AGENT_MODELS[context.agent.model].label}`,
     `Начин на работа: ${role.guidance}`,
     context.agent.purpose
@@ -185,6 +202,7 @@ export function buildWorkContextStatusReply(value) {
     `Модел: ${AGENT_MODELS[context.agent.model].label}`,
     `Роля: ${AGENT_ROLES[context.agent.role].label}`,
     `Изпълнител: ${AGENT_ENGINES[context.agent.engine].label}`,
+    `Любимец: ${WORK_PETS[context.agent.petId]}`,
     `Проект: ${context.project.name || "Без активен проект"}`,
   ].join("\n");
 }

--- a/src/services/workspaceStateService.js
+++ b/src/services/workspaceStateService.js
@@ -3,12 +3,14 @@ import { createHash } from "node:crypto";
 import { getOpenSearchClient } from "../config/opensearch.js";
 
 const DEFAULT_INDEX = "synchron-workspaces-v1";
+const WORKSPACE_VERSION = 5;
 const VALID_MODES = new Set(["chat", "work"]);
 const VALID_STATUSES = new Set(["ready", "running", "needs-input", "blocked"]);
 const VALID_ROLES = new Set([
   "general",
   "researcher",
   "organizer",
+  "documents",
   "builder",
   "coder",
 ]);
@@ -25,6 +27,62 @@ const VALID_MODELS = new Set([
   "gpt-5.6-luna",
 ]);
 const VALID_PETS = new Set(["robot", "drop", "spark", "owl", "rock", "cat"]);
+
+const DEFAULT_AGENTS = Object.freeze([
+  Object.freeze({
+    id: "synchron-builder",
+    name: "AI CORE",
+    role: "builder",
+    model: "auto",
+    purpose: "Подготвя реален резултат и показва какво е проверено.",
+    engine: "ai-core",
+    petId: "robot",
+  }),
+  Object.freeze({
+    id: "research-agent",
+    name: "Изследовател",
+    role: "researcher",
+    model: "auto",
+    purpose: "Проверява актуални източници и отделя фактите от изводите.",
+    engine: "ai-core",
+    petId: "owl",
+  }),
+  Object.freeze({
+    id: "organizer-agent",
+    name: "Организатор",
+    role: "organizer",
+    model: "auto",
+    purpose: "Подрежда задачи и календар, като спира преди външни промени.",
+    engine: "ai-core",
+    petId: "rock",
+  }),
+  Object.freeze({
+    id: "documents-agent",
+    name: "Документи",
+    role: "documents",
+    model: "auto",
+    purpose: "Работи с разрешени файлове, документи и поща.",
+    engine: "ai-core",
+    petId: "cat",
+  }),
+  Object.freeze({
+    id: "codex-agent",
+    name: "Codex",
+    role: "coder",
+    model: "gpt-5.6-terra",
+    purpose: "Анализира кода в изолирана област без запис и без интернет.",
+    engine: "codex",
+    petId: "spark",
+  }),
+]);
+
+function agentPetId(agent) {
+  if (VALID_PETS.has(agent?.petId)) return agent.petId;
+  return (
+    DEFAULT_AGENTS.find((defaultAgent) => defaultAgent.id === agent?.id)
+      ?.petId || "robot"
+  );
+}
 
 export class WorkspaceStateError extends Error {
   constructor(message, status = 503, code = "WORKSPACE_STATE_UNAVAILABLE") {
@@ -75,7 +133,7 @@ function normalizeProjectRun(value, timestamp) {
 
 function defaultWorkspaceState(now = new Date().toISOString()) {
   return {
-    version: 4,
+    version: WORKSPACE_VERSION,
     mode: "chat",
     activeProjectId: "starter-project",
     activeAgentId: "synchron-builder",
@@ -91,24 +149,7 @@ function defaultWorkspaceState(now = new Date().toISOString()) {
         run: null,
       },
     ],
-    agents: [
-      {
-        id: "synchron-builder",
-        name: "AI CORE",
-        role: "builder",
-        model: "auto",
-        purpose: "Подготвя реален резултат и показва какво е проверено.",
-        engine: "ai-core",
-      },
-      {
-        id: "codex-agent",
-        name: "Codex",
-        role: "coder",
-        model: "gpt-5.6-terra",
-        purpose: "Анализира кода в изолирана област без запис и без интернет.",
-        engine: "codex",
-      },
-    ],
+    agents: DEFAULT_AGENTS.map((agent) => ({ ...agent })),
     activities: [],
   };
 }
@@ -138,6 +179,7 @@ export function normalizeWorkspaceState(value, { now } = {}) {
         model: VALID_MODELS.has(agent?.model) ? agent.model : "auto",
         purpose: cleanText(agent?.purpose, 400),
         engine: VALID_ENGINES.has(agent?.engine) ? agent.engine : "ai-core",
+        petId: agentPetId(agent),
       }))
     : fallback.agents;
   const activities = Array.isArray(value.activities)
@@ -158,6 +200,14 @@ export function normalizeWorkspaceState(value, { now } = {}) {
   if (!agents.some((agent) => agent.engine === "codex") && agents.length < 12) {
     agents.push(fallback.agents.find((agent) => agent.engine === "codex"));
   }
+  if ((Number.parseInt(value.version, 10) || 0) < WORKSPACE_VERSION) {
+    for (const defaultAgent of fallback.agents) {
+      if (agents.length >= 12) break;
+      if (!agents.some((agent) => agent.id === defaultAgent.id)) {
+        agents.push({ ...defaultAgent });
+      }
+    }
+  }
 
   const activeProjectId = projects.some(
     (project) => project.id === value.activeProjectId,
@@ -167,13 +217,18 @@ export function normalizeWorkspaceState(value, { now } = {}) {
   const activeAgentId = agents.some((agent) => agent.id === value.activeAgentId)
     ? value.activeAgentId
     : agents[0].id;
+  const petId = VALID_PETS.has(value.petId) ? value.petId : "robot";
+  if ((Number.parseInt(value.version, 10) || 0) < WORKSPACE_VERSION) {
+    const activeAgent = agents.find((agent) => agent.id === activeAgentId);
+    if (activeAgent) activeAgent.petId = petId;
+  }
 
   return {
-    version: 4,
+    version: WORKSPACE_VERSION,
     mode: VALID_MODES.has(value.mode) ? value.mode : "chat",
     activeProjectId,
     activeAgentId,
-    petId: VALID_PETS.has(value.petId) ? value.petId : "robot",
+    petId,
     petState: VALID_STATUSES.has(value.petState) ? value.petState : "ready",
     projects,
     agents,

--- a/tests/workModeService.test.js
+++ b/tests/workModeService.test.js
@@ -41,6 +41,7 @@ test("work context is bounded and uses a server-owned role allowlist", () => {
       model: "made-up-model",
       purpose: "Следи проверките",
       engine: "root-shell",
+      petId: "owl",
     },
   });
 
@@ -50,6 +51,7 @@ test("work context is bounded and uses a server-owned role allowlist", () => {
   assert.equal(context.agent.model, "auto");
   assert.equal(context.agent.name, "Моят агент");
   assert.equal(context.agent.engine, "ai-core");
+  assert.equal(context.agent.petId, "owl");
   assert.equal(context.project.id, "project-one");
   assert.equal(context.project.run.sequence, 4);
   assert.equal(context.project.run.codeChanged, false);
@@ -97,7 +99,14 @@ test("the available personal-agent models are explicit and server-owned", () => 
 test("the available personal-agent roles are explicit", () => {
   assert.deepEqual(
     listWorkAgentRoles().map(({ id }) => id),
-    ["general", "researcher", "organizer", "builder", "coder"],
+    [
+      "general",
+      "researcher",
+      "organizer",
+      "documents",
+      "builder",
+      "coder",
+    ],
   );
 });
 
@@ -163,6 +172,7 @@ test("active work context questions use verified state instead of chat history",
       "Модел: GPT-5.6 Sol",
       "Роля: Организатор",
       "Изпълнител: AI CORE",
+      "Любимец: Кори",
       "Проект: AI CORE развитие",
     ].join("\n"),
   );

--- a/tests/workModeUi.test.js
+++ b/tests/workModeUi.test.js
@@ -64,6 +64,10 @@ test("Chat and Work are available with projects, agents, and pet state", async (
   assert.match(workMode, /Личният любимец/u);
   assert.match(workMode, /label: "Кори"/u);
   assert.match(workMode, /name: "Codex"/u);
+  assert.match(workMode, /name: "Изследовател"/u);
+  assert.match(workMode, /name: "Организатор"/u);
+  assert.match(workMode, /name: "Документи"/u);
+  assert.match(workMode, /documents: "Документи и поща"/u);
   assert.match(workMode, /codex: "Codex · изолиран кодов анализ"/u);
   assert.match(workMode, /label: "Капка"/u);
   assert.match(workMode, /label: "Искра"/u);
@@ -98,6 +102,7 @@ test("work settings are scoped by authenticated user and payload is bounded", as
     script,
     /model: Object\.hasOwn\(MODEL_OPTIONS, agent\?\.model\)/u,
   );
+  assert.match(script, /petId: agentPetId\(agent\)/u);
   assert.match(script, /if \(busy && workState\?\.mode === "work"\)/u);
 });
 
@@ -137,6 +142,17 @@ test("work mode runs in the browser and creates an isolated project payload", as
   dom.window.document.getElementById("workModeToolbarBtn").click();
   dom.window.SynchronWorkMode.openManager();
 
+  const researcher = [...dom.window.document.querySelectorAll("button")].find(
+    (button) => button.textContent.includes("Изследовател"),
+  );
+  assert.ok(researcher);
+  researcher.click();
+  assert.equal(dom.window.document.getElementById("workPet").textContent, "🦉");
+  assert.equal(
+    dom.window.SynchronWorkMode.getRequestPayload().workContext.agent.role,
+    "researcher",
+  );
+
   const projectForm = dom.window.document.querySelectorAll("form")[0];
   projectForm.querySelector("input").value = "Тестов проект";
   projectForm.querySelector("textarea").value = "Готов резултат";
@@ -171,6 +187,7 @@ test("work mode runs in the browser and creates an isolated project payload", as
   assert.equal(agentPayload.workContext.agent.name, "Тестов ръководител");
   assert.equal(agentPayload.workContext.agent.model, "gpt-5.6-sol");
   assert.equal(agentPayload.workContext.agent.engine, "codex");
+  assert.equal(agentPayload.workContext.agent.petId, "robot");
 
   const editAgent = [...dom.window.document.querySelectorAll("button")].find(
     (button) =>
@@ -183,6 +200,7 @@ test("work mode runs in the browser and creates an isolated project payload", as
   editForm.querySelector("#editWorkAgentRole").value = "builder";
   editForm.querySelector("#editWorkAgentModel").value = "gpt-5.6-terra";
   editForm.querySelector("#editWorkAgentEngine").value = "ai-core";
+  editForm.querySelector("#editWorkAgentPet").value = "owl";
   editForm.querySelector("#editWorkAgentPurpose").value =
     "Строи и проверява резултата";
   editForm.dispatchEvent(
@@ -194,6 +212,7 @@ test("work mode runs in the browser and creates an isolated project payload", as
   assert.equal(editedPayload.workContext.agent.role, "builder");
   assert.equal(editedPayload.workContext.agent.model, "gpt-5.6-terra");
   assert.equal(editedPayload.workContext.agent.engine, "ai-core");
+  assert.equal(editedPayload.workContext.agent.petId, "owl");
   assert.equal(
     editedPayload.workContext.agent.purpose,
     "Строи и проверява резултата",
@@ -254,6 +273,51 @@ test("work mode runs in the browser and creates an isolated project payload", as
     dom.window.localStorage.getItem("synchronWorkMode:tester-one"),
     /"petId":"spark"/u,
   );
+  dom.window.close();
+});
+
+test("legacy favorite stays attached to the active agent after migration", async () => {
+  const script = await readFile(
+    new URL("../public/work-mode.js", import.meta.url),
+    "utf8",
+  );
+  const dom = createWorkModeDom(script);
+  dom.window.localStorage.setItem(
+    "synchronWorkMode:legacy-tester",
+    JSON.stringify({
+      version: 4,
+      mode: "work",
+      activeProjectId: "starter-project",
+      activeAgentId: "synchron-builder",
+      petId: "drop",
+      petState: "ready",
+      projects: [{ id: "starter-project", name: "Първи проект" }],
+      agents: [
+        {
+          id: "synchron-builder",
+          name: "AI CORE",
+          role: "builder",
+          model: "auto",
+          engine: "ai-core",
+        },
+        {
+          id: "codex-agent",
+          name: "Codex",
+          role: "coder",
+          model: "gpt-5.6-terra",
+          engine: "codex",
+        },
+      ],
+    }),
+  );
+
+  dom.window.SynchronWorkMode.init({ id: "legacy-tester", role: "tester" });
+
+  assert.equal(
+    dom.window.SynchronWorkMode.getRequestPayload().workContext.agent.petId,
+    "drop",
+  );
+  assert.equal(dom.window.document.getElementById("workPet").textContent, "💧");
   dom.window.close();
 });
 

--- a/tests/workspaceStateService.test.js
+++ b/tests/workspaceStateService.test.js
@@ -50,7 +50,7 @@ test("workspace state is bounded and strips untrusted values", () => {
     { now: "2026-08-01T10:00:00.000Z" },
   );
 
-  assert.equal(state.version, 4);
+  assert.equal(state.version, 5);
   assert.equal(state.mode, "chat");
   assert.equal(state.petId, "robot");
   assert.equal(state.projects.length, 20);
@@ -63,7 +63,10 @@ test("workspace state is bounded and strips untrusted values", () => {
   assert.equal(state.agents[0].role, "general");
   assert.equal(state.agents[0].model, "auto");
   assert.equal(state.agents[0].engine, "ai-core");
-  assert.equal(state.agents.at(-1).engine, "codex");
+  assert.ok(state.agents.some((agent) => agent.engine === "codex"));
+  assert.ok(state.agents.some((agent) => agent.role === "researcher"));
+  assert.ok(state.agents.some((agent) => agent.role === "organizer"));
+  assert.ok(state.agents.some((agent) => agent.role === "documents"));
   assert.equal(state.activities.length, 40);
 });
 
@@ -82,6 +85,38 @@ test("workspace keeps a supported personal pet", () => {
   const state = normalizeWorkspaceState({ petId: "drop" });
 
   assert.equal(state.petId, "drop");
+});
+
+test("legacy workspaces receive specialized agents with their own pets", () => {
+  const state = normalizeWorkspaceState({
+    version: 4,
+    activeAgentId: "synchron-builder",
+    petId: "drop",
+    agents: [
+      {
+        id: "synchron-builder",
+        name: "AI CORE",
+        role: "builder",
+        engine: "ai-core",
+      },
+      {
+        id: "codex-agent",
+        name: "Codex",
+        role: "coder",
+        engine: "codex",
+      },
+    ],
+  });
+
+  assert.equal(state.version, 5);
+  assert.equal(
+    state.agents.find((agent) => agent.id === "synchron-builder").petId,
+    "drop",
+  );
+  assert.equal(state.agents.find((agent) => agent.id === "codex-agent").petId, "spark");
+  assert.equal(state.agents.find((agent) => agent.id === "research-agent").petId, "owl");
+  assert.equal(state.agents.find((agent) => agent.id === "organizer-agent").petId, "rock");
+  assert.equal(state.agents.find((agent) => agent.id === "documents-agent").petId, "cat");
 });
 
 test("workspace state is saved in an isolated hashed document", async () => {
@@ -130,7 +165,7 @@ test("workspace state is saved in an isolated hashed document", async () => {
   assert.doesNotMatch(JSON.stringify(indexed.body), /primary-user/u);
   assert.equal(result.state.mode, "work");
   assert.equal(result.state.agents[0].model, "gpt-5.6-terra");
-  assert.equal(result.state.agents.at(-1).engine, "codex");
+  assert.ok(result.state.agents.some((agent) => agent.engine === "codex"));
   assert.equal(result.state.projects[0].run.nextStep, "Продължи");
   assert.equal(result.persisted, true);
 });
@@ -148,5 +183,8 @@ test("missing workspace returns a safe starter state", async () => {
   assert.equal(result.persisted, false);
   assert.equal(result.state.projects[0].id, "starter-project");
   assert.equal(result.state.agents[0].name, "AI CORE");
-  assert.equal(result.state.agents[1].name, "Codex");
+  assert.deepEqual(
+    result.state.agents.map((agent) => agent.name),
+    ["AI CORE", "Изследовател", "Организатор", "Документи", "Codex"],
+  );
 });


### PR DESCRIPTION
## Какво се променя

- добавя готови специализирани агенти: Изследовател, Организатор и Документи;
- запазва AI CORE и Codex като отделни изпълнители;
- свързва всеки агент със собствен любимец и сменя любимеца при избор на агент;
- позволява избор на любимец при създаване и редактиране на личен агент;
- мигрира старите работни профили без загуба на проекти, задачи или предишния избран любимец;
- добавя отделна роля „Документи и поща“ без разширяване на разрешенията.

## Защо

Личните агенти вече не са само свободно име и описание. Потребителят получава готови роли според нуждата, а визуалният любимец следва избрания агент.

## Сигурност

- изборът на агент или любимец не дава нови права;
- външните write действия продължават да изискват съществуващите потвърждения;
- Codex остава изолиран, без запис и без интернет.

## Проверки

- 517/517 теста успешни;
- `npm audit --omit=dev --audit-level=high`: 0 уязвимости;
- Git tree SHA в GitHub съвпада с локално тествания tree.