### PR TITLE
Advertise optional OAuth for MCP tools

### DIFF
--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -218,10 +218,13 @@ export function requiredScopesForMcpTool(name) {
 }
 
 export function mcpToolSecuritySchemes(name) {
-  void name;
   return Object.freeze([
     Object.freeze({
       type: "noauth",
+    }),
+    Object.freeze({
+      type: "oauth2",
+      scopes: Object.freeze(requiredScopesForMcpTool(name)),
     }),
   ]);
 }

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -53,6 +53,7 @@ test("MCP initialize and tool discovery work without credentials", async () => {
   assert.equal(listed.body.result.tools.length, 14);
   assert.deepEqual(listed.body.result.tools[0].securitySchemes, [
     { type: "noauth" },
+    { type: "oauth2", scopes: ["synchron:read"] },
   ]);
 });
 

--- a/tests/mcpReadService.test.js
+++ b/tests/mcpReadService.test.js
@@ -39,31 +39,46 @@ test("MCP exposes read tools and a two-step cleanup flow", () => {
   );
   assert.equal(confirm.annotations.readOnlyHint, false);
   assert.equal(confirm.annotations.destructiveHint, true);
-  assert.deepEqual(confirm.securitySchemes, [{ type: "noauth" }]);
+  assert.deepEqual(confirm.securitySchemes, [
+    { type: "noauth" },
+    { type: "oauth2", scopes: ["synchron:github.write"] },
+  ]);
   const conversation = MCP_TOOLS.find(
     (tool) => tool.name === "talk_to_ai_core",
   );
   assert.equal(conversation.annotations.readOnlyHint, false);
   assert.equal(conversation.annotations.destructiveHint, false);
   assert.equal(conversation.annotations.openWorldHint, true);
-  assert.deepEqual(conversation.securitySchemes, [{ type: "noauth" }]);
+  assert.deepEqual(conversation.securitySchemes, [
+    { type: "noauth" },
+    { type: "oauth2", scopes: ["synchron:agent.chat"] },
+  ]);
   const confirmWww = MCP_TOOLS.find(
     (tool) => tool.name === "confirm_digitalocean_www_domain",
   );
   assert.equal(confirmWww.annotations.readOnlyHint, false);
   assert.equal(confirmWww.annotations.destructiveHint, true);
-  assert.deepEqual(confirmWww.securitySchemes, [{ type: "noauth" }]);
+  assert.deepEqual(confirmWww.securitySchemes, [
+    { type: "noauth" },
+    { type: "oauth2", scopes: ["synchron:infrastructure.write"] },
+  ]);
   const digitalOceanAudit = MCP_TOOLS.find(
     (tool) => tool.name === "get_digitalocean_account_audit",
   );
   assert.equal(digitalOceanAudit.annotations.readOnlyHint, true);
   assert.equal(digitalOceanAudit.annotations.destructiveHint, false);
-  assert.deepEqual(digitalOceanAudit.securitySchemes, [{ type: "noauth" }]);
+  assert.deepEqual(digitalOceanAudit.securitySchemes, [
+    { type: "noauth" },
+    { type: "oauth2", scopes: ["synchron:read"] },
+  ]);
   const systemConfiguration = MCP_TOOLS.find(
     (tool) => tool.name === "get_system_configuration",
   );
   assert.equal(systemConfiguration.annotations.readOnlyHint, true);
-  assert.deepEqual(systemConfiguration.securitySchemes, [{ type: "noauth" }]);
+  assert.deepEqual(systemConfiguration.securitySchemes, [
+    { type: "noauth" },
+    { type: "oauth2", scopes: ["synchron:read"] },
+  ]);
 });
 
 test("MCP sends one owner-scoped message to AI CORE and audits it", async () => {
@@ -151,7 +166,10 @@ test("MCP tracks a GitHub Copilot task as a read-only tool", async () => {
     (candidate) => candidate.name === "get_github_copilot_task_status",
   );
   assert.equal(tool.annotations.readOnlyHint, true);
-  assert.deepEqual(tool.securitySchemes, [{ type: "noauth" }]);
+  assert.deepEqual(tool.securitySchemes, [
+    { type: "noauth" },
+    { type: "oauth2", scopes: ["synchron:read"] },
+  ]);
 });
 
 test("MCP returns the safe system configuration without secret values", async () => {


### PR DESCRIPTION
Advertises both noauth discovery and the exact oauth2 scope for each tool. This lets mixed-auth ChatGPT apps enumerate tools without the broken management OAuth callback, while real tools/call requests remain protected and can trigger OAuth. Full local suite: 536/536 passed.