### PR TITLE
Fix OAuth consent browser round trip

### DIFF
--- a/src/routes/mcpOAuthRouter.js
+++ b/src/routes/mcpOAuthRouter.js
@@ -8,7 +8,7 @@ import {
   getMcpProtectedResourceMetadata,
   McpOAuthError,
   recordMcpAuthorizationRuntimeStatus,
-  validateMcpConsentToken,
+  resolveMcpConsentRequest,
   validateMcpAuthorizationRequest,
 } from "../services/mcpOAuthService.js";
 
@@ -48,14 +48,6 @@ function oauthError(res, error) {
 
 function consentPage(request, identity, consentToken) {
   const fields = {
-    response_type: "code",
-    client_id: request.clientId,
-    redirect_uri: request.redirectUri,
-    state: request.state,
-    code_challenge: request.codeChallenge,
-    code_challenge_method: "S256",
-    resource: request.resource,
-    scope: request.scopes.join(" "),
     consent_token: consentToken,
   };
   const hidden = Object.entries(fields)
@@ -130,8 +122,10 @@ export function createMcpOAuthRouter({
             "access_denied",
           );
         }
-        const request = await validateRequest(req.body);
-        validateMcpConsentToken(req.body?.consent_token, request, identity);
+        const request = resolveMcpConsentRequest(
+          req.body?.consent_token,
+          identity,
+        );
         const callback = new URL(request.redirectUri);
         if (req.body?.decision !== "allow") {
           recordMcpAuthorizationRuntimeStatus({

--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -488,20 +488,16 @@ function safeStringEqual(left, right) {
   return a.length === b.length && timingSafeEqual(a, b);
 }
 
-function consentBinding(request, identity) {
-  return createHash("sha256")
-    .update(
-      JSON.stringify({
-        clientId: request.clientId,
-        redirectUri: request.redirectUri,
-        state: request.state,
-        codeChallenge: request.codeChallenge,
-        resource: request.resource,
-        scopes: request.scopes,
-        subject: String(identity.id),
-      }),
-    )
-    .digest("base64url");
+function consentRequest(request) {
+  return {
+    clientId: String(request.clientId),
+    clientName: String(request.clientName || "ChatGPT"),
+    redirectUri: String(request.redirectUri),
+    state: String(request.state),
+    codeChallenge: String(request.codeChallenge),
+    resource: String(request.resource),
+    scopes: [...request.scopes],
+  };
 }
 
 export function createMcpConsentToken(
@@ -517,7 +513,8 @@ export function createMcpConsentToken(
     "sx-consent",
     {
       typ: "consent",
-      binding: consentBinding(request, identity),
+      subject: String(identity.id),
+      request: consentRequest(request),
       iat: now,
       exp: now + CONSENT_TOKEN_TTL_SECONDS,
     },
@@ -525,9 +522,8 @@ export function createMcpConsentToken(
   );
 }
 
-export function validateMcpConsentToken(
+export function resolveMcpConsentRequest(
   token,
-  request,
   identity,
   env = process.env,
   now = Math.floor(Date.now() / 1_000),
@@ -543,7 +539,32 @@ export function validateMcpConsentToken(
     payload.iat > now + 60 ||
     payload.exp <= now ||
     payload.exp - payload.iat !== CONSENT_TOKEN_TTL_SECONDS ||
-    !safeStringEqual(payload.binding, consentBinding(request, identity))
+    !safeStringEqual(payload.subject, String(identity?.id || "")) ||
+    !payload.request ||
+    payload.request.resource !== resolveMcpResourceUrl(env) ||
+    !Array.isArray(payload.request.scopes)
+  ) {
+    throw new McpOAuthError("Невалидно потвърждение.", 403, "access_denied");
+  }
+  return consentRequest({
+    ...payload.request,
+    scopes: parseScopes(payload.request.scopes.join(" ")),
+  });
+}
+
+export function validateMcpConsentToken(
+  token,
+  request,
+  identity,
+  env = process.env,
+  now = Math.floor(Date.now() / 1_000),
+) {
+  const trustedRequest = resolveMcpConsentRequest(token, identity, env, now);
+  if (
+    !safeStringEqual(
+      JSON.stringify(trustedRequest),
+      JSON.stringify(consentRequest(request)),
+    )
   ) {
     throw new McpOAuthError("Невалидно потвърждение.", 403, "access_denied");
   }

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -320,6 +320,57 @@ test("authorization consent rejects a modified browser-independent token", async
   }
 });
 
+test("authorization consent ignores altered repeated OAuth form fields", async () => {
+  const previous = process.env.MCP_ACCESS_TOKEN;
+  process.env.MCP_ACCESS_TOKEN = SECRET;
+  try {
+    const oauthRequest = {
+      clientId: "https://chatgpt.com/oauth/synchron/client.json",
+      clientName: "ChatGPT",
+      redirectUri: "https://chatgpt.com/connector/oauth/test-callback",
+      state: "state-browser-round-trip",
+      codeChallenge: "c".repeat(43),
+      resource: "https://synchron.foundation/mcp",
+      scopes: ["synchron:read"],
+    };
+    const app = express();
+    app.use(
+      createMcpOAuthRouter({
+        resolveIdentity: async () => ({
+          id: "owner-id",
+          displayName: "Радко",
+          role: "owner",
+          memoryOwnerId: "primary-user",
+        }),
+        validateRequest: async () => oauthRequest,
+      }),
+    );
+    const consent = await request(app).get("/oauth/authorize").expect(200);
+    const consentToken = consent.text.match(
+      /name="consent_token" value="([^"]+)"/u,
+    )?.[1];
+    assert.ok(consentToken);
+    assert.doesNotMatch(consent.text, /name="state"/u);
+    const approved = await request(app)
+      .post("/oauth/authorize")
+      .type("form")
+      .send({
+        consent_token: consentToken,
+        decision: "allow",
+        state: "altered-by-browser",
+        redirect_uri: "https://attacker.example/callback",
+      })
+      .expect(302);
+    const callback = new URL(approved.headers.location);
+    assert.equal(callback.origin, "https://chatgpt.com");
+    assert.equal(callback.searchParams.get("state"), oauthRequest.state);
+    assert.match(callback.searchParams.get("code"), /^sx-code\./u);
+  } finally {
+    if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
+    else process.env.MCP_ACCESS_TOKEN = previous;
+  }
+});
+
 test("authorization consent names the AI CORE conversation permission", async () => {
   const previous = process.env.MCP_ACCESS_TOKEN;
   process.env.MCP_ACCESS_TOKEN = SECRET;


### PR DESCRIPTION
## Какво се променя

- подписаният еднократен consent token вече съдържа проверената OAuth заявка;
- POST `/oauth/authorize` използва подписаната заявка вместо повторно изпратени скрити полета;
- профилът, TTL, callback адресът, resource, scopes и PKCE остават обвързани и защитени;
- добавен е тест за реален браузърен round trip с променени повторни полета.

## Причина

Реалният ChatGPT OAuth прозорец стигаше до „Разреши“, но повторното форм-подаване водеше до `access_denied: Невалидно потвърждение` преди authorization code да бъде издаден.

## Проверки

- `npm test`: 541/541 успешни
- `npm audit --omit=dev`: 0 уязвимости