### PR TITLE
Fix production smoke OAuth 401 handling

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -230,26 +230,29 @@ jobs:
             exit 1
           fi
 
-          challenge="$(curl --fail --silent --show-error \
+          challenge_headers="$(mktemp)"
+          challenge_body="$(mktemp)"
+          trap 'rm -f "${challenge_headers}" "${challenge_body}"' EXIT
+          challenge_status="$(curl --silent --show-error \
             --max-time 30 \
+            --dump-header "${challenge_headers}" \
+            --output "${challenge_body}" \
+            --write-out '%{http_code}' \
             --header 'Content-Type: application/json' \
             --header 'Accept: application/json, text/event-stream' \
             --data '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_github_copilot_task_status","arguments":{"issueNumber":83}}}' \
             https://synchron.foundation/mcp)"
-          printf '%s' "${challenge}" | node -e '
-            let input = "";
-            process.stdin.on("data", (chunk) => { input += chunk; });
-            process.stdin.on("end", () => {
-              const result = JSON.parse(input).result;
-              const challenges = result?._meta?.["mcp/www_authenticate"] || [];
-              const valid =
-                result?.isError === true &&
-                challenges.some(
-                  (value) => value.includes("Bearer") && value.includes("synchron:read"),
-                );
-              if (!valid) process.exit(1);
-            });
-          '
+          test "${challenge_status}" = "401"
+          grep -Eqi '^www-authenticate:[[:space:]]*Bearer.*resource_metadata="https://synchron\.foundation/\.well-known/oauth-protected-resource".*scope="synchron:read"' "${challenge_headers}"
+          node -e '
+            const fs = require("node:fs");
+            const result = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const valid =
+              result?.jsonrpc === "2.0" &&
+              result?.id === 2 &&
+              result?.error?.code === -32001;
+            if (!valid) process.exit(1);
+          ' "${challenge_body}"
 
       - name: Check tester auth readiness
         shell: bash

--- a/tests/productionSmokeWorkflow.test.js
+++ b/tests/productionSmokeWorkflow.test.js
@@ -23,7 +23,11 @@ test("production smoke publishes a readable commit status without a custom secre
   assert.match(workflow, /Check MCP tool catalog and OAuth challenge/u);
   assert.match(workflow, /get_github_copilot_task_status/u);
   assert.match(workflow, /names\.length === expected\.length/u);
-  assert.match(workflow, /mcp\/www_authenticate/u);
+  assert.match(workflow, /challenge_status/u);
+  assert.match(workflow, /test "\$\{challenge_status\}" = "401"/u);
+  assert.match(workflow, /www-authenticate:/u);
+  assert.match(workflow, /oauth-protected-resource/u);
+  assert.match(workflow, /error\?\.code === -32001/u);
   assert.match(workflow, /synchron:read/u);
   assert.match(workflow, /Check workspace authentication boundary/u);
   assert.match(workflow, /\/api\/workspaces/u);


### PR DESCRIPTION
## Summary

- accept the expected HTTP 401 response from a protected MCP tool call
- validate the `WWW-Authenticate` OAuth resource metadata and required scope
- validate the JSON-RPC authorization error body
- update the workflow contract test for the HTTP challenge

## Root cause

The production endpoint correctly returns HTTP 401 for an unauthenticated protected MCP call. The smoke check used `curl --fail`, so curl exited before the workflow could inspect the valid OAuth challenge.

## Impact

This changes only the production smoke workflow and its test. It does not change the site, MCP implementation, OAuth implementation, `www` configuration, or production deployment.

## Validation

- `npm test` — 543 passed, 0 failed
- targeted workflow test — 1 passed, 0 failed
- `git diff --check`
- remote comparison — exactly 2 modified files, 0 commits behind `main`

Draft only. No merge or deployment.