### PR TITLE
Fix ChatGPT OAuth refresh continuity

### DIFF
--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -12,11 +12,16 @@ export const MCP_READ_SCOPE = "synchron:read";
 export const MCP_AGENT_CHAT_SCOPE = "synchron:agent.chat";
 export const MCP_GITHUB_WRITE_SCOPE = "synchron:github.write";
 export const MCP_INFRASTRUCTURE_WRITE_SCOPE = "synchron:infrastructure.write";
+export const MCP_OFFLINE_ACCESS_SCOPE = "offline_access";
 export const MCP_SCOPES = Object.freeze([
   MCP_READ_SCOPE,
   MCP_AGENT_CHAT_SCOPE,
   MCP_GITHUB_WRITE_SCOPE,
   MCP_INFRASTRUCTURE_WRITE_SCOPE,
+]);
+const MCP_AUTHORIZATION_SCOPES = Object.freeze([
+  ...MCP_SCOPES,
+  MCP_OFFLINE_ACCESS_SCOPE,
 ]);
 const MCP_OWNER_ONLY_SCOPES = Object.freeze([
   MCP_GITHUB_WRITE_SCOPE,
@@ -197,7 +202,7 @@ export function getMcpAuthorizationServerMetadata(env = process.env) {
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
-    scopes_supported: MCP_SCOPES,
+    scopes_supported: MCP_AUTHORIZATION_SCOPES,
   };
 }
 
@@ -295,7 +300,7 @@ function parseScopes(value) {
     .filter(Boolean);
   if (
     scopes.length === 0 ||
-    scopes.some((scope) => !MCP_SCOPES.includes(scope))
+    scopes.some((scope) => !MCP_AUTHORIZATION_SCOPES.includes(scope))
   ) {
     throw new McpOAuthError(
       "Поисканите MCP права не се поддържат.",

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -34,6 +34,7 @@ test("OAuth discovery is public and describes the exact MCP resource", async () 
     authorization.body.token_endpoint,
     "https://synchron.foundation/oauth/token",
   );
+  assert.ok(authorization.body.scopes_supported.includes("offline_access"));
   if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
   else process.env.MCP_ACCESS_TOKEN = previous;
 });

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -17,6 +17,7 @@ import {
   MCP_AGENT_CHAT_SCOPE,
   MCP_GITHUB_WRITE_SCOPE,
   MCP_INFRASTRUCTURE_WRITE_SCOPE,
+  MCP_OFFLINE_ACCESS_SCOPE,
   MCP_READ_SCOPE,
   requiresPersistentMcpReplayGuard,
   resetMcpOAuthStateForTests,
@@ -111,6 +112,13 @@ test("publishes OAuth 2.1 protected-resource and authorization metadata", () => 
     "refresh_token",
   ]);
   assert.deepEqual(authorization.code_challenge_methods_supported, ["S256"]);
+  assert.deepEqual(authorization.scopes_supported, [
+    MCP_READ_SCOPE,
+    MCP_AGENT_CHAT_SCOPE,
+    MCP_GITHUB_WRITE_SCOPE,
+    MCP_INFRASTRUCTURE_WRITE_SCOPE,
+    MCP_OFFLINE_ACCESS_SCOPE,
+  ]);
 });
 
 test("uses an explicit dedicated or legacy fallback OAuth key mode", () => {
@@ -278,6 +286,48 @@ test("validates OpenAI CIMD metadata and exact callback and resource", async () 
       { env: ENV, fetchImpl: clientMetadataFetch },
     ),
     (error) => error.code === "invalid_target",
+  );
+});
+
+test("accepts offline_access for ChatGPT refresh-token continuity", async () => {
+  const request = await validateMcpAuthorizationRequest(
+    authorizationInput([MCP_READ_SCOPE, MCP_OFFLINE_ACCESS_SCOPE]),
+    { env: ENV, fetchImpl: clientMetadataFetch },
+  );
+  assert.deepEqual(request.scopes, [
+    MCP_READ_SCOPE,
+    MCP_OFFLINE_ACCESS_SCOPE,
+  ]);
+
+  const code = createMcpAuthorizationCode(
+    request,
+    { id: "owner-id", memoryOwnerId: "primary-user", role: "owner" },
+    ENV,
+  );
+  const token = await exchangeMcpAuthorizationCode(
+    {
+      grant_type: "authorization_code",
+      code,
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: VERIFIER,
+      resource: ENV.MCP_RESOURCE_URL,
+    },
+    ENV,
+  );
+
+  assert.ok(token.refresh_token);
+  assert.equal(
+    token.scope,
+    `${MCP_READ_SCOPE} ${MCP_OFFLINE_ACCESS_SCOPE}`,
+  );
+  assert.equal(
+    verifyMcpAccessToken(
+      `Bearer ${token.access_token}`,
+      [MCP_READ_SCOPE],
+      ENV,
+    ).memoryOwnerId,
+    "primary-user",
   );
 });
 


### PR DESCRIPTION
## Причина

ChatGPT Apps изисква `offline_access` да бъде публикуван в OAuth metadata и приеман при authorization, за да има refresh-token continuity при повторно удостоверяване. Production metadata не го рекламираше, което прекъсваше защитените MCP инструменти след изтичане на сесията.

## Поправка

- добавя `offline_access` към `scopes_supported`;
- приема scope-а в authorization заявките;
- запазва съществуващите PKCE, state, redirect URI и confirmation защити;
- не променя публичните инструменти или несвързани модули.

## Проверка

- добавени regression тестове за metadata и OAuth scope continuity;
- всички тестове: **543/543 успешни**.
