### PR TITLE
Fix ChatGPT CIMD client verification fallback

### DIFF
--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -326,6 +326,47 @@ function isAllowedOpenAiClientId(value) {
   }
 }
 
+function trustedChatGptClientMetadata(clientId, redirectUri) {
+  try {
+    const clientUrl = new URL(clientId);
+    const callbackUrl = new URL(redirectUri);
+    const clientSegments = clientUrl.pathname.split("/").filter(Boolean);
+    const callbackSegments = callbackUrl.pathname.split("/").filter(Boolean);
+    const safeSegment = (segment) =>
+      /^[A-Za-z0-9._~-]+$/u.test(segment) &&
+      segment !== "." &&
+      segment !== "..";
+
+    if (
+      clientUrl.origin !== "https://chatgpt.com" ||
+      clientUrl.search ||
+      clientUrl.hash ||
+      clientSegments.length < 3 ||
+      clientSegments[0] !== "oauth" ||
+      clientSegments.at(-1) !== "client.json" ||
+      !clientSegments.slice(1, -1).every(safeSegment) ||
+      callbackUrl.origin !== "https://chatgpt.com" ||
+      callbackUrl.search ||
+      callbackUrl.hash ||
+      callbackSegments.length !== 3 ||
+      callbackSegments[0] !== "connector" ||
+      callbackSegments[1] !== "oauth" ||
+      !/^[A-Za-z0-9_-]{6,128}$/u.test(callbackSegments[2])
+    ) {
+      return null;
+    }
+
+    return {
+      client_id: clientId,
+      client_name: "ChatGPT",
+      redirect_uris: [redirectUri],
+      token_endpoint_auth_methods_supported: ["none"],
+    };
+  } catch {
+    return null;
+  }
+}
+
 export async function validateMcpAuthorizationRequest(
   input,
   { env = process.env, fetchImpl = fetch } = {},
@@ -365,11 +406,14 @@ export async function validateMcpAuthorizationRequest(
     if (!response.ok) throw new Error("CLIENT_METADATA_UNAVAILABLE");
     metadata = await response.json();
   } catch {
-    throw new McpOAuthError(
-      "OAuth клиентът не може да бъде проверен.",
-      400,
-      "invalid_client",
-    );
+    metadata = trustedChatGptClientMetadata(clientId, redirectUri);
+    if (!metadata) {
+      throw new McpOAuthError(
+        "OAuth клиентът не може да бъде проверен.",
+        400,
+        "invalid_client",
+      );
+    }
   }
 
   if (

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -281,6 +281,52 @@ test("validates OpenAI CIMD metadata and exact callback and resource", async () 
   );
 });
 
+test("uses a pinned ChatGPT client policy when CIMD retrieval is unavailable", async () => {
+  const request = await validateMcpAuthorizationRequest(authorizationInput(), {
+    env: ENV,
+    fetchImpl: async () => {
+      throw new Error("network unavailable");
+    },
+  });
+
+  assert.equal(request.clientId, CLIENT_ID);
+  assert.equal(request.clientName, "ChatGPT");
+  assert.equal(request.redirectUri, REDIRECT_URI);
+  assert.deepEqual(request.scopes, [MCP_READ_SCOPE]);
+});
+
+test("does not apply the ChatGPT fallback outside pinned OAuth paths", async () => {
+  const unavailable = async () => {
+    throw new Error("network unavailable");
+  };
+
+  await assert.rejects(
+    validateMcpAuthorizationRequest(
+      {
+        ...authorizationInput(),
+        client_id: "https://chatgpt.com/not-oauth/client.json",
+      },
+      { env: ENV, fetchImpl: unavailable },
+    ),
+    (error) =>
+      error.code === "invalid_client" &&
+      error.description === "OAuth клиентът не може да бъде проверен.",
+  );
+
+  await assert.rejects(
+    validateMcpAuthorizationRequest(
+      {
+        ...authorizationInput(),
+        redirect_uri: "https://chatgpt.com/not-a-connector/callback",
+      },
+      { env: ENV, fetchImpl: unavailable },
+    ),
+    (error) =>
+      error.code === "invalid_client" &&
+      error.description === "OAuth клиентът не може да бъде проверен.",
+  );
+});
+
 test("exchanges a one-time PKCE code for an opaque owner-scoped token", async () => {
   const request = await validateMcpAuthorizationRequest(
     authorizationInput([MCP_READ_SCOPE, MCP_GITHUB_WRITE_SCOPE]),


### PR DESCRIPTION
## Какво се променя

- запазва стандартното изтегляне и валидиране на ChatGPT CIMD документа;
- при временна недостъпност допуска само строго фиксираните production адреси `https://chatgpt.com/oauth/.../client.json` и `https://chatgpt.com/connector/oauth/...`;
- блокира всички други client и callback пътища.

## Причина

Реалното повторно OAuth свързване стига до authorization endpoint, но production не успява да изтегли CIMD документа от ChatGPT и връща `invalid_client` преди екрана за съгласие.

## Проверки

- целеви OAuth тестове: 31/31 успешни;
- пълен тестов набор: 540/540 успешни;
- `npm audit --omit=dev --audit-level=high`: 0 уязвимости.