### PR TITLE
Fix production smoke for AI CORE conversation tool

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -170,6 +170,7 @@ jobs:
                     "get_project_context",
                     "list_synchron_conversations",
                     "get_synchron_conversation",
+                    "talk_to_ai_core",
                     "get_digitalocean_app_status",
                     "get_system_configuration",
                     "get_digitalocean_account_audit",
@@ -187,6 +188,12 @@ jobs:
                   const trackerScopes = tracker?.securitySchemes?.flatMap(
                     (scheme) => scheme.scopes || [],
                   ) || [];
+                  const conversation = tools?.find(
+                    (tool) => tool.name === "talk_to_ai_core",
+                  );
+                  const conversationScopes = conversation?.securitySchemes?.flatMap(
+                    (scheme) => scheme.scopes || [],
+                  ) || [];
                   const confirmWww = tools?.find(
                     (tool) => tool.name === "confirm_digitalocean_www_domain",
                   );
@@ -199,6 +206,8 @@ jobs:
                     expected.every((name) => names.includes(name)) &&
                     tracker?.annotations?.readOnlyHint === true &&
                     trackerScopes.includes("synchron:read") &&
+                    conversation?.annotations?.destructiveHint === false &&
+                    conversationScopes.includes("synchron:agent.chat") &&
                     confirmWww?.annotations?.destructiveHint === true &&
                     confirmWwwScopes.includes("synchron:infrastructure.write");
                   console.log(JSON.stringify({ names, trackerReadOnly: tracker?.annotations?.readOnlyHint }));


### PR DESCRIPTION
## Причина
Production MCP каталогът вече съдържа 14 инструмента след добавянето на `talk_to_ai_core`, но smoke проверката още очакваше 13.

## Промяна
- добавя `talk_to_ai_core` към очаквания каталог;
- проверява, че инструментът е недеструктивен;
- проверява OAuth обхвата `synchron:agent.chat`.

## Проверки
- YAML parse: успешно;
- реалният production MCP каталог минава новата проверка;
- `npm test`: 523/523 успешни.

Не променя AI CORE, паметта, production конфигурацията или потребителските данни.