### PR TITLE
Fix ChatGPT OAuth handoff and consent replay

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -230,26 +230,35 @@ jobs:
             exit 1
           fi
 
-          challenge="$(curl --fail --silent --show-error \
+          challenge_headers="$(mktemp)"
+          challenge_body="$(mktemp)"
+          trap 'rm -f "${challenge_headers}" "${challenge_body}"' EXIT
+          challenge_status="$(curl --silent --show-error \
             --max-time 30 \
+            --dump-header "${challenge_headers}" \
+            --output "${challenge_body}" \
+            --write-out '%{http_code}' \
             --header 'Content-Type: application/json' \
             --header 'Accept: application/json, text/event-stream' \
             --data '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_github_copilot_task_status","arguments":{"issueNumber":83}}}' \
             https://synchron.foundation/mcp)"
-          printf '%s' "${challenge}" | node -e '
-            let input = "";
-            process.stdin.on("data", (chunk) => { input += chunk; });
-            process.stdin.on("end", () => {
-              const result = JSON.parse(input).result;
-              const challenges = result?._meta?.["mcp/www_authenticate"] || [];
-              const valid =
-                result?.isError === true &&
-                challenges.some(
-                  (value) => value.includes("Bearer") && value.includes("synchron:read"),
-                );
-              if (!valid) process.exit(1);
-            });
-          '
+          test "${challenge_status}" = "401"
+          grep -Eqi '^www-authenticate:[[:space:]]*Bearer.*resource_metadata="https://synchron\.foundation/\.well-known/oauth-protected-resource".*scope="synchron:read".*error="invalid_token"' "${challenge_headers}"
+          node -e '
+            const fs = require("node:fs");
+            const result = JSON.parse(fs.readFileSync(process.argv[1], "utf8")).result;
+            const challenges = result?._meta?.["mcp/www_authenticate"] || [];
+            const valid =
+              result?.isError === true &&
+              challenges.some(
+                (value) =>
+                  value.includes("Bearer") &&
+                  value.includes("synchron:read") &&
+                  value.includes("error=\"invalid_token\"") &&
+                  value.includes("error_description="),
+              );
+            if (!valid) process.exit(1);
+          ' "${challenge_body}"
 
       - name: Check tester auth readiness
         shell: bash

--- a/src/routes/mcpOAuthRouter.js
+++ b/src/routes/mcpOAuthRouter.js
@@ -1,6 +1,7 @@
 import express from "express";
 import { resolveRequestIdentity } from "../middleware/ownerAuth.js";
 import {
+  consumeMcpConsentRequest,
   createMcpAuthorizationCode,
   createMcpConsentToken,
   exchangeMcpToken,
@@ -8,7 +9,6 @@ import {
   getMcpProtectedResourceMetadata,
   McpOAuthError,
   recordMcpAuthorizationRuntimeStatus,
-  resolveMcpConsentRequest,
   validateMcpAuthorizationRequest,
 } from "../services/mcpOAuthService.js";
 
@@ -128,7 +128,7 @@ export function createMcpOAuthRouter({
             "access_denied",
           );
         }
-        const request = resolveMcpConsentRequest(
+        const request = await consumeMcpConsentRequest(
           req.body?.consent_token,
           identity,
         );

--- a/src/routes/mcpRouter.js
+++ b/src/routes/mcpRouter.js
@@ -139,25 +139,24 @@ export function requireMcpAuthorization(
           error: oauthError.code,
           description: oauthError.description,
         }
-      : {},
+      : {
+          error: "invalid_token",
+          description: "OAuth access token is required.",
+        },
   );
   res.set("WWW-Authenticate", challenge);
-  if (authorization) {
-    return res.status(oauthError?.status === 403 ? 403 : 401).json({
-      jsonrpc: "2.0",
-      id: req.body?.id ?? null,
-      error: {
-        code: -32001,
-        message: oauthError?.message || "Невалиден или изтекъл MCP token.",
-      },
-    });
-  }
-  return res.status(401).json({
+  const message = authorization
+    ? oauthError?.message || "Невалиден или изтекъл MCP token."
+    : "Нужно е OAuth свързване със AI CORE.";
+  return res.status(oauthError?.status === 403 ? 403 : 401).json({
     jsonrpc: "2.0",
     id: req.body?.id ?? null,
-    error: {
-      code: -32001,
-      message: "Нужно е OAuth свързване със AI CORE.",
+    result: {
+      content: [{ type: "text", text: message }],
+      _meta: {
+        "mcp/www_authenticate": [challenge],
+      },
+      isError: true,
     },
   });
 }

--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -36,6 +36,7 @@ const MAX_CONSUMED_TOKEN_RECORDS = 10_000;
 const REPLAY_CLEANUP_INTERVAL_SECONDS = 6 * 60 * 60;
 const MCP_OAUTH_REPLAY_INDEX =
   process.env.MCP_OAUTH_REPLAY_INDEX || "synchron-mcp-oauth-replay-v1";
+const consumedConsentTokens = new Map();
 const consumedAuthorizationCodes = new Map();
 const consumedRefreshTokens = new Map();
 let replayIndexPromise = null;
@@ -527,7 +528,7 @@ export function createMcpConsentToken(
   );
 }
 
-export function resolveMcpConsentRequest(
+function validatedMcpConsentPayload(
   token,
   identity,
   env = process.env,
@@ -549,6 +550,39 @@ export function resolveMcpConsentRequest(
     payload.request.resource !== resolveMcpResourceUrl(env) ||
     !Array.isArray(payload.request.scopes)
   ) {
+    throw new McpOAuthError("Невалидно потвърждение.", 403, "access_denied");
+  }
+  return payload;
+}
+
+export function resolveMcpConsentRequest(
+  token,
+  identity,
+  env = process.env,
+  now = Math.floor(Date.now() / 1_000),
+) {
+  const payload = validatedMcpConsentPayload(token, identity, env, now);
+  return consentRequest({
+    ...payload.request,
+    scopes: parseScopes(payload.request.scopes.join(" ")),
+  });
+}
+
+export async function consumeMcpConsentRequest(
+  token,
+  identity,
+  env = process.env,
+  now = Math.floor(Date.now() / 1_000),
+  { consumeGrant = consumeMcpGrantOnce } = {},
+) {
+  const payload = validatedMcpConsentPayload(token, identity, env, now);
+  const consumed = await consumeGrant({
+    grantType: "consent_token",
+    tokenId: createHash("sha256").update(String(token)).digest("base64url"),
+    expiresAt: payload.exp,
+    env,
+  });
+  if (!consumed) {
     throw new McpOAuthError("Невалидно потвърждение.", 403, "access_denied");
   }
   return consentRequest({
@@ -591,9 +625,9 @@ function markTokenConsumed(store, tokenId, expiresAt) {
 }
 
 function replayStore(grantType) {
-  return grantType === "authorization_code"
-    ? consumedAuthorizationCodes
-    : consumedRefreshTokens;
+  if (grantType === "consent_token") return consumedConsentTokens;
+  if (grantType === "authorization_code") return consumedAuthorizationCodes;
+  return consumedRefreshTokens;
 }
 
 function replayRecordId(grantType, tokenId) {
@@ -924,8 +958,7 @@ export async function exchangeMcpToken(input, env = process.env) {
       ...oauthRuntimeStatus,
       tokenExchange: "failed",
       grantType,
-      errorCode:
-        error instanceof McpOAuthError ? error.code : "server_error",
+      errorCode: error instanceof McpOAuthError ? error.code : "server_error",
       updatedAt: new Date().toISOString(),
     });
     throw error;
@@ -1005,6 +1038,7 @@ export function verifyMcpAccessToken(
 }
 
 export function resetMcpOAuthStateForTests() {
+  consumedConsentTokens.clear();
   consumedAuthorizationCodes.clear();
   consumedRefreshTokens.clear();
   replayIndexPromise = null;

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -133,7 +133,7 @@ test("MCP returns a JSON-RPC parse error for malformed JSON", async () => {
   assert.equal(response.body.error.code, -32700);
 });
 
-test("an unauthenticated tool call returns the ChatGPT OAuth challenge", async () => {
+test("an unauthenticated tool call returns the ChatGPT OAuth UI challenge", async () => {
   const previous = process.env.MCP_ACCESS_TOKEN;
   process.env.MCP_ACCESS_TOKEN = SECRET;
   const app = express();
@@ -148,12 +148,22 @@ test("an unauthenticated tool call returns the ChatGPT OAuth challenge", async (
       params: { name: "get_personal_context", arguments: {} },
     })
     .expect(401);
-  assert.equal(response.body.error.code, -32001);
+  assert.equal(response.body.result.isError, true);
+  assert.match(
+    response.body.result.content[0].text,
+    /OAuth свързване/u,
+  );
+  assert.equal(
+    response.body.result._meta["mcp/www_authenticate"][0],
+    response.headers["www-authenticate"],
+  );
   assert.match(
     response.headers["www-authenticate"],
     /oauth-protected-resource/u,
   );
   assert.match(response.headers["www-authenticate"], /synchron:read/u);
+  assert.match(response.headers["www-authenticate"], /error="invalid_token"/u);
+  assert.match(response.headers["www-authenticate"], /error_description=/u);
   if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
   else process.env.MCP_ACCESS_TOKEN = previous;
 });
@@ -174,7 +184,11 @@ test("an invalid bearer token is rejected with HTTP 401", async () => {
       params: { name: "get_personal_context", arguments: {} },
     })
     .expect(401);
-  assert.equal(response.body.error.code, -32001);
+  assert.equal(response.body.result.isError, true);
+  assert.equal(
+    response.body.result._meta["mcp/www_authenticate"][0],
+    response.headers["www-authenticate"],
+  );
   assert.match(response.headers["www-authenticate"], /invalid_token/u);
   if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
   else process.env.MCP_ACCESS_TOKEN = previous;
@@ -199,7 +213,11 @@ test("the dedicated OAuth secret is never accepted as a legacy static bearer", a
         params: { name: "get_personal_context", arguments: {} },
       })
       .expect(401);
-    assert.equal(response.body.error.code, -32001);
+    assert.equal(response.body.result.isError, true);
+    assert.equal(
+      response.body.result._meta["mcp/www_authenticate"][0],
+      response.headers["www-authenticate"],
+    );
   } finally {
     if (previousAccess === undefined) delete process.env.MCP_ACCESS_TOKEN;
     else process.env.MCP_ACCESS_TOKEN = previousAccess;

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -133,7 +133,7 @@ test("MCP returns a JSON-RPC parse error for malformed JSON", async () => {
   assert.equal(response.body.error.code, -32700);
 });
 
-test("an unauthenticated tool call returns the ChatGPT OAuth UI challenge", async () => {
+test("an unauthenticated tool call returns the ChatGPT OAuth challenge", async () => {
   const previous = process.env.MCP_ACCESS_TOKEN;
   process.env.MCP_ACCESS_TOKEN = SECRET;
   const app = express();
@@ -149,10 +149,6 @@ test("an unauthenticated tool call returns the ChatGPT OAuth UI challenge", asyn
     })
     .expect(401);
   assert.equal(response.body.result.isError, true);
-  assert.match(
-    response.body.result.content[0].text,
-    /OAuth свързване/u,
-  );
   assert.equal(
     response.body.result._meta["mcp/www_authenticate"][0],
     response.headers["www-authenticate"],
@@ -253,10 +249,7 @@ test("authorization consent issues a code bound to the browser profile", async (
     }),
   );
   const consent = await request(app).get("/oauth/authorize").expect(200);
-  assert.equal(
-    consent.headers["cross-origin-opener-policy"],
-    "unsafe-none",
-  );
+  assert.equal(consent.headers["cross-origin-opener-policy"], "unsafe-none");
   assert.match(consent.text, /Свързване на ChatGPT със AI CORE/u);
   assert.match(consent.text, /Четене на разрешените данни/u);
   assert.match(consent.text, /отделно точно потвърждение/u);
@@ -270,10 +263,7 @@ test("authorization consent issues a code bound to the browser profile", async (
     .type("form")
     .send({ consent_token: consentToken, decision: "allow" })
     .expect(302);
-  assert.equal(
-    approved.headers["cross-origin-opener-policy"],
-    "unsafe-none",
-  );
+  assert.equal(approved.headers["cross-origin-opener-policy"], "unsafe-none");
   const callback = new URL(approved.headers.location);
   assert.equal(callback.origin, "https://chatgpt.com");
   assert.equal(callback.searchParams.get("state"), "state-123");
@@ -283,7 +273,10 @@ test("authorization consent issues a code bound to the browser profile", async (
   assert.equal(authorizationStatus.authorization, "redirected");
   assert.equal(authorizationStatus.authorizationDecision, "allow");
   assert.equal(authorizationStatus.authorizationErrorCode, null);
-  assert.match(authorizationStatus.authorizationUpdatedAt, /^\d{4}-\d{2}-\d{2}T/u);
+  assert.match(
+    authorizationStatus.authorizationUpdatedAt,
+    /^\d{4}-\d{2}-\d{2}T/u,
+  );
   const token = await request(app)
     .post("/oauth/token")
     .type("form")
@@ -339,10 +332,7 @@ test("authorization flow overrides global COOP so ChatGPT can complete the popup
       /name="consent_token" value="([^"]+)"/u,
     )?.[1];
     assert.ok(consentToken);
-    assert.equal(
-      consent.headers["cross-origin-opener-policy"],
-      "unsafe-none",
-    );
+    assert.equal(consent.headers["cross-origin-opener-policy"], "unsafe-none");
 
     const approved = await request(app)
       .post("/oauth/authorize")
@@ -354,10 +344,7 @@ test("authorization flow overrides global COOP so ChatGPT can complete the popup
     assert.equal(callback.pathname, "/connector/oauth/test-callback");
     assert.equal(callback.searchParams.get("state"), oauthRequest.state);
     assert.match(callback.searchParams.get("code"), /^sx-code\./u);
-    assert.equal(
-      approved.headers["cross-origin-opener-policy"],
-      "unsafe-none",
-    );
+    assert.equal(approved.headers["cross-origin-opener-policy"], "unsafe-none");
     assert.equal(
       approved.headers["cross-origin-resource-policy"],
       "same-origin",
@@ -458,6 +445,54 @@ test("authorization consent ignores altered repeated OAuth form fields", async (
     assert.equal(callback.origin, "https://chatgpt.com");
     assert.equal(callback.searchParams.get("state"), oauthRequest.state);
     assert.match(callback.searchParams.get("code"), /^sx-code\./u);
+  } finally {
+    if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
+    else process.env.MCP_ACCESS_TOKEN = previous;
+  }
+});
+
+test("authorization consent token cannot issue more than one code", async () => {
+  const previous = process.env.MCP_ACCESS_TOKEN;
+  process.env.MCP_ACCESS_TOKEN = SECRET;
+  try {
+    const oauthRequest = {
+      clientId: "https://chatgpt.com/oauth/synchron/client.json",
+      clientName: "ChatGPT",
+      redirectUri: "https://chatgpt.com/connector/oauth/test-callback",
+      state: "state-one-time-consent",
+      codeChallenge: "c".repeat(43),
+      resource: "https://synchron.foundation/mcp",
+      scopes: ["synchron:read"],
+    };
+    const app = express();
+    app.use(
+      createMcpOAuthRouter({
+        resolveIdentity: async () => ({
+          id: "owner-id",
+          displayName: "Радко",
+          role: "owner",
+          memoryOwnerId: "primary-user",
+        }),
+        validateRequest: async () => oauthRequest,
+      }),
+    );
+    const consent = await request(app).get("/oauth/authorize").expect(200);
+    const consentToken = consent.text.match(
+      /name="consent_token" value="([^"]+)"/u,
+    )?.[1];
+    assert.ok(consentToken);
+
+    await request(app)
+      .post("/oauth/authorize")
+      .type("form")
+      .send({ consent_token: consentToken, decision: "allow" })
+      .expect(302);
+    const replayed = await request(app)
+      .post("/oauth/authorize")
+      .type("form")
+      .send({ consent_token: consentToken, decision: "allow" })
+      .expect(403);
+    assert.equal(replayed.body.error, "access_denied");
   } finally {
     if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
     else process.env.MCP_ACCESS_TOKEN = previous;

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -4,8 +4,10 @@ import test from "node:test";
 
 import {
   cleanupExpiredMcpReplayRecords,
+  consumeMcpConsentRequest,
   consumeMcpGrantOnce,
   createMcpAuthorizationCode,
+  createMcpConsentToken,
   exchangeMcpAuthorizationCode,
   exchangeMcpRefreshToken,
   exchangeMcpToken,
@@ -294,10 +296,7 @@ test("accepts offline_access for ChatGPT refresh-token continuity", async () => 
     authorizationInput([MCP_READ_SCOPE, MCP_OFFLINE_ACCESS_SCOPE]),
     { env: ENV, fetchImpl: clientMetadataFetch },
   );
-  assert.deepEqual(request.scopes, [
-    MCP_READ_SCOPE,
-    MCP_OFFLINE_ACCESS_SCOPE,
-  ]);
+  assert.deepEqual(request.scopes, [MCP_READ_SCOPE, MCP_OFFLINE_ACCESS_SCOPE]);
 
   const code = createMcpAuthorizationCode(
     request,
@@ -317,16 +316,10 @@ test("accepts offline_access for ChatGPT refresh-token continuity", async () => 
   );
 
   assert.ok(token.refresh_token);
+  assert.equal(token.scope, `${MCP_READ_SCOPE} ${MCP_OFFLINE_ACCESS_SCOPE}`);
   assert.equal(
-    token.scope,
-    `${MCP_READ_SCOPE} ${MCP_OFFLINE_ACCESS_SCOPE}`,
-  );
-  assert.equal(
-    verifyMcpAccessToken(
-      `Bearer ${token.access_token}`,
-      [MCP_READ_SCOPE],
-      ENV,
-    ).memoryOwnerId,
+    verifyMcpAccessToken(`Bearer ${token.access_token}`, [MCP_READ_SCOPE], ENV)
+      .memoryOwnerId,
     "primary-user",
   );
 });
@@ -607,6 +600,49 @@ test("production replay guard is atomic across local state resets", async () => 
   assert.equal(await consumeMcpGrantOnce(input), true);
   resetMcpOAuthStateForTests();
   assert.equal(await consumeMcpGrantOnce(input), false);
+});
+
+test("consent token replay stays blocked across an application restart", async () => {
+  const seen = new Set();
+  const client = {
+    async create({ id }) {
+      if (seen.has(id)) {
+        const error = new Error("version conflict");
+        error.meta = { statusCode: 409 };
+        throw error;
+      }
+      seen.add(id);
+    },
+  };
+  const env = { ...ENV, NODE_ENV: "production" };
+  const identity = {
+    id: "owner-id",
+    memoryOwnerId: "primary-user",
+    role: "owner",
+  };
+  const oauthRequest = {
+    clientId: CLIENT_ID,
+    clientName: "ChatGPT",
+    redirectUri: REDIRECT_URI,
+    state: "state-consent-restart",
+    codeChallenge: createHash("sha256").update(VERIFIER).digest("base64url"),
+    resource: ENV.MCP_RESOURCE_URL,
+    scopes: [MCP_READ_SCOPE],
+  };
+  const now = Math.floor(Date.now() / 1_000);
+  const token = createMcpConsentToken(oauthRequest, identity, env, now);
+  const consumeGrant = (input) => consumeMcpGrantOnce({ ...input, client });
+
+  const resolved = await consumeMcpConsentRequest(token, identity, env, now, {
+    consumeGrant,
+  });
+  assert.deepEqual(resolved, oauthRequest);
+
+  resetMcpOAuthStateForTests();
+  await assert.rejects(
+    consumeMcpConsentRequest(token, identity, env, now, { consumeGrant }),
+    (error) => error.code === "access_denied" && error.status === 403,
+  );
 });
 
 test("first production token exchange creates the durable replay index", async () => {

--- a/tests/productionSmokeWorkflow.test.js
+++ b/tests/productionSmokeWorkflow.test.js
@@ -14,7 +14,10 @@ test("production smoke publishes a readable commit status without a custom secre
   assert.match(workflow, /synchron\/production-smoke/u);
   assert.match(workflow, /statuses\/\$\{GITHUB_SHA\}/u);
   assert.match(workflow, /required_matches=5/u);
-  assert.match(workflow, /consecutive_matches=\$\(\(consecutive_matches \+ 1\)\)/u);
+  assert.match(
+    workflow,
+    /consecutive_matches=\$\(\(consecutive_matches \+ 1\)\)/u,
+  );
   assert.match(workflow, /deployment-check=\$\{GITHUB_RUN_ID\}-\$\{attempt\}/u);
   assert.match(workflow, /Cache-Control: no-cache/u);
   assert.match(workflow, /Check AI CORE public shell/u);
@@ -23,7 +26,12 @@ test("production smoke publishes a readable commit status without a custom secre
   assert.match(workflow, /Check MCP tool catalog and OAuth challenge/u);
   assert.match(workflow, /get_github_copilot_task_status/u);
   assert.match(workflow, /names\.length === expected\.length/u);
+  assert.match(workflow, /challenge_status/u);
+  assert.match(workflow, /test "\$\{challenge_status\}" = "401"/u);
+  assert.match(workflow, /www-authenticate:/u);
+  assert.match(workflow, /oauth-protected-resource/u);
   assert.match(workflow, /mcp\/www_authenticate/u);
+  assert.match(workflow, /error=\\"invalid_token\\"/u);
   assert.match(workflow, /synchron:read/u);
   assert.match(workflow, /Check workspace authentication boundary/u);
   assert.match(workflow, /\/api\/workspaces/u);


### PR DESCRIPTION
## Какво поправя

- връща задължителния tool-level `_meta["mcp/www_authenticate"]` payload за смесено MCP удостоверяване;
- запазва HTTP `401/403` и точния `WWW-Authenticate` header с `resource_metadata`, scope, `error` и `error_description`;
- прави подписания consent token реално еднократен чрез съществуващия устойчив OAuth replay store;
- поправя production smoke проверката да валидира очаквания HTTP `401`, header-а и MCP `_meta` payload-а.

## Доказани причини

1. PR #267 правилно сменя unauthenticated tool response от HTTP 200 на 401, но премахва `_meta["mcp/www_authenticate"]`. Официалният ChatGPT mixed-auth договор изисква и двата сигнала за надеждно отваряне на OAuth интерфейса.
2. Поправката в PR #262 правилно носи проверената OAuth заявка в защитения consent token и не зависи от повторно изпратени form полета. Независим тест обаче доказа, че един и същ token издава втори authorization code в рамките на TTL.
3. Текущият production smoke run `31021564493` стига до здрав сайт, readiness, memory acceptance 9/9 и MCP catalog, но прекъсва на реалния 401 заради стария `curl --fail` договор.

## Независим OAuth review

Потвърдени без допълнителна архитектурна промяна:

- authorization code + PKCE S256;
- CIMD metadata, публичен client метод `none` и точен callback `https://chatgpt.com/connector/oauth/{callback_id}`;
- binding на `resource`, `state`, scopes, profile identity и callback;
- 10-минутен consent TTL, AES-GCM tamper protection и dedicated/legacy secret fallback;
- еднократни authorization codes, refresh-token rotation и устойчив replay guard;
- refresh continuity чрез `offline_access`;
- работа на refresh и replay защитите след нов module instance/restart;
- безопасни runtime diagnostics без code, token, client ID, profile или secret;
- browser/form round trip, който игнорира променени повторни OAuth полета.

## Риск

Consent POST вече fail-closed зависи от съществуващия OpenSearch replay store. Това е същата production зависимост, която вече пази authorization codes и refresh tokens. При недостъпен store свързването връща безопасен `temporarily_unavailable`, вместо да допуска replay.

Не се променят Chat, Memory данни, Capability Engine, production secrets, Cloudflare или DigitalOcean конфигурация.

## Проверки

- възпроизвеждане преди поправката: 3/3 нови проверки fail;
- OAuth/MCP/smoke: 37/37 успешни;
- `npm test`: 545/545 успешни;
- `npm audit --omit=dev`: 0 уязвимости;
- Prettier: успешен;
- `git diff --check`: успешен;
- scan за разпознаваеми private-key/API-token префикси: няма резултати.

Локалната среда е Node 24.14.0, а production договорът в `package.json` е Node 22.x. GitHub Node.js checks са източникът за проверка в правилната CI среда.

## Оставащи неизвестни

- реалният owner ChatGPT OAuth handoff и token exchange трябва да се приемат след review и deployment;
- двата нови GitHub Pages workflow-а в текущия `main` не са част от този PR. Те имат `pages: write` и `id-token: write` и трябва да бъдат прегледани отделно спрямо правилото, че DigitalOcean публикува `main`.

Draft PR. Без merge и без deployment.