### PR TITLE
Fix responsive layout between 761 and 900px

### DIFF
--- a/public/synchron-vision.css
+++ b/public/synchron-vision.css
@@ -390,6 +390,16 @@ input:focus-visible {
     padding: 0 !important;
   }
 
+  .app-shell > .sidebar {
+    display: none;
+  }
+
+  .app-shell > .sidebar.mobile-visible {
+    position: fixed;
+    inset: 0 auto 0 0;
+    display: flex;
+  }
+
   .chatPanel {
     height: 100dvh !important;
     border: 0 !important;

--- a/tests/synchronVisionUi.test.js
+++ b/tests/synchronVisionUi.test.js
@@ -79,6 +79,23 @@ test("desktop keeps the chat visible and both panes reachable with the mouse", a
   );
 });
 
+test("intermediate widths use the mobile sidebar without pushing chat below it", async () => {
+  const css = await readFile(
+    new URL("../public/synchron-vision.css", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(css, /@media \(max-width: 900px\)/u);
+  assert.match(
+    css,
+    /\.app-shell > \.sidebar\s*\{[\s\S]*?display:\s*none;/u,
+  );
+  assert.match(
+    css,
+    /\.app-shell > \.sidebar\.mobile-visible\s*\{[\s\S]*?position:\s*fixed;[\s\S]*?display:\s*flex;/u,
+  );
+});
+
 test("mobile chat content clears the measured composer and command bar", async () => {
   const [css, script, app] = await Promise.all([
     readFile(new URL("../public/synchron-vision.css", import.meta.url), "utf8"),


### PR DESCRIPTION
## Какво е поправено

- Скрива страничното меню по подразбиране при ширина до 900 px.
- Показва го като фиксиран панел само когато е отворено.
- Предотвратява изместването на чата под менюто при увеличен текст или zoom.
- Добавя тест за междинния диапазон 761–900 px.

## Проверка

Промяната е ограничена до CSS и UI тест. Няма промени по API, памет, потребители или production настройки.