### PR TITLE
Allow a redacted public MCP status fallback

### DIFF
--- a/src/routes/mcpRouter.js
+++ b/src/routes/mcpRouter.js
@@ -5,6 +5,7 @@ import {
   MCP_PROTOCOL_VERSION,
 } from "../services/mcpReadService.js";
 import {
+  allowsAnonymousMcpTool,
   buildMcpAuthenticateChallenge,
   McpOAuthError,
   requiredScopesForMcpTool,
@@ -95,6 +96,17 @@ export function requireMcpAuthorization(
       id: "owner",
       role: "owner",
       displayName: "Радко",
+    };
+    return next();
+  }
+
+  if (!authorization && allowsAnonymousMcpTool(toolName)) {
+    req.mcpOwnerId = null;
+    req.mcpAuthentication = {
+      mode: "noauth",
+      id: "anonymous",
+      role: "anonymous",
+      displayName: "Публична проверка",
     };
     return next();
   }

--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -217,16 +217,18 @@ export function requiredScopesForMcpTool(name) {
     : [MCP_READ_SCOPE];
 }
 
+export function allowsAnonymousMcpTool(name) {
+  return name === "get_digitalocean_app_status";
+}
+
 export function mcpToolSecuritySchemes(name) {
-  return Object.freeze([
-    Object.freeze({
-      type: "noauth",
-    }),
-    Object.freeze({
-      type: "oauth2",
-      scopes: Object.freeze(requiredScopesForMcpTool(name)),
-    }),
-  ]);
+  const oauth2 = Object.freeze({
+    type: "oauth2",
+    scopes: Object.freeze(requiredScopesForMcpTool(name)),
+  });
+  return allowsAnonymousMcpTool(name)
+    ? Object.freeze([Object.freeze({ type: "noauth" }), oauth2])
+    : Object.freeze([oauth2]);
 }
 
 export function buildMcpAuthenticateChallenge(

--- a/src/services/mcpReadService.js
+++ b/src/services/mcpReadService.js
@@ -287,6 +287,27 @@ function safeLimit(value, fallback = 20) {
     : fallback;
 }
 
+function publicDigitalOceanStatus(status = {}) {
+  const publicDeployment = (deployment) =>
+    deployment
+      ? {
+          phase: deployment.phase || null,
+          createdAt: deployment.createdAt || null,
+          updatedAt: deployment.updatedAt || null,
+        }
+      : null;
+  return {
+    name: status.name || "SYNCHRON-X",
+    liveUrl: status.liveUrl || null,
+    activeDeployment: publicDeployment(status.activeDeployment),
+    inProgressDeployment: publicDeployment(status.inProgressDeployment),
+    deploymentsAvailable: status.deploymentsAvailable !== false,
+    deployments: (Array.isArray(status.deployments) ? status.deployments : [])
+      .slice(0, 5)
+      .map(publicDeployment),
+  };
+}
+
 export function isValidMcpToken(header, expectedToken) {
   if (typeof expectedToken !== "string" || expectedToken.length < 32)
     return false;
@@ -364,7 +385,14 @@ export function createMcpRequestHandler({
       result = textResult(conversation, conversation.response);
     } else if (name === "get_digitalocean_app_status") {
       const status = await getDigitalOceanStatus();
-      result = textResult(status, formatDigitalOceanStatus(status));
+      const visibleStatus =
+        identity?.role === "anonymous"
+          ? publicDigitalOceanStatus(status)
+          : status;
+      result = textResult(
+        visibleStatus,
+        formatDigitalOceanStatus(visibleStatus),
+      );
     } else if (name === "get_digitalocean_account_audit") {
       const auditReport = await getDigitalOceanAudit();
       result = textResult(auditReport, formatDigitalOceanAudit(auditReport));

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -11,6 +11,7 @@ import {
 } from "../src/services/mcpOAuthService.js";
 import mcpRouter, {
   mcpJsonParseErrorHandler,
+  requireMcpAuthorization,
 } from "../src/routes/mcpRouter.js";
 
 const SECRET = "router-test-secret-with-more-than-thirty-two-characters";
@@ -52,9 +53,34 @@ test("MCP initialize and tool discovery work without credentials", async () => {
     .expect(200);
   assert.equal(listed.body.result.tools.length, 14);
   assert.deepEqual(listed.body.result.tools[0].securitySchemes, [
+    { type: "oauth2", scopes: ["synchron:read"] },
+  ]);
+  const publicStatus = listed.body.result.tools.find(
+    (tool) => tool.name === "get_digitalocean_app_status",
+  );
+  assert.deepEqual(publicStatus.securitySchemes, [
     { type: "noauth" },
     { type: "oauth2", scopes: ["synchron:read"] },
   ]);
+});
+
+test("only the redacted production status can pass without credentials", async () => {
+  const app = express();
+  app.use(express.json());
+  app.post("/mcp", requireMcpAuthorization, (req, res) =>
+    res.json({ authentication: req.mcpAuthentication }),
+  );
+  const publicStatus = await request(app)
+    .post("/mcp")
+    .send({
+      jsonrpc: "2.0",
+      id: 23,
+      method: "tools/call",
+      params: { name: "get_digitalocean_app_status", arguments: {} },
+    })
+    .expect(200);
+  assert.equal(publicStatus.body.authentication.mode, "noauth");
+  assert.equal(publicStatus.body.authentication.role, "anonymous");
 });
 
 test("MCP rejects an untrusted Origin", async () => {

--- a/tests/mcpReadService.test.js
+++ b/tests/mcpReadService.test.js
@@ -40,7 +40,6 @@ test("MCP exposes read tools and a two-step cleanup flow", () => {
   assert.equal(confirm.annotations.readOnlyHint, false);
   assert.equal(confirm.annotations.destructiveHint, true);
   assert.deepEqual(confirm.securitySchemes, [
-    { type: "noauth" },
     { type: "oauth2", scopes: ["synchron:github.write"] },
   ]);
   const conversation = MCP_TOOLS.find(
@@ -50,7 +49,6 @@ test("MCP exposes read tools and a two-step cleanup flow", () => {
   assert.equal(conversation.annotations.destructiveHint, false);
   assert.equal(conversation.annotations.openWorldHint, true);
   assert.deepEqual(conversation.securitySchemes, [
-    { type: "noauth" },
     { type: "oauth2", scopes: ["synchron:agent.chat"] },
   ]);
   const confirmWww = MCP_TOOLS.find(
@@ -59,7 +57,6 @@ test("MCP exposes read tools and a two-step cleanup flow", () => {
   assert.equal(confirmWww.annotations.readOnlyHint, false);
   assert.equal(confirmWww.annotations.destructiveHint, true);
   assert.deepEqual(confirmWww.securitySchemes, [
-    { type: "noauth" },
     { type: "oauth2", scopes: ["synchron:infrastructure.write"] },
   ]);
   const digitalOceanAudit = MCP_TOOLS.find(
@@ -68,7 +65,6 @@ test("MCP exposes read tools and a two-step cleanup flow", () => {
   assert.equal(digitalOceanAudit.annotations.readOnlyHint, true);
   assert.equal(digitalOceanAudit.annotations.destructiveHint, false);
   assert.deepEqual(digitalOceanAudit.securitySchemes, [
-    { type: "noauth" },
     { type: "oauth2", scopes: ["synchron:read"] },
   ]);
   const systemConfiguration = MCP_TOOLS.find(
@@ -76,9 +72,62 @@ test("MCP exposes read tools and a two-step cleanup flow", () => {
   );
   assert.equal(systemConfiguration.annotations.readOnlyHint, true);
   assert.deepEqual(systemConfiguration.securitySchemes, [
+    { type: "oauth2", scopes: ["synchron:read"] },
+  ]);
+  const publicStatus = MCP_TOOLS.find(
+    (tool) => tool.name === "get_digitalocean_app_status",
+  );
+  assert.deepEqual(publicStatus.securitySchemes, [
     { type: "noauth" },
     { type: "oauth2", scopes: ["synchron:read"] },
   ]);
+});
+
+test("anonymous production status omits identifiers and configuration names", async () => {
+  const handle = createMcpRequestHandler({
+    getDigitalOceanStatus: async () => ({
+      id: "private-app-id",
+      name: "SYNCHRON-X",
+      liveUrl: "https://synchron.foundation",
+      activeDeployment: {
+        id: "private-deployment-id",
+        phase: "ACTIVE",
+        createdAt: "2026-08-03T00:00:00.000Z",
+        updatedAt: "2026-08-03T00:01:00.000Z",
+      },
+      inProgressDeployment: null,
+      environmentVariables: [{ key: "PRIVATE_VARIABLE_NAME" }],
+      deploymentsAvailable: true,
+      deployments: [
+        {
+          id: "private-history-id",
+          phase: "ACTIVE",
+          cause: "private commit message",
+          createdAt: "2026-08-03T00:00:00.000Z",
+          updatedAt: "2026-08-03T00:01:00.000Z",
+        },
+      ],
+    }),
+    audit: async () => {},
+  });
+  const response = await handle(
+    {
+      jsonrpc: "2.0",
+      id: 24,
+      method: "tools/call",
+      params: { name: "get_digitalocean_app_status", arguments: {} },
+    },
+    null,
+    { role: "anonymous" },
+  );
+  assert.equal(response.result.structuredContent.name, "SYNCHRON-X");
+  assert.equal(response.result.structuredContent.id, undefined);
+  assert.equal(
+    response.result.structuredContent.activeDeployment.id,
+    undefined,
+  );
+  assert.equal(response.result.structuredContent.environmentVariables, undefined);
+  assert.equal(response.result.structuredContent.deployments[0].cause, undefined);
 });
 
 test("MCP sends one owner-scoped message to AI CORE and audits it", async () => {
@@ -167,7 +216,6 @@ test("MCP tracks a GitHub Copilot task as a read-only tool", async () => {
   );
   assert.equal(tool.annotations.readOnlyHint, true);
   assert.deepEqual(tool.securitySchemes, [
-    { type: "noauth" },
     { type: "oauth2", scopes: ["synchron:read"] },
   ]);
 });


### PR DESCRIPTION
## Какво се променя

- Разрешава само `get_digitalocean_app_status` без OAuth.
- Премахва `noauth` от всички лични, GitHub, AI разговорни и write инструменти.
- Редактира публичния status отговор: без app/deployment ID, имена на environment променливи и deployment cause.
- Запазва OAuth и точните потвърждения за лични данни и промени.

## Причина

AI CORE успешно издава authorization code и redirect, но текущият ChatGPT OAuth callback не извиква `/oauth/token`. Това блокира всички инструменти. Ограниченият fallback оставя неповерителната production проверка работеща, без да отслабва защитата на личните и променящите инструменти.

## Проверки

- 538/538 локални теста успешни.
- `git diff --check` успешен.
- Добавени тестове за точната anonymous allowlist и редактирания публичен payload.