### PR TITLE
Defer MCP OAuth to real tool calls

### DIFF
--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -218,10 +218,10 @@ export function requiredScopesForMcpTool(name) {
 }
 
 export function mcpToolSecuritySchemes(name) {
+  void name;
   return Object.freeze([
     Object.freeze({
-      type: "oauth2",
-      scopes: Object.freeze(requiredScopesForMcpTool(name)),
+      type: "noauth",
     }),
   ]);
 }

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -51,7 +51,9 @@ test("MCP initialize and tool discovery work without credentials", async () => {
     .send({ jsonrpc: "2.0", id: 2, method: "tools/list" })
     .expect(200);
   assert.equal(listed.body.result.tools.length, 14);
-  assert.equal(listed.body.result.tools[0].securitySchemes[0].type, "oauth2");
+  assert.deepEqual(listed.body.result.tools[0].securitySchemes, [
+    { type: "noauth" },
+  ]);
 });
 
 test("MCP rejects an untrusted Origin", async () => {

--- a/tests/mcpReadService.test.js
+++ b/tests/mcpReadService.test.js
@@ -39,41 +39,31 @@ test("MCP exposes read tools and a two-step cleanup flow", () => {
   );
   assert.equal(confirm.annotations.readOnlyHint, false);
   assert.equal(confirm.annotations.destructiveHint, true);
-  assert.deepEqual(confirm.securitySchemes, [
-    { type: "oauth2", scopes: ["synchron:github.write"] },
-  ]);
+  assert.deepEqual(confirm.securitySchemes, [{ type: "noauth" }]);
   const conversation = MCP_TOOLS.find(
     (tool) => tool.name === "talk_to_ai_core",
   );
   assert.equal(conversation.annotations.readOnlyHint, false);
   assert.equal(conversation.annotations.destructiveHint, false);
   assert.equal(conversation.annotations.openWorldHint, true);
-  assert.deepEqual(conversation.securitySchemes, [
-    { type: "oauth2", scopes: ["synchron:agent.chat"] },
-  ]);
+  assert.deepEqual(conversation.securitySchemes, [{ type: "noauth" }]);
   const confirmWww = MCP_TOOLS.find(
     (tool) => tool.name === "confirm_digitalocean_www_domain",
   );
   assert.equal(confirmWww.annotations.readOnlyHint, false);
   assert.equal(confirmWww.annotations.destructiveHint, true);
-  assert.deepEqual(confirmWww.securitySchemes, [
-    { type: "oauth2", scopes: ["synchron:infrastructure.write"] },
-  ]);
+  assert.deepEqual(confirmWww.securitySchemes, [{ type: "noauth" }]);
   const digitalOceanAudit = MCP_TOOLS.find(
     (tool) => tool.name === "get_digitalocean_account_audit",
   );
   assert.equal(digitalOceanAudit.annotations.readOnlyHint, true);
   assert.equal(digitalOceanAudit.annotations.destructiveHint, false);
-  assert.deepEqual(digitalOceanAudit.securitySchemes, [
-    { type: "oauth2", scopes: ["synchron:read"] },
-  ]);
+  assert.deepEqual(digitalOceanAudit.securitySchemes, [{ type: "noauth" }]);
   const systemConfiguration = MCP_TOOLS.find(
     (tool) => tool.name === "get_system_configuration",
   );
   assert.equal(systemConfiguration.annotations.readOnlyHint, true);
-  assert.deepEqual(systemConfiguration.securitySchemes, [
-    { type: "oauth2", scopes: ["synchron:read"] },
-  ]);
+  assert.deepEqual(systemConfiguration.securitySchemes, [{ type: "noauth" }]);
 });
 
 test("MCP sends one owner-scoped message to AI CORE and audits it", async () => {
@@ -161,9 +151,7 @@ test("MCP tracks a GitHub Copilot task as a read-only tool", async () => {
     (candidate) => candidate.name === "get_github_copilot_task_status",
   );
   assert.equal(tool.annotations.readOnlyHint, true);
-  assert.deepEqual(tool.securitySchemes, [
-    { type: "oauth2", scopes: ["synchron:read"] },
-  ]);
+  assert.deepEqual(tool.securitySchemes, [{ type: "noauth" }]);
 });
 
 test("MCP returns the safe system configuration without secret values", async () => {


### PR DESCRIPTION
Works around the ChatGPT apps-management OAuth callback/state loop by allowing anonymous initialize/tools/list discovery while keeping every tools/call protected by the existing OAuth challenge and scope checks. Full local suite: 536/536 passed.