### PR TITLE
Expose safe MCP OAuth runtime diagnostics

### DIFF
--- a/src/services/mcpReadService.js
+++ b/src/services/mcpReadService.js
@@ -40,7 +40,10 @@ import {
   getCopilotTaskStatus,
 } from "./copilotTaskService.js";
 import { getLatestAuthorizedGitHubSession } from "./githubOAuthService.js";
-import { mcpToolSecuritySchemes } from "./mcpOAuthService.js";
+import {
+  getMcpOAuthRuntimeStatus,
+  mcpToolSecuritySchemes,
+} from "./mcpOAuthService.js";
 import { sendMcpAgentMessage } from "./mcpAgentConversationService.js";
 
 export const MCP_PROTOCOL_VERSION = "2025-06-18";
@@ -287,7 +290,7 @@ function safeLimit(value, fallback = 20) {
     : fallback;
 }
 
-function publicDigitalOceanStatus(status = {}) {
+function publicDigitalOceanStatus(status = {}, oauth = {}) {
   const publicDeployment = (deployment) =>
     deployment
       ? {
@@ -305,6 +308,15 @@ function publicDigitalOceanStatus(status = {}) {
     deployments: (Array.isArray(status.deployments) ? status.deployments : [])
       .slice(0, 5)
       .map(publicDeployment),
+    oauth: {
+      authorization: oauth.authorization || "not-attempted",
+      authorizationDecision: oauth.authorizationDecision || null,
+      authorizationErrorCode: oauth.authorizationErrorCode || null,
+      tokenExchange: oauth.tokenExchange || "not-attempted",
+      grantType: oauth.grantType || null,
+      errorCode: oauth.errorCode || null,
+      updatedAt: oauth.updatedAt || oauth.authorizationUpdatedAt || null,
+    },
   };
 }
 
@@ -330,6 +342,7 @@ export function createMcpRequestHandler({
   validateConfirmation = validateDurableConfirmation,
   consumeConfirmation = markDurableConfirmationUsed,
   getDigitalOceanStatus = getDigitalOceanAppStatus,
+  getOAuthRuntimeStatus = getMcpOAuthRuntimeStatus,
   getDigitalOceanAudit = getDigitalOceanAccountAudit,
   inspectDigitalOceanDomain = inspectDigitalOceanDomainAlias,
   activateDigitalOceanDomain = activateDigitalOceanDomainAlias,
@@ -387,7 +400,7 @@ export function createMcpRequestHandler({
       const status = await getDigitalOceanStatus();
       const visibleStatus =
         identity?.role === "anonymous"
-          ? publicDigitalOceanStatus(status)
+          ? publicDigitalOceanStatus(status, getOAuthRuntimeStatus())
           : status;
       result = textResult(
         visibleStatus,

--- a/tests/mcpReadService.test.js
+++ b/tests/mcpReadService.test.js
@@ -108,6 +108,15 @@ test("anonymous production status omits identifiers and configuration names", as
         },
       ],
     }),
+    getOAuthRuntimeStatus: () => ({
+      authorization: "redirected",
+      authorizationDecision: "allow",
+      authorizationErrorCode: null,
+      tokenExchange: "failed",
+      grantType: "authorization_code",
+      errorCode: "temporarily_unavailable",
+      updatedAt: "2026-08-03T07:48:00.000Z",
+    }),
     audit: async () => {},
   });
   const response = await handle(
@@ -128,6 +137,15 @@ test("anonymous production status omits identifiers and configuration names", as
   );
   assert.equal(response.result.structuredContent.environmentVariables, undefined);
   assert.equal(response.result.structuredContent.deployments[0].cause, undefined);
+  assert.deepEqual(response.result.structuredContent.oauth, {
+    authorization: "redirected",
+    authorizationDecision: "allow",
+    authorizationErrorCode: null,
+    tokenExchange: "failed",
+    grantType: "authorization_code",
+    errorCode: "temporarily_unavailable",
+    updatedAt: "2026-08-03T07:48:00.000Z",
+  });
 });
 
 test("MCP sends one owner-scoped message to AI CORE and audits it", async () => {


### PR DESCRIPTION
## Какво се променя

Добавя само безопасните OAuth runtime полета към анонимния, вече редактиран production status: етап, grant type, стабилен error code и timestamp. Не връща token-и, authorization code, client ID, callback, профил или secrets.

## Причина

Реалното OAuth съгласие вече се зарежда, но след `Разреши` ChatGPT повтаря authorization екрана. Тази диагностика позволява да се различи `invalid_grant` от временен replay-store отказ без достъп до чувствителни логове.

## Проверки

- OAuth/MCP целеви проверки: 42/42;
- пълен тестов набор: 540/540.