### PR TITLE
Fix desktop layout and mouse scrolling

### DIFF
--- a/public/synchron-vision.css
+++ b/public/synchron-vision.css
@@ -358,6 +358,32 @@ input:focus-visible {
   display: none;
 }
 
+@media (min-width: 901px) {
+  .app-shell > .chatPanel {
+    grid-area: auto !important;
+    grid-column: 2;
+    grid-row: 1;
+    width: 100%;
+    height: 100%;
+  }
+
+  .app-shell > .sidebar {
+    min-height: 0;
+    overflow-y: auto !important;
+    overscroll-behavior: contain;
+  }
+
+  .app-shell > .sidebar .sidebar-section {
+    min-height: 180px;
+    flex: 0 0 auto;
+    overflow: visible;
+  }
+
+  :root[data-font-scale="max"] .app-shell {
+    grid-template-columns: clamp(340px, 24vw, 400px) minmax(0, 1fr) !important;
+  }
+}
+
 @media (max-width: 900px) {
   .app-shell {
     display: block !important;

--- a/tests/synchronVisionUi.test.js
+++ b/tests/synchronVisionUi.test.js
@@ -58,6 +58,27 @@ test("mobile conversation history stays reachable with very large text", async (
   assert.match(app, /Все още няма запазени разговори/u);
 });
 
+test("desktop keeps the chat visible and both panes reachable with the mouse", async () => {
+  const css = await readFile(
+    new URL("../public/synchron-vision.css", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(css, /@media \(min-width: 901px\)/u);
+  assert.match(
+    css,
+    /\.app-shell > \.chatPanel\s*\{[\s\S]*?grid-area:\s*auto\s*!important;[\s\S]*?grid-column:\s*2;/u,
+  );
+  assert.match(
+    css,
+    /\.app-shell > \.sidebar\s*\{[\s\S]*?overflow-y:\s*auto\s*!important;/u,
+  );
+  assert.match(
+    css,
+    /data-font-scale="max"[^}]*grid-template-columns:\s*clamp\(340px, 24vw, 400px\) minmax\(0, 1fr\)\s*!important;/u,
+  );
+});
+
 test("mobile chat content clears the measured composer and command bar", async () => {
   const [css, script, app] = await Promise.all([
     readFile(new URL("../public/synchron-vision.css", import.meta.url), "utf8"),


### PR DESCRIPTION
## Какво се поправя

- връща AI CORE чата в дясната desktop колона;
- позволява превъртане с колелцето на мишката в чата и страничното меню;
- разширява страничната колона при много едър текст;
- запазва мобилния изглед непроменен.

## Причина

Старото правило `grid-area: chat` се прилагаше върху новия `app-shell`, който няма такава именувана grid зона. Така чатът излизаше извън видимата desktop решетка. Едновременно с това страницата забранява общото превъртане, а desktop страничното меню нямаше собствен scroll контейнер.

## Проверка

- `node --test tests/synchronVisionUi.test.js` — 7/7 успешни;
- `node --check public/synchron-vision.js` — успешно;
- `git diff --check` — успешно.

Production не е променен.