### PR TITLE
Return HTTP 401 for MCP OAuth challenges

### DIFF
--- a/src/routes/mcpRouter.js
+++ b/src/routes/mcpRouter.js
@@ -152,18 +152,12 @@ export function requireMcpAuthorization(
       },
     });
   }
-  return res.json({
+  return res.status(401).json({
     jsonrpc: "2.0",
     id: req.body?.id ?? null,
-    result: {
-      content: [
-        {
-          type: "text",
-          text: "Нужно е OAuth свързване със AI CORE.",
-        },
-      ],
-      isError: true,
-      _meta: { "mcp/www_authenticate": [challenge] },
+    error: {
+      code: -32001,
+      message: "Нужно е OAuth свързване със AI CORE.",
     },
   });
 }

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -147,10 +147,10 @@ test("an unauthenticated tool call returns the ChatGPT OAuth challenge", async (
       method: "tools/call",
       params: { name: "get_personal_context", arguments: {} },
     })
-    .expect(200);
-  assert.equal(response.body.result.isError, true);
+    .expect(401);
+  assert.equal(response.body.error.code, -32001);
   assert.match(
-    response.body.result._meta["mcp/www_authenticate"][0],
+    response.headers["www-authenticate"],
     /oauth-protected-resource/u,
   );
   assert.match(response.headers["www-authenticate"], /synchron:read/u);


### PR DESCRIPTION
## Какво се променя
- връща HTTP 401 при защитен MCP tool call без bearer token
- запазва точния WWW-Authenticate challenge с resource metadata и изисквания scope
- добавя регресионен тест за ChatGPT OAuth handoff

## Причина
Production връщаше JSON-RPC OAuth грешка с HTTP 200. Актуалният OpenAI plugin OAuth contract изисква 401 Unauthorized + WWW-Authenticate, за да стартира свързването.

## Проверки
- OAuth/MCP tests: 15/15
- full suite: 543/543
- git diff --check