### PR TITLE
Add Secure MCP Tunnel worker

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -130,3 +130,29 @@ services:
       - key: PAID_AI_RATE_LIMIT
         value: "60"
         scope: RUN_TIME
+
+workers:
+  - name: mcp-tunnel
+    image:
+      registry_type: GHCR
+      registry: openai
+      repository: tunnel-client
+      tag: v0.0.10
+    instance_count: 1
+    instance_size_slug: apps-s-1vcpu-0.5gb
+    envs:
+      - key: CONTROL_PLANE_API_KEY
+        scope: RUN_TIME
+        type: SECRET
+      - key: CONTROL_PLANE_TUNNEL_ID
+        scope: RUN_TIME
+        type: SECRET
+      - key: MCP_SERVER_URL
+        value: http://web/mcp
+        scope: RUN_TIME
+      - key: LOG_LEVEL
+        value: info
+        scope: RUN_TIME
+      - key: LOG_FORMAT
+        value: json
+        scope: RUN_TIME


### PR DESCRIPTION
## Какво се променя

Добавя отделен DigitalOcean worker `mcp-tunnel`, който използва официалния образ `ghcr.io/openai/tunnel-client:v0.0.10`.

Worker-ът достига MCP сървъра вътрешно през `http://web/mcp` и очаква две DigitalOcean runtime secrets:

- `CONTROL_PLANE_API_KEY`
- `CONTROL_PLANE_TUNNEL_ID`

## Защо

Създаденият Secure MCP Tunnel няма постоянно работещ клиент. Без `tunnel-client` ChatGPT не може да изпраща MCP заявки към SYNCHRON-X AI CORE през тунела.

## Проверка

- YAML синтаксисът и очакваните полета са валидирани локално.
- Сравнението с `main` показва само `.do/app.yaml`: 26 добавени реда, без изтривания.
- Не са добавени тайни стойности.

## Преди merge

Това е draft. Не го сливайте и не стартирайте deployment, преди двете runtime стойности да бъдат създадени и записани в DigitalOcean. Активирането на отделния worker добавя месечен инфраструктурен разход.