### PR TITLE
Fix ChatGPT OAuth callback compatibility

### DIFF
--- a/src/routes/mcpOAuthRouter.js
+++ b/src/routes/mcpOAuthRouter.js
@@ -8,7 +8,6 @@ import {
   getMcpProtectedResourceMetadata,
   McpOAuthError,
   recordMcpAuthorizationRuntimeStatus,
-  resolveMcpIssuerUrl,
   validateMcpConsentToken,
   validateMcpAuthorizationRequest,
 } from "../services/mcpOAuthService.js";
@@ -141,7 +140,6 @@ export function createMcpOAuthRouter({
           });
           callback.searchParams.set("error", "access_denied");
           callback.searchParams.set("state", request.state);
-          callback.searchParams.set("iss", resolveMcpIssuerUrl());
           return res.redirect(callback.href);
         }
         const code = createMcpAuthorizationCode(request, identity);
@@ -151,7 +149,6 @@ export function createMcpOAuthRouter({
         });
         callback.searchParams.set("code", code);
         callback.searchParams.set("state", request.state);
-        callback.searchParams.set("iss", resolveMcpIssuerUrl());
         noStore(res);
         return res.redirect(callback.href);
       } catch (error) {

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -221,6 +221,7 @@ test("authorization consent issues a code bound to the browser profile", async (
   const callback = new URL(approved.headers.location);
   assert.equal(callback.origin, "https://chatgpt.com");
   assert.equal(callback.searchParams.get("state"), "state-123");
+  assert.equal(callback.searchParams.has("iss"), false);
   assert.match(callback.searchParams.get("code"), /^sx-code\./u);
   const authorizationStatus = getMcpOAuthRuntimeStatus();
   assert.equal(authorizationStatus.authorization, "redirected");


### PR DESCRIPTION
Removes the optional authorization-response `iss` query parameter that ChatGPT does not require, while preserving state, PKCE S256, resource binding, identity checks, and the signed consent token. Full local suite: 536/536 passed.