### PR TITLE
Prepare MCP replay index on first OAuth link

### DIFF
--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -33,6 +33,7 @@ const MCP_OAUTH_REPLAY_INDEX =
   process.env.MCP_OAUTH_REPLAY_INDEX || "synchron-mcp-oauth-replay-v1";
 const consumedAuthorizationCodes = new Map();
 const consumedRefreshTokens = new Map();
+let replayIndexPromise = null;
 let lastReplayCleanupAt = 0;
 let activeReplayCleanup = null;
 
@@ -518,6 +519,47 @@ function replayRecordId(grantType, tokenId) {
     .digest("hex");
 }
 
+async function ensureMcpReplayIndex(client, env = process.env) {
+  if (
+    !client?.indices ||
+    typeof client.indices.exists !== "function" ||
+    typeof client.indices.create !== "function"
+  ) {
+    return;
+  }
+  if (!replayIndexPromise) {
+    const index = env.MCP_OAUTH_REPLAY_INDEX || MCP_OAUTH_REPLAY_INDEX;
+    replayIndexPromise = (async () => {
+      const existsResponse = await client.indices.exists({ index });
+      const exists = existsResponse.body ?? existsResponse;
+      if (exists) return;
+      try {
+        await client.indices.create({
+          index,
+          body: {
+            mappings: {
+              properties: {
+                grantType: { type: "keyword" },
+                expiresAt: { type: "date" },
+              },
+            },
+          },
+        });
+      } catch (error) {
+        const status = openSearchStatus(error);
+        const type = error?.meta?.body?.error?.type;
+        if (status !== 400 || type !== "resource_already_exists_exception") {
+          throw error;
+        }
+      }
+    })().catch((error) => {
+      replayIndexPromise = null;
+      throw error;
+    });
+  }
+  await replayIndexPromise;
+}
+
 function openSearchStatus(error) {
   return error?.statusCode || error?.meta?.statusCode || 0;
 }
@@ -584,6 +626,7 @@ export async function consumeMcpGrantOnce({
   if (client) {
     try {
       const replayIndex = env.MCP_OAUTH_REPLAY_INDEX || MCP_OAUTH_REPLAY_INDEX;
+      await ensureMcpReplayIndex(client, env);
       await client.create({
         index: replayIndex,
         id: replayRecordId(grantType, tokenId),
@@ -839,6 +882,7 @@ export function verifyMcpAccessToken(
 export function resetMcpOAuthStateForTests() {
   consumedAuthorizationCodes.clear();
   consumedRefreshTokens.clear();
+  replayIndexPromise = null;
   lastReplayCleanupAt = 0;
   activeReplayCleanup = null;
 }

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -511,6 +511,52 @@ test("production replay guard is atomic across local state resets", async () => 
   assert.equal(await consumeMcpGrantOnce(input), false);
 });
 
+test("first production token exchange creates the durable replay index", async () => {
+  const calls = [];
+  const client = {
+    indices: {
+      async exists(input) {
+        calls.push(["exists", input]);
+        return { body: false };
+      },
+      async create(input) {
+        calls.push(["create-index", input]);
+      },
+    },
+    async create(input) {
+      calls.push(["create-record", input]);
+    },
+    async deleteByQuery() {
+      return { deleted: 0 };
+    },
+  };
+  const env = {
+    ...ENV,
+    NODE_ENV: "production",
+    MCP_OAUTH_REPLAY_INDEX: "oauth-replay-first-link-test",
+  };
+
+  assert.equal(
+    await consumeMcpGrantOnce({
+      grantType: "authorization_code",
+      tokenId: "first-chatgpt-link",
+      expiresAt: Math.floor(Date.now() / 1_000) + 60,
+      env,
+      client,
+    }),
+    true,
+  );
+  assert.deepEqual(
+    calls.map(([name]) => name),
+    ["exists", "create-index", "create-record"],
+  );
+  assert.equal(calls[1][1].index, "oauth-replay-first-link-test");
+  assert.deepEqual(calls[1][1].body.mappings.properties, {
+    grantType: { type: "keyword" },
+    expiresAt: { type: "date" },
+  });
+});
+
 test("production OAuth fails closed without the durable replay store", async () => {
   assert.equal(
     requiresPersistentMcpReplayGuard({ NODE_ENV: "production" }),


### PR DESCRIPTION
## Какво се променя

- Подготвя устойчивия OpenSearch индекс преди първата OAuth token размяна.
- Добавя точни mappings за вида grant и срока на валидност.
- Запазва защитата срещу повторно използване и обработва безопасно едновременно създаване на индекса.

## Причина

След поправката на consent екрана реалният поток стига до token endpoint, но първият production вход може да се провали, ако replay индексът още не съществува. Това изглежда като безкрайно презареждане в ChatGPT.

## Проверка

- Целеви OAuth тестове: 27/27 успешни.
- Целият тестов набор: 535/535 успешни.
- Променени са само два OAuth файла.