### PR TITLE
Expose safe MCP token exchange diagnostics

### DIFF
--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -12,7 +12,10 @@ import {
   MCP_TOOLS,
   createMcpRequestHandler,
 } from "../services/mcpReadService.js";
-import { isMcpOAuthConfigured } from "../services/mcpOAuthService.js";
+import {
+  getMcpOAuthRuntimeStatus,
+  isMcpOAuthConfigured,
+} from "../services/mcpOAuthService.js";
 import { isCopilotAutomationEnabled } from "../config/featureFlags.js";
 import { isCodexAgentConfigured } from "../services/codexAgentService.js";
 import { isToolExecutable } from "../tools/capabilityEngine.js";
@@ -164,6 +167,7 @@ export async function getBridgeDiagnosticsStatus({
         mode: "oauth2-with-legacy-static-bearer",
         chatgptOAuthReady: isMcpOAuthConfigured(env),
         discovery: "/.well-known/oauth-protected-resource",
+        tokenExchange: getMcpOAuthRuntimeStatus(),
       },
     },
   };

--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -36,6 +36,12 @@ const consumedRefreshTokens = new Map();
 let replayIndexPromise = null;
 let lastReplayCleanupAt = 0;
 let activeReplayCleanup = null;
+let oauthRuntimeStatus = Object.freeze({
+  tokenExchange: "not-attempted",
+  grantType: null,
+  errorCode: null,
+  updatedAt: null,
+});
 
 export class McpOAuthError extends Error {
   constructor(
@@ -812,17 +818,41 @@ export async function exchangeMcpRefreshToken(
 }
 
 export async function exchangeMcpToken(input, env = process.env) {
-  if (input?.grant_type === "authorization_code") {
-    return exchangeMcpAuthorizationCode(input, env);
+  const grantType = String(input?.grant_type || "unknown");
+  try {
+    let result;
+    if (grantType === "authorization_code") {
+      result = await exchangeMcpAuthorizationCode(input, env);
+    } else if (grantType === "refresh_token") {
+      result = await exchangeMcpRefreshToken(input, env);
+    } else {
+      throw new McpOAuthError(
+        "Неподдържан OAuth grant.",
+        400,
+        "unsupported_grant_type",
+      );
+    }
+    oauthRuntimeStatus = Object.freeze({
+      tokenExchange: "success",
+      grantType,
+      errorCode: null,
+      updatedAt: new Date().toISOString(),
+    });
+    return result;
+  } catch (error) {
+    oauthRuntimeStatus = Object.freeze({
+      tokenExchange: "failed",
+      grantType,
+      errorCode:
+        error instanceof McpOAuthError ? error.code : "server_error",
+      updatedAt: new Date().toISOString(),
+    });
+    throw error;
   }
-  if (input?.grant_type === "refresh_token") {
-    return exchangeMcpRefreshToken(input, env);
-  }
-  throw new McpOAuthError(
-    "Неподдържан OAuth grant.",
-    400,
-    "unsupported_grant_type",
-  );
+}
+
+export function getMcpOAuthRuntimeStatus() {
+  return { ...oauthRuntimeStatus };
 }
 
 export function verifyMcpAccessToken(
@@ -885,4 +915,10 @@ export function resetMcpOAuthStateForTests() {
   replayIndexPromise = null;
   lastReplayCleanupAt = 0;
   activeReplayCleanup = null;
+  oauthRuntimeStatus = Object.freeze({
+    tokenExchange: "not-attempted",
+    grantType: null,
+    errorCode: null,
+    updatedAt: null,
+  });
 }

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -8,6 +8,8 @@ import {
   createMcpAuthorizationCode,
   exchangeMcpAuthorizationCode,
   exchangeMcpRefreshToken,
+  exchangeMcpToken,
+  getMcpOAuthRuntimeStatus,
   getMcpOAuthSecretMode,
   getMcpAuthorizationServerMetadata,
   getMcpProtectedResourceMetadata,
@@ -572,6 +574,24 @@ test("production OAuth fails closed without the durable replay store", async () 
     }),
     (error) => error.code === "temporarily_unavailable" && error.status === 503,
   );
+});
+
+test("OAuth runtime diagnostics expose only a safe token exchange result", async () => {
+  await assert.rejects(
+    exchangeMcpToken({ grant_type: "unsupported" }, ENV),
+    (error) => error.code === "unsupported_grant_type",
+  );
+  const status = getMcpOAuthRuntimeStatus();
+  assert.equal(status.tokenExchange, "failed");
+  assert.equal(status.grantType, "unsupported");
+  assert.equal(status.errorCode, "unsupported_grant_type");
+  assert.match(status.updatedAt, /^\\d{4}-\\d{2}-\\d{2}T/u);
+  assert.deepEqual(Object.keys(status).sort(), [
+    "errorCode",
+    "grantType",
+    "tokenExchange",
+    "updatedAt",
+  ]);
 });
 
 test("expired durable replay records are cleaned on a bounded schedule", async () => {

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -585,7 +585,7 @@ test("OAuth runtime diagnostics expose only a safe token exchange result", async
   assert.equal(status.tokenExchange, "failed");
   assert.equal(status.grantType, "unsupported");
   assert.equal(status.errorCode, "unsupported_grant_type");
-  assert.match(status.updatedAt, /^\\d{4}-\\d{2}-\\d{2}T/u);
+  assert.match(status.updatedAt, /^\d{4}-\d{2}-\d{2}T/u);
   assert.deepEqual(Object.keys(status).sort(), [
     "errorCode",
     "grantType",


### PR DESCRIPTION
## Какво се променя

- Добавя безопасен runtime статус за последната OAuth token размяна.
- Показва само успех/отказ, вида grant, безопасен код на грешката и време.
- Не показва authorization code, token, client ID, профил или други лични данни.

## Причина

Реалният ChatGPT OAuth поток се връща към consent екрана след callback. Сегашният health check доказва само discovery и MCP каталога, но не показва дали token endpoint е приел кода.

## Проверка

- Целеви тестове: 37/37 успешни.
- Целият тестов набор: 536/536 успешни.