### PR TITLE
Fix ChatGPT OAuth popup handoff isolation

### DIFF
--- a/src/routes/mcpOAuthRouter.js
+++ b/src/routes/mcpOAuthRouter.js
@@ -26,6 +26,10 @@ function noStore(res) {
   res.set("Pragma", "no-cache");
 }
 
+function preserveOAuthPopupHandoff(res) {
+  res.set("Cross-Origin-Opener-Policy", "unsafe-none");
+}
+
 function escapeHtml(value) {
   return String(value)
     .replace(/&/gu, "&amp;")
@@ -93,6 +97,7 @@ export function createMcpOAuthRouter({
   });
 
   router.get("/oauth/authorize", oauthRateLimiter, async (req, res) => {
+    preserveOAuthPopupHandoff(res);
     try {
       const request = await validateRequest(req.query);
       const identity = await resolveIdentity(req, res);
@@ -113,6 +118,7 @@ export function createMcpOAuthRouter({
     oauthRateLimiter,
     formParser,
     async (req, res) => {
+      preserveOAuthPopupHandoff(res);
       try {
         const identity = await resolveIdentity(req, res);
         if (!identity) {

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -234,6 +234,10 @@ test("authorization consent issues a code bound to the browser profile", async (
     }),
   );
   const consent = await request(app).get("/oauth/authorize").expect(200);
+  assert.equal(
+    consent.headers["cross-origin-opener-policy"],
+    "unsafe-none",
+  );
   assert.match(consent.text, /Свързване на ChatGPT със AI CORE/u);
   assert.match(consent.text, /Четене на разрешените данни/u);
   assert.match(consent.text, /отделно точно потвърждение/u);
@@ -247,6 +251,10 @@ test("authorization consent issues a code bound to the browser profile", async (
     .type("form")
     .send({ consent_token: consentToken, decision: "allow" })
     .expect(302);
+  assert.equal(
+    approved.headers["cross-origin-opener-policy"],
+    "unsafe-none",
+  );
   const callback = new URL(approved.headers.location);
   assert.equal(callback.origin, "https://chatgpt.com");
   assert.equal(callback.searchParams.get("state"), "state-123");
@@ -273,6 +281,72 @@ test("authorization consent issues a code bound to the browser profile", async (
   assert.ok(token.body.refresh_token);
   if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
   else process.env.MCP_ACCESS_TOKEN = previous;
+});
+
+test("authorization flow overrides global COOP so ChatGPT can complete the popup handoff", async () => {
+  resetMcpOAuthStateForTests();
+  const previous = process.env.MCP_ACCESS_TOKEN;
+  process.env.MCP_ACCESS_TOKEN = SECRET;
+  try {
+    const oauthRequest = {
+      clientId: "https://chatgpt.com/oauth/synchron/client.json",
+      clientName: "ChatGPT",
+      redirectUri: "https://chatgpt.com/connector/oauth/test-callback",
+      state: "state-popup-handoff",
+      codeChallenge: "c".repeat(43),
+      resource: "https://synchron.foundation/mcp",
+      scopes: ["synchron:read"],
+    };
+    const app = express();
+    app.use((_req, res, next) => {
+      res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+      res.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+      next();
+    });
+    app.use(
+      createMcpOAuthRouter({
+        resolveIdentity: async () => ({
+          id: "owner-id",
+          displayName: "Радко",
+          role: "owner",
+          memoryOwnerId: "primary-user",
+        }),
+        validateRequest: async () => oauthRequest,
+      }),
+    );
+
+    const consent = await request(app).get("/oauth/authorize").expect(200);
+    const consentToken = consent.text.match(
+      /name="consent_token" value="([^"]+)"/u,
+    )?.[1];
+    assert.ok(consentToken);
+    assert.equal(
+      consent.headers["cross-origin-opener-policy"],
+      "unsafe-none",
+    );
+
+    const approved = await request(app)
+      .post("/oauth/authorize")
+      .type("form")
+      .send({ consent_token: consentToken, decision: "allow" })
+      .expect(302);
+    const callback = new URL(approved.headers.location);
+    assert.equal(callback.origin, "https://chatgpt.com");
+    assert.equal(callback.pathname, "/connector/oauth/test-callback");
+    assert.equal(callback.searchParams.get("state"), oauthRequest.state);
+    assert.match(callback.searchParams.get("code"), /^sx-code\./u);
+    assert.equal(
+      approved.headers["cross-origin-opener-policy"],
+      "unsafe-none",
+    );
+    assert.equal(
+      approved.headers["cross-origin-resource-policy"],
+      "same-origin",
+    );
+  } finally {
+    if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
+    else process.env.MCP_ACCESS_TOKEN = previous;
+  }
 });
 
 test("authorization consent rejects a modified browser-independent token", async () => {


### PR DESCRIPTION
## Причина

Глобалният `Cross-Origin-Opener-Policy: same-origin` се прилага и върху OAuth authorization страницата и consent POST redirect-а. Реален headless Chrome тест възпроизвежда прекъсването: callback-ът получава `window.opener=null`, затова ChatGPT не завършва handoff-а и не извиква token endpoint.

`same-origin-allow-popups` също беше проверен и не запазва opener при този cross-origin flow. `unsafe-none` само за `/oauth/authorize` GET/POST запазва popup handoff-а. `Cross-Origin-Resource-Policy: same-origin` остава непроменен.

## Промяна

- override на COOP до `unsafe-none` само за OAuth authorization GET/POST;
- регресионен тест за целия consent redirect, exact callback, `state`, code и запазения CORP boundary.

## Проверки

- целеви OAuth/security тестове: 35/35;
- пълен тестов набор: 542/542;
- реален Chrome popup proof:
  - `same-origin` → `opener-null`, няма completion message;
  - `same-origin-allow-popups` → `opener-null`, няма completion message;
  - `unsafe-none` → `opener-present`, completion message е получено.

Не включва merge или production deploy.