### PR TITLE
Show verified AI provider and model

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1276,6 +1276,23 @@ function showConversationPersistenceWarning(message) {
   turn.insertBefore(warning, actions || null);
 }
 
+function showAiResponseSource(message, provider, model) {
+  const turn = message?.closest(".assistant-turn");
+  if (!turn || turn.querySelector(".ai-response-source")) return;
+
+  const cleanProvider = typeof provider === "string" ? provider.trim() : "";
+  const cleanModel = typeof model === "string" ? model.trim() : "";
+  if (!cleanProvider && !cleanModel) return;
+
+  const source = document.createElement("div");
+  source.className = "ai-response-source";
+  source.textContent = [cleanProvider, cleanModel].filter(Boolean).join(" · ");
+  source.setAttribute("aria-label", "AI доставчик и модел");
+
+  const actions = turn.querySelector(".message-actions");
+  turn.insertBefore(source, actions || null);
+}
+
 async function handleMessageAction(event) {
   const button = event.target.closest("button[data-action]");
   if (!button) return;
@@ -1473,6 +1490,11 @@ async function sendMessage() {
         } else if (parsed.event === "done") {
           completed = true;
           globalThis.SynchronWorkMode?.onDone(parsed.data);
+          showAiResponseSource(
+            responseBubble,
+            parsed.data?.provider,
+            parsed.data?.model,
+          );
           if (
             parsed.data?.conversationPersisted === false &&
             parsed.data?.warningCode === "CONVERSATION_NOT_SAVED"

--- a/public/styles.css
+++ b/public/styles.css
@@ -632,6 +632,13 @@ input {
     line-height: 1.4;
 }
 
+.ai-response-source {
+  margin-top: 6px;
+  color: var(--muted-text, #6b7280);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .user-turn {
     max-width: 82%;
     align-self: flex-end;

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -75,7 +75,7 @@ import {
   planCapabilities,
   shouldUseAgentPlanner,
 } from "../services/agentPlannerService.js";
-import { requestOpenAIText } from "../services/aiCoreService.js";
+import { requestOpenAIResponse } from "../services/aiCoreService.js";
 import { executeTaskPlan } from "../services/taskExecutionService.js";
 import { CodexAgentError } from "../services/codexAgentService.js";
 import {
@@ -1497,7 +1497,7 @@ router.post("/chat", async (req, res) => {
   }, aiTimeoutMs);
 
   try {
-    const fullReply = await requestOpenAIText({
+    const aiResponse = await requestOpenAIResponse({
       apiKey: openAiApiKey,
       input: messages,
       model: resolveWorkAgentModel(cleanWorkContext?.agent?.model),
@@ -1505,6 +1505,7 @@ router.post("/chat", async (req, res) => {
       reasoningEffort: "low",
       verbosity: "medium",
     });
+    const fullReply = aiResponse.text;
     sendEvent("token", { token: fullReply });
     if (!fullReply.trim()) {
       throw new Error("AI ядрото приключи без текстов отговор.");
@@ -1524,7 +1525,8 @@ router.post("/chat", async (req, res) => {
       capabilities: capabilityResults.map(({ request }) => request.capability),
       task: taskResult,
       mode: capabilityResults.length ? "agentic" : "conversation",
-      provider: "openai",
+      provider: aiResponse.provider,
+      model: aiResponse.model,
       ...(projectRun ? { projectRun } : {}),
       ...getConversationPersistenceMetadata(conversationPersisted),
     });

--- a/src/services/aiCoreService.js
+++ b/src/services/aiCoreService.js
@@ -27,7 +27,7 @@ export function extractOpenAIOutputText(data) {
   return text;
 }
 
-export async function requestOpenAIText({
+export async function requestOpenAIResponse({
   apiKey = process.env.OPENAI_API_KEY,
   input,
   model = process.env.OPENAI_CHAT_MODEL || DEFAULT_OPENAI_CHAT_MODEL,
@@ -77,5 +77,17 @@ export async function requestOpenAIText({
       "OPENAI_EMPTY_RESPONSE",
     );
   }
-  return text;
+  return {
+    text,
+    provider: "openai",
+    model:
+      typeof data?.model === "string" && data.model.trim()
+        ? data.model.trim()
+        : model,
+  };
+}
+
+export async function requestOpenAIText(options) {
+  const response = await requestOpenAIResponse(options);
+  return response.text;
 }

--- a/tests/aiCoreService.test.js
+++ b/tests/aiCoreService.test.js
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   DEFAULT_OPENAI_CHAT_MODEL,
   extractOpenAIOutputText,
+  requestOpenAIResponse,
   requestOpenAIText,
 } from "../src/services/aiCoreService.js";
 
@@ -69,5 +70,27 @@ test("allows the final conversation to request stronger reasoning and detail", a
         headers: { "content-type": "application/json" },
       });
     },
+  });
+});
+
+test("returns the provider and model reported by OpenAI", async () => {
+  const result = await requestOpenAIResponse({
+    apiKey: "test-openai-key",
+    input: [{ role: "user", content: "Кой модел работи?" }],
+    model: "requested-model",
+    fetchImpl: async () =>
+      new Response(
+        JSON.stringify({
+          model: "actual-response-model",
+          output_text: "Проверено.",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+  });
+
+  assert.deepEqual(result, {
+    text: "Проверено.",
+    provider: "openai",
+    model: "actual-response-model",
   });
 });

--- a/tests/chatResilience.test.js
+++ b/tests/chatResilience.test.js
@@ -67,6 +67,7 @@ test("normal chat uses OpenAI Responses without the removed DigitalOcean agent",
     assert.equal(body.store, false);
     return new Response(
       JSON.stringify({
+        model: "gpt-5.6-terra-verified",
         output: [
           {
             type: "message",
@@ -87,6 +88,7 @@ test("normal chat uses OpenAI Responses without the removed DigitalOcean agent",
 
     assert.match(response.text, /Отговор от OpenAI\./u);
     assert.match(response.text, /"provider":"openai"/u);
+    assert.match(response.text, /"model":"gpt-5.6-terra-verified"/u);
   } finally {
     globalThis.fetch = originalFetch;
     if (originalOpenAiKey === undefined) delete process.env.OPENAI_API_KEY;

--- a/tests/synchronVisionUi.test.js
+++ b/tests/synchronVisionUi.test.js
@@ -138,3 +138,16 @@ test("the chat keeps a successful answer visible when conversation persistence f
   assert.match(script, /showConversationPersistenceWarning\(responseBubble\)/u);
   assert.match(css, /\.conversation-persistence-warning/u);
 });
+
+test("each live AI answer shows its verified provider and model", async () => {
+  const [script, css] = await Promise.all([
+    readFile(new URL("../public/app.js", import.meta.url), "utf8"),
+    readFile(new URL("../public/styles.css", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(script, /showAiResponseSource\(/u);
+  assert.match(script, /parsed\.data\?\.provider/u);
+  assert.match(script, /parsed\.data\?\.model/u);
+  assert.match(script, /AI доставчик и модел/u);
+  assert.match(css, /\.ai-response-source/u);
+});


### PR DESCRIPTION
## Какво се променя

- Запазва доставчика и модела от реалния OpenAI Responses API отговор.
- Добавя `provider` и `model` към завършващото събитие на чата.
- Показва под всеки нов AI отговор безопасен ред, например `openai · gpt-5.6-terra`.
- Не показва ключове, тайни или вътрешни данни.

## Причина

AI CORE досега показваше доставчика само в невидимото stream събитие и изхвърляше модела, върнат от OpenAI. Затова потребителят не можеше да провери кой модел реално е използван.

## Проверки

- `npm test`
- 527 теста успешни, 0 неуспешни.
- Сравнението с актуалния `main` потвърждава точно 7 променени файла и запазва PR №249.

## Риск

Нисък. Няма промени по паметта, разрешенията, потребителите, инфраструктурата или production настройките.