### PR TITLE
Answer runtime model questions from verified metadata

### DIFF
--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -92,6 +92,7 @@ import { logSafeError, safeErrorCode } from "../utils/safeLogging.js";
 import {
   buildWorkContextStatusReply,
   buildWorkModeContext,
+  isRuntimeAiIdentityRequest,
   isWorkContextStatusRequest,
   normalizeInteractionMode,
   resolveWorkAgentModel,
@@ -1505,7 +1506,9 @@ router.post("/chat", async (req, res) => {
       reasoningEffort: "low",
       verbosity: "medium",
     });
-    const fullReply = aiResponse.text;
+    const fullReply = isRuntimeAiIdentityRequest(cleanMessage)
+      ? `Този отговор реално е обработен от ${aiResponse.provider} · ${aiResponse.model}.`
+      : aiResponse.text;
     sendEvent("token", { token: fullReply });
     if (!fullReply.trim()) {
       throw new Error("AI ядрото приключи без текстов отговор.");

--- a/src/services/workModeService.js
+++ b/src/services/workModeService.js
@@ -192,6 +192,22 @@ export function isWorkContextStatusRequest(message) {
   return asksForStatus && mentionsContext && asksForCurrent;
 }
 
+export function isRuntimeAiIdentityRequest(message) {
+  const text = cleanText(message, 500).toLocaleLowerCase("bg-BG");
+  if (!text) return false;
+  const asksForIdentity =
+    /(?:кой|какъв|каква|кажи|покажи|посочи|използва|работи|доставчик|provider)/u.test(
+      text,
+    );
+  const mentionsRuntime =
+    /(?:ai|изкуствен интелект|доставчик|provider|модел)/u.test(text);
+  const refersToCurrentReply =
+    /(?:този разговор|текущ(?:ия|ият)|реалн|в момента|използва|работи)/u.test(
+      text,
+    );
+  return asksForIdentity && mentionsRuntime && refersToCurrentReply;
+}
+
 export function buildWorkContextStatusReply(value) {
   const context = sanitizeWorkContext(value);
   if (!context) {
@@ -236,6 +252,7 @@ export function routeSelectedWorkAgentCapabilities(requests, value, message) {
   const nonCodeRequests = safeRequests.filter(
     ({ capability }) => !String(capability || "").startsWith("code."),
   );
+  if (isRuntimeAiIdentityRequest(message)) return nonCodeRequests;
   return [
     {
       capability: "code.analyze",

--- a/tests/chatResilience.test.js
+++ b/tests/chatResilience.test.js
@@ -96,6 +96,49 @@ test("normal chat uses OpenAI Responses without the removed DigitalOcean agent",
   }
 });
 
+test("runtime model question answers from verified OpenAI response metadata", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        model: "gpt-5.6-terra-verified",
+        output: [
+          {
+            type: "message",
+            content: [
+              {
+                type: "output_text",
+                text: "Не мога да проверя локалните файлове.",
+              },
+            ],
+          },
+        ],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+
+  try {
+    const response = await request(app)
+      .post("/chat/chat")
+      .set("Cookie", OWNER_COOKIE)
+      .send({
+        sessionId: "runtime-model-test",
+        message: "Кой AI доставчик и кой модел използва този разговор?",
+      })
+      .expect(200);
+
+    assert.match(
+      response.text,
+      /Този отговор реално е обработен от openai · gpt-5\.6-terra-verified\./u,
+    );
+    assert.doesNotMatch(response.text, /Не мога да проверя локалните файлове/u);
+    assert.match(response.text, /"provider":"openai"/u);
+    assert.match(response.text, /"model":"gpt-5.6-terra-verified"/u);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("normal chat does not call the removed DigitalOcean agent when OpenAI is unavailable", async () => {
   const originalFetch = globalThis.fetch;
   const originalOpenAiKey = process.env.OPENAI_API_KEY;

--- a/tests/workModeService.test.js
+++ b/tests/workModeService.test.js
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   buildWorkContextStatusReply,
   buildWorkModeContext,
+  isRuntimeAiIdentityRequest,
   isWorkContextStatusRequest,
   listWorkAgentModels,
   listWorkAgentEngines,
@@ -141,6 +142,34 @@ test("the available agent engines are explicit and Codex replaces code writes wi
       { capability: "web.search", action: "web.read" },
     ],
   );
+});
+
+test("runtime provider and model questions do not launch Codex code analysis", () => {
+  for (const message of [
+    "Кой AI доставчик и кой модел използва този разговор?",
+    "Покажи реалния модел, който работи в момента.",
+    "Кой provider обработва текущия отговор?",
+  ]) {
+    assert.equal(isRuntimeAiIdentityRequest(message), true);
+    assert.deepEqual(
+      routeSelectedWorkAgentCapabilities(
+        [{ capability: "code.read", action: "github.read" }],
+        {
+          project: { name: "SYNCHRON-X" },
+          agent: {
+            name: "Codex",
+            role: "coder",
+            model: "gpt-5.6-terra",
+            engine: "codex",
+          },
+        },
+        message,
+      ),
+      [],
+    );
+  }
+
+  assert.equal(isRuntimeAiIdentityRequest("Провери модела в src/config.js"), false);
 });
 
 test("active work context questions use verified state instead of chat history", () => {


### PR DESCRIPTION
## Какво се променя

- Разпознава въпросите за текущия AI доставчик и модел.
- Отговаря чрез проверените runtime метаданни от OpenAI, вместо да стартира Codex sandbox проверка.
- Запазва нормалното Codex маршрутизиране за останалите задачи.
- Добавя регресионни тестове за чата и Work режима.

## Причина

Въпросите за реалния доставчик и модел се насочваха към изолирания Codex sandbox. При sandbox грешка AI CORE повтаряше техническата грешка, въпреки че OpenAI разговорът работеше нормално.

## Проверка

- 533 от 533 теста са успешни.
- Разликата спрямо `main` е само в 4 очаквани файла.
- Няма промени по паметта, разрешенията или инфраструктурата.