### PR TITLE
Fix MCP OAuth consent confirmation

### DIFF
--- a/src/routes/mcpOAuthRouter.js
+++ b/src/routes/mcpOAuthRouter.js
@@ -1,13 +1,14 @@
 import express from "express";
-import { randomUUID } from "node:crypto";
 import { resolveRequestIdentity } from "../middleware/ownerAuth.js";
 import {
   createMcpAuthorizationCode,
+  createMcpConsentToken,
   exchangeMcpToken,
   getMcpAuthorizationServerMetadata,
   getMcpProtectedResourceMetadata,
   McpOAuthError,
   resolveMcpIssuerUrl,
+  validateMcpConsentToken,
   validateMcpAuthorizationRequest,
 } from "../services/mcpOAuthService.js";
 
@@ -45,7 +46,7 @@ function oauthError(res, error) {
   });
 }
 
-function consentPage(request, identity, csrfToken) {
+function consentPage(request, identity, consentToken) {
   const fields = {
     response_type: "code",
     client_id: request.clientId,
@@ -55,7 +56,7 @@ function consentPage(request, identity, csrfToken) {
     code_challenge_method: "S256",
     resource: request.resource,
     scope: request.scopes.join(" "),
-    csrf_token: csrfToken,
+    consent_token: consentToken,
   };
   const hidden = Object.entries(fields)
     .map(
@@ -106,12 +107,10 @@ export function createMcpOAuthRouter({
       noStore(res);
       if (!identity)
         return res.status(401).type("html").send(loginRequiredPage());
-      const csrfToken = randomUUID();
-      res.append(
-        "Set-Cookie",
-        `synchron_mcp_csrf=${csrfToken}; Path=/oauth; HttpOnly; Secure; SameSite=Strict; Max-Age=600`,
-      );
-      return res.type("html").send(consentPage(request, identity, csrfToken));
+      const consentToken = createMcpConsentToken(request, identity);
+      return res
+        .type("html")
+        .send(consentPage(request, identity, consentToken));
     } catch (error) {
       return oauthError(res, error);
     }
@@ -131,19 +130,8 @@ export function createMcpOAuthRouter({
             "access_denied",
           );
         }
-        const csrfCookie = String(req.headers.cookie || "")
-          .split(";")
-          .map((part) => part.trim())
-          .find((part) => part.startsWith("synchron_mcp_csrf="))
-          ?.slice("synchron_mcp_csrf=".length);
-        if (!csrfCookie || csrfCookie !== req.body?.csrf_token) {
-          throw new McpOAuthError(
-            "Невалидно потвърждение.",
-            403,
-            "access_denied",
-          );
-        }
         const request = await validateRequest(req.body);
+        validateMcpConsentToken(req.body?.consent_token, request, identity);
         const callback = new URL(request.redirectUri);
         if (req.body?.decision !== "allow") {
           callback.searchParams.set("error", "access_denied");
@@ -155,10 +143,6 @@ export function createMcpOAuthRouter({
         callback.searchParams.set("code", code);
         callback.searchParams.set("state", request.state);
         callback.searchParams.set("iss", resolveMcpIssuerUrl());
-        res.append(
-          "Set-Cookie",
-          "synchron_mcp_csrf=; Path=/oauth; HttpOnly; Secure; SameSite=Strict; Max-Age=0",
-        );
         noStore(res);
         return res.redirect(callback.href);
       } catch (error) {

--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -26,6 +26,7 @@ const MCP_OWNER_ONLY_SCOPES = Object.freeze([
 const ACCESS_TOKEN_TTL_SECONDS = 60 * 60;
 const REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60;
 const AUTHORIZATION_CODE_TTL_SECONDS = 5 * 60;
+const CONSENT_TOKEN_TTL_SECONDS = 10 * 60;
 const MAX_CONSUMED_TOKEN_RECORDS = 10_000;
 const REPLAY_CLEANUP_INTERVAL_SECONDS = 6 * 60 * 60;
 const MCP_OAUTH_REPLAY_INDEX =
@@ -134,6 +135,21 @@ function grantSecret(env = process.env) {
 
 function grantVerificationSecrets(env = process.env) {
   return oauthVerificationSecrets(env).map(deriveGrantSecret);
+}
+
+function deriveConsentSecret(secret) {
+  return createHash("sha256")
+    .update(secret)
+    .update("synchron-mcp-oauth-consent-v1\0")
+    .digest();
+}
+
+function consentSecret(env = process.env) {
+  return deriveConsentSecret(oauthSecret(env));
+}
+
+function consentVerificationSecrets(env = process.env) {
+  return oauthVerificationSecrets(env).map(deriveConsentSecret);
 }
 
 export function getMcpOAuthSecretMode(env = process.env) {
@@ -410,6 +426,68 @@ function safeStringEqual(left, right) {
   const a = Buffer.from(String(left), "utf8");
   const b = Buffer.from(String(right), "utf8");
   return a.length === b.length && timingSafeEqual(a, b);
+}
+
+function consentBinding(request, identity) {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        clientId: request.clientId,
+        redirectUri: request.redirectUri,
+        state: request.state,
+        codeChallenge: request.codeChallenge,
+        resource: request.resource,
+        scopes: request.scopes,
+        subject: String(identity.id),
+      }),
+    )
+    .digest("base64url");
+}
+
+export function createMcpConsentToken(
+  request,
+  identity,
+  env = process.env,
+  now = Math.floor(Date.now() / 1_000),
+) {
+  if (!identity?.id) {
+    throw new McpOAuthError("Липсва валиден SYNCHRON-X профил.", 401);
+  }
+  return encryptPayload(
+    "sx-consent",
+    {
+      typ: "consent",
+      binding: consentBinding(request, identity),
+      iat: now,
+      exp: now + CONSENT_TOKEN_TTL_SECONDS,
+    },
+    consentSecret(env),
+  );
+}
+
+export function validateMcpConsentToken(
+  token,
+  request,
+  identity,
+  env = process.env,
+  now = Math.floor(Date.now() / 1_000),
+) {
+  const payload = decryptPayloadWithFallback(
+    String(token || ""),
+    "sx-consent",
+    consentVerificationSecrets(env),
+  );
+  if (
+    !payload ||
+    payload.typ !== "consent" ||
+    payload.iat > now + 60 ||
+    payload.exp <= now ||
+    payload.exp - payload.iat !== CONSENT_TOKEN_TTL_SECONDS ||
+    !safeStringEqual(payload.binding, consentBinding(request, identity))
+  ) {
+    throw new McpOAuthError("Невалидно потвърждение.", 403, "access_denied");
+  }
+  return true;
 }
 
 function wasTokenConsumed(store, tokenId, now) {

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -203,13 +203,15 @@ test("authorization consent issues a code bound to the browser profile", async (
   assert.match(consent.text, /Свързване на ChatGPT със AI CORE/u);
   assert.match(consent.text, /Четене на разрешените данни/u);
   assert.match(consent.text, /отделно точно потвърждение/u);
-  const csrf = consent.text.match(/name="csrf_token" value="([^"]+)"/u)?.[1];
-  assert.ok(csrf);
+  const consentToken = consent.text.match(
+    /name="consent_token" value="([^"]+)"/u,
+  )?.[1];
+  assert.ok(consentToken);
+  assert.equal(consent.headers["set-cookie"], undefined);
   const approved = await request(app)
     .post("/oauth/authorize")
-    .set("Cookie", `synchron_mcp_csrf=${csrf}`)
     .type("form")
-    .send({ csrf_token: csrf, decision: "allow" })
+    .send({ consent_token: consentToken, decision: "allow" })
     .expect(302);
   const callback = new URL(approved.headers.location);
   assert.equal(callback.origin, "https://chatgpt.com");
@@ -231,6 +233,51 @@ test("authorization consent issues a code bound to the browser profile", async (
   assert.ok(token.body.refresh_token);
   if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
   else process.env.MCP_ACCESS_TOKEN = previous;
+});
+
+test("authorization consent rejects a modified browser-independent token", async () => {
+  const previous = process.env.MCP_ACCESS_TOKEN;
+  process.env.MCP_ACCESS_TOKEN = SECRET;
+  try {
+    const oauthRequest = {
+      clientId: "https://chatgpt.com/oauth/synchron/client.json",
+      clientName: "ChatGPT",
+      redirectUri: "https://chatgpt.com/connector/oauth/test-callback",
+      state: "state-tampered-consent",
+      codeChallenge: "c".repeat(43),
+      resource: "https://synchron.foundation/mcp",
+      scopes: ["synchron:read"],
+    };
+    const app = express();
+    app.use(
+      createMcpOAuthRouter({
+        resolveIdentity: async () => ({
+          id: "owner-id",
+          displayName: "Радко",
+          role: "owner",
+          memoryOwnerId: "primary-user",
+        }),
+        validateRequest: async () => oauthRequest,
+      }),
+    );
+    const consent = await request(app).get("/oauth/authorize").expect(200);
+    const consentToken = consent.text.match(
+      /name="consent_token" value="([^"]+)"/u,
+    )?.[1];
+    assert.ok(consentToken);
+    const [prefix, encoded] = consentToken.split(".");
+    const tamperedToken = `${prefix}.${encoded.startsWith("A") ? "B" : "A"}${encoded.slice(1)}`;
+    const response = await request(app)
+      .post("/oauth/authorize")
+      .type("form")
+      .send({ consent_token: tamperedToken, decision: "allow" })
+      .expect(403);
+    assert.equal(response.body.error, "access_denied");
+    assert.equal(response.body.error_description, "Невалидно потвърждение.");
+  } finally {
+    if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
+    else process.env.MCP_ACCESS_TOKEN = previous;
+  }
 });
 
 test("authorization consent names the AI CORE conversation permission", async () => {


### PR DESCRIPTION
## Какво поправя

- премахва зависимостта на OAuth потвърждението от временна браузърна CSRF бисквитка;
- използва кратко живеещ подписан знак, обвързан с профила и OAuth заявката;
- запазва authorization code + PKCE потока;
- добавя тестове за реалното потвърждение и за отхвърляне на променен знак.

## Проверка

- 534 теста успешни;
- 0 production зависимости с уязвимост с висока тежест.