### PR TITLE
Add safe OAuth authorization redirect diagnostics

### DIFF
--- a/src/routes/mcpOAuthRouter.js
+++ b/src/routes/mcpOAuthRouter.js
@@ -7,6 +7,7 @@ import {
   getMcpAuthorizationServerMetadata,
   getMcpProtectedResourceMetadata,
   McpOAuthError,
+  recordMcpAuthorizationRuntimeStatus,
   resolveMcpIssuerUrl,
   validateMcpConsentToken,
   validateMcpAuthorizationRequest,
@@ -134,18 +135,32 @@ export function createMcpOAuthRouter({
         validateMcpConsentToken(req.body?.consent_token, request, identity);
         const callback = new URL(request.redirectUri);
         if (req.body?.decision !== "allow") {
+          recordMcpAuthorizationRuntimeStatus({
+            authorization: "redirected",
+            decision: "deny",
+          });
           callback.searchParams.set("error", "access_denied");
           callback.searchParams.set("state", request.state);
           callback.searchParams.set("iss", resolveMcpIssuerUrl());
           return res.redirect(callback.href);
         }
         const code = createMcpAuthorizationCode(request, identity);
+        recordMcpAuthorizationRuntimeStatus({
+          authorization: "redirected",
+          decision: "allow",
+        });
         callback.searchParams.set("code", code);
         callback.searchParams.set("state", request.state);
         callback.searchParams.set("iss", resolveMcpIssuerUrl());
         noStore(res);
         return res.redirect(callback.href);
       } catch (error) {
+        recordMcpAuthorizationRuntimeStatus({
+          authorization: "failed",
+          decision: req.body?.decision === "allow" ? "allow" : "deny",
+          errorCode:
+            error instanceof McpOAuthError ? error.code : "server_error",
+        });
         return oauthError(res, error);
       }
     },

--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -37,6 +37,10 @@ let replayIndexPromise = null;
 let lastReplayCleanupAt = 0;
 let activeReplayCleanup = null;
 let oauthRuntimeStatus = Object.freeze({
+  authorization: "not-attempted",
+  authorizationDecision: null,
+  authorizationErrorCode: null,
+  authorizationUpdatedAt: null,
   tokenExchange: "not-attempted",
   grantType: null,
   errorCode: null,
@@ -833,6 +837,7 @@ export async function exchangeMcpToken(input, env = process.env) {
       );
     }
     oauthRuntimeStatus = Object.freeze({
+      ...oauthRuntimeStatus,
       tokenExchange: "success",
       grantType,
       errorCode: null,
@@ -841,6 +846,7 @@ export async function exchangeMcpToken(input, env = process.env) {
     return result;
   } catch (error) {
     oauthRuntimeStatus = Object.freeze({
+      ...oauthRuntimeStatus,
       tokenExchange: "failed",
       grantType,
       errorCode:
@@ -849,6 +855,20 @@ export async function exchangeMcpToken(input, env = process.env) {
     });
     throw error;
   }
+}
+
+export function recordMcpAuthorizationRuntimeStatus({
+  authorization,
+  decision = null,
+  errorCode = null,
+}) {
+  oauthRuntimeStatus = Object.freeze({
+    ...oauthRuntimeStatus,
+    authorization,
+    authorizationDecision: decision,
+    authorizationErrorCode: errorCode,
+    authorizationUpdatedAt: new Date().toISOString(),
+  });
 }
 
 export function getMcpOAuthRuntimeStatus() {
@@ -916,6 +936,10 @@ export function resetMcpOAuthStateForTests() {
   lastReplayCleanupAt = 0;
   activeReplayCleanup = null;
   oauthRuntimeStatus = Object.freeze({
+    authorization: "not-attempted",
+    authorizationDecision: null,
+    authorizationErrorCode: null,
+    authorizationUpdatedAt: null,
     tokenExchange: "not-attempted",
     grantType: null,
     errorCode: null,

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -5,6 +5,10 @@ import express from "express";
 import request from "supertest";
 
 import { createMcpOAuthRouter } from "../src/routes/mcpOAuthRouter.js";
+import {
+  getMcpOAuthRuntimeStatus,
+  resetMcpOAuthStateForTests,
+} from "../src/services/mcpOAuthService.js";
 import mcpRouter, {
   mcpJsonParseErrorHandler,
 } from "../src/routes/mcpRouter.js";
@@ -175,6 +179,7 @@ test("the dedicated OAuth secret is never accepted as a legacy static bearer", a
 });
 
 test("authorization consent issues a code bound to the browser profile", async () => {
+  resetMcpOAuthStateForTests();
   const previous = process.env.MCP_ACCESS_TOKEN;
   process.env.MCP_ACCESS_TOKEN = SECRET;
   const verifier = "v".repeat(64);
@@ -217,6 +222,11 @@ test("authorization consent issues a code bound to the browser profile", async (
   assert.equal(callback.origin, "https://chatgpt.com");
   assert.equal(callback.searchParams.get("state"), "state-123");
   assert.match(callback.searchParams.get("code"), /^sx-code\./u);
+  const authorizationStatus = getMcpOAuthRuntimeStatus();
+  assert.equal(authorizationStatus.authorization, "redirected");
+  assert.equal(authorizationStatus.authorizationDecision, "allow");
+  assert.equal(authorizationStatus.authorizationErrorCode, null);
+  assert.match(authorizationStatus.authorizationUpdatedAt, /^\d{4}-\d{2}-\d{2}T/u);
   const token = await request(app)
     .post("/oauth/token")
     .type("form")

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -587,6 +587,10 @@ test("OAuth runtime diagnostics expose only a safe token exchange result", async
   assert.equal(status.errorCode, "unsupported_grant_type");
   assert.match(status.updatedAt, /^\d{4}-\d{2}-\d{2}T/u);
   assert.deepEqual(Object.keys(status).sort(), [
+    "authorization",
+    "authorizationDecision",
+    "authorizationErrorCode",
+    "authorizationUpdatedAt",
     "errorCode",
     "grantType",
     "tokenExchange",


### PR DESCRIPTION
Adds safe, secret-free runtime status for the authorization consent redirect so the real ChatGPT OAuth loop can be diagnosed. Includes tests. Local full suite: 536/536 passed.