### PR TITLE
Fix MCP transport validation

### DIFF
--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ import testerAuthAdminRouter from "./src/routes/testerAuthAdminRouter.js";
 import digitalOceanDomainAdminRouter from "./src/routes/digitalOceanDomainAdminRouter.js";
 import systemRouter from "./src/routes/systemRouter.js";
 import workspacesRouter from "./src/routes/workspacesRouter.js";
-import mcpRouter from "./src/routes/mcpRouter.js";
+import mcpRouter, { mcpJsonParseErrorHandler } from "./src/routes/mcpRouter.js";
 import { createMcpOAuthRouter } from "./src/routes/mcpOAuthRouter.js";
 
 dotenv.config();
@@ -140,7 +140,7 @@ app.use("/health", healthRouter);
 app.use("/api/public-config", publicConfigRouter);
 app.use("/api/auth", oauthRateLimiter, userAuthRouter);
 app.use("/api/github", oauthRateLimiter, githubOAuthRouter);
-app.use("/mcp", privateApiRateLimiter, mcpRouter);
+app.use("/mcp", mcpJsonParseErrorHandler, privateApiRateLimiter, mcpRouter);
 
 app.use("/chat", requireOwnerSession, paidAiRateLimiter, chatRouter);
 app.use("/memory", requireOwnerSession, privateApiRateLimiter, memoryRouter);

--- a/src/routes/mcpRouter.js
+++ b/src/routes/mcpRouter.js
@@ -2,6 +2,7 @@ import express from "express";
 import {
   createMcpRequestHandler,
   isValidMcpToken,
+  MCP_PROTOCOL_VERSION,
 } from "../services/mcpReadService.js";
 import {
   buildMcpAuthenticateChallenge,
@@ -12,6 +13,69 @@ import {
 
 const router = express.Router();
 const handleMcpRequest = createMcpRequestHandler();
+const DEFAULT_ALLOWED_MCP_ORIGINS = Object.freeze([
+  "https://synchron.foundation",
+  "https://www.synchron.foundation",
+  "https://chatgpt.com",
+]);
+const SUPPORTED_MCP_PROTOCOL_VERSIONS = new Set([
+  "2025-03-26",
+  MCP_PROTOCOL_VERSION,
+]);
+
+function allowedMcpOrigins(env = process.env) {
+  const configured = String(env.MCP_ALLOWED_ORIGINS || "")
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+  return new Set(
+    configured.length > 0 ? configured : DEFAULT_ALLOWED_MCP_ORIGINS,
+  );
+}
+
+export function validateMcpTransport(
+  req,
+  res,
+  next,
+  { env = process.env } = {},
+) {
+  const origin = req.get("origin");
+  if (origin && !allowedMcpOrigins(env).has(origin)) {
+    return res.status(403).json({
+      jsonrpc: "2.0",
+      id: req.body?.id ?? null,
+      error: { code: -32000, message: "Неразрешен Origin за MCP заявка." },
+    });
+  }
+
+  const requestedVersion = req.get("mcp-protocol-version");
+  const isInitialization = req.body?.method === "initialize";
+  if (
+    !isInitialization &&
+    requestedVersion &&
+    !SUPPORTED_MCP_PROTOCOL_VERSIONS.has(requestedVersion)
+  ) {
+    return res.status(400).json({
+      jsonrpc: "2.0",
+      id: req.body?.id ?? null,
+      error: {
+        code: -32600,
+        message: "Неподдържана MCP протоколна версия.",
+      },
+    });
+  }
+
+  return next();
+}
+
+export function mcpJsonParseErrorHandler(error, req, res, next) {
+  if (error?.type !== "entity.parse.failed") return next(error);
+  return res.status(400).json({
+    jsonrpc: "2.0",
+    id: null,
+    error: { code: -32700, message: "Невалиден JSON в MCP заявката." },
+  });
+}
 
 export function requireMcpAuthorization(
   req,
@@ -92,15 +156,20 @@ export function requireMcpAuthorization(
   });
 }
 
-router.post("/", requireMcpAuthorization, async (req, res) => {
-  const response = await handleMcpRequest(
-    req.body,
-    req.mcpOwnerId,
-    req.mcpAuthentication,
-  );
-  if (!response) return res.status(202).end();
-  return res.json(response);
-});
+router.post(
+  "/",
+  validateMcpTransport,
+  requireMcpAuthorization,
+  async (req, res) => {
+    const response = await handleMcpRequest(
+      req.body,
+      req.mcpOwnerId,
+      req.mcpAuthentication,
+    );
+    if (!response) return res.status(202).end();
+    return res.json(response);
+  },
+);
 
 router.get("/", (_req, res) =>
   res.status(405).json({

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -5,7 +5,9 @@ import express from "express";
 import request from "supertest";
 
 import { createMcpOAuthRouter } from "../src/routes/mcpOAuthRouter.js";
-import mcpRouter from "../src/routes/mcpRouter.js";
+import mcpRouter, {
+  mcpJsonParseErrorHandler,
+} from "../src/routes/mcpRouter.js";
 
 const SECRET = "router-test-secret-with-more-than-thirty-two-characters";
 const DEDICATED_SECRET =
@@ -46,6 +48,55 @@ test("MCP initialize and tool discovery work without credentials", async () => {
     .expect(200);
   assert.equal(listed.body.result.tools.length, 14);
   assert.equal(listed.body.result.tools[0].securitySchemes[0].type, "oauth2");
+});
+
+test("MCP rejects an untrusted Origin", async () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/mcp", mcpRouter);
+  const response = await request(app)
+    .post("/mcp")
+    .set("Origin", "https://evil.example")
+    .send({ jsonrpc: "2.0", id: 20, method: "initialize" })
+    .expect(403);
+  assert.equal(response.body.error.code, -32000);
+});
+
+test("MCP accepts a trusted Origin", async () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/mcp", mcpRouter);
+  const response = await request(app)
+    .post("/mcp")
+    .set("Origin", "https://chatgpt.com")
+    .send({ jsonrpc: "2.0", id: 21, method: "initialize" })
+    .expect(200);
+  assert.equal(response.body.result.protocolVersion, "2025-06-18");
+});
+
+test("MCP rejects an unsupported protocol version after initialization", async () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/mcp", mcpRouter);
+  const response = await request(app)
+    .post("/mcp")
+    .set("MCP-Protocol-Version", "invalid")
+    .send({ jsonrpc: "2.0", id: 22, method: "tools/list" })
+    .expect(400);
+  assert.equal(response.body.error.code, -32600);
+});
+
+test("MCP returns a JSON-RPC parse error for malformed JSON", async () => {
+  const app = express();
+  app.use(express.json());
+  app.use("/mcp", mcpJsonParseErrorHandler, mcpRouter);
+  const response = await request(app)
+    .post("/mcp")
+    .set("Content-Type", "application/json")
+    .send("{bad json")
+    .expect(400);
+  assert.equal(response.type, "application/json");
+  assert.equal(response.body.error.code, -32700);
 });
 
 test("an unauthenticated tool call returns the ChatGPT OAuth challenge", async () => {


### PR DESCRIPTION
## Какво е променено

- отказва MCP заявки от непознат `Origin` с HTTP 403
- проверява `MCP-Protocol-Version` след инициализация и отказва неподдържани версии с HTTP 400
- връща стандартна JSON-RPC parse грешка `-32700` при повреден JSON
- запазва достъпа за `synchron.foundation`, `www.synchron.foundation` и `chatgpt.com`
- добавя четири регресионни теста

## Причина

Публичният MCP одит показа, че транспортният слой приема произволен `Origin`, невалидна протоколна версия и връща HTML при повреден JSON.

## Проверка

- `node --test tests/mcpOAuthRouter.test.js`: 11/11 успешни
- `npm test`: 529/529 успешни
- `git diff --check`: успешно
