### PR TITLE
Fix production acceptance checks

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -230,7 +230,7 @@ jobs:
             exit 1
           fi
 
-          challenge="$(curl --fail --silent --show-error \
+          challenge="$(curl --silent --show-error \
             --max-time 30 \
             --header 'Content-Type: application/json' \
             --header 'Accept: application/json, text/event-stream' \

--- a/src/routes/chat.js
+++ b/src/routes/chat.js
@@ -92,6 +92,7 @@ import { logSafeError, safeErrorCode } from "../utils/safeLogging.js";
 import {
   buildWorkContextStatusReply,
   buildWorkModeContext,
+  hasExplicitNoAdditionalToolsBoundary,
   hasExplicitNoToolBoundary,
   isRuntimeAiIdentityRequest,
   isWorkContextStatusRequest,
@@ -360,6 +361,7 @@ export function detectCapabilityRequests(message) {
         subtask,
       ) &&
       !hasExplicitNoToolBoundary(subtask) &&
+      !hasExplicitNoAdditionalToolsBoundary(subtask) &&
       !copilotBridgeStatusRequest &&
       !/(?:регистрирани|tool\s+registry|capability\s+engine)/iu.test(subtask)
     ) {
@@ -1293,6 +1295,7 @@ router.post("/chat", async (req, res) => {
     capabilityPlanningAllowed &&
     !memoryAction &&
     openAiApiKey &&
+    !hasExplicitNoAdditionalToolsBoundary(cleanMessage) &&
     shouldUseAgentPlanner(cleanMessage, fallbackCapabilityRequests)
   ) {
     try {

--- a/src/services/workModeService.js
+++ b/src/services/workModeService.js
@@ -196,7 +196,7 @@ export function isRuntimeAiIdentityRequest(message) {
   const text = cleanText(message, 500).toLocaleLowerCase("bg-BG");
   if (!text) return false;
   const asksForIdentity =
-    /(?:кой|какъв|каква|кажи|покажи|посочи|използва|работи|доставчик|provider)/u.test(
+    /(?:кой|какъв|каква|кажи|покажи|посочи|доставчик|provider)/u.test(
       text,
     );
   const mentionsRuntime =
@@ -248,6 +248,14 @@ export function hasExplicitNoToolBoundary(message) {
   const text = cleanText(message, 8000);
   if (!text) return false;
   return /(?:не\s+(?:използвай|ползвай|стартирай|извиквай)\s+(?:никакви\s+)?инструмент(?:и|ите)?|без\s+(?:да\s+)?(?:използваш|ползваш|стартираш|извикваш)\s+инструмент(?:и|ите)?)/iu.test(
+    text,
+  );
+}
+
+export function hasExplicitNoAdditionalToolsBoundary(message) {
+  const text = cleanText(message, 8000);
+  if (!text) return false;
+  return /(?:не\s+(?:използвай|ползвай|стартирай|извиквай)\s+(?:други|допълнителни)\s+инструмент(?:и|ите)?|без\s+(?:други|допълнителни)\s+инструмент(?:и|ите)?)/iu.test(
     text,
   );
 }

--- a/tests/chatCapabilityExecution.test.js
+++ b/tests/chatCapabilityExecution.test.js
@@ -56,6 +56,17 @@ test("a negative tool instruction remains an ordinary AI conversation", () => {
   assert.deepEqual(requests, []);
 });
 
+test("an explicit GitHub read with no additional tools stays focused", () => {
+  const requests = detectCapabilityRequests(
+    "AUTO тест: провери само за четене последния commit в GitHub. Не използвай други инструменти и не прави промени.",
+  );
+
+  assert.deepEqual(
+    requests.map(({ capability, action }) => ({ capability, action })),
+    [{ capability: "code.read", action: "github.read" }],
+  );
+});
+
 test("member profiles receive only web search and their own memory tools", () => {
   const requests = detectCapabilityRequests(
     "Потърси актуалната прогноза, провери паметта и провери GitHub.",

--- a/tests/productionSmokeWorkflow.test.js
+++ b/tests/productionSmokeWorkflow.test.js
@@ -25,6 +25,11 @@ test("production smoke publishes a readable commit status without a custom secre
   assert.match(workflow, /names\.length === expected\.length/u);
   assert.match(workflow, /mcp\/www_authenticate/u);
   assert.match(workflow, /synchron:read/u);
+  assert.match(workflow, /challenge="\$\(curl --silent --show-error/u);
+  assert.doesNotMatch(
+    workflow,
+    /challenge="\$\(curl --fail --silent --show-error/u,
+  );
   assert.match(workflow, /Check workspace authentication boundary/u);
   assert.match(workflow, /\/api\/workspaces/u);
   assert.match(workflow, /AUTH_REQUIRED/u);

--- a/tests/workModeService.test.js
+++ b/tests/workModeService.test.js
@@ -211,6 +211,12 @@ test("runtime provider and model questions do not launch Codex code analysis", (
   }
 
   assert.equal(isRuntimeAiIdentityRequest("Провери модела в src/config.js"), false);
+  assert.equal(
+    isRuntimeAiIdentityRequest(
+      "Тест на AI CORE: отговори само с „AI CORE работи“ и не използвай инструменти.",
+    ),
+    false,
+  );
 });
 
 test("active work context questions use verified state instead of chat history", () => {


### PR DESCRIPTION
## Резултат

Поправя трите дефекта от реалния production acceptance:

- AI CORE командата за точен отговор вече не се разпознава погрешно като въпрос за runtime модела;
- изричното „не използвай други инструменти“ запазва GitHub read-only заявката фокусирана;
- production smoke приема очаквания MCP OAuth `401` и проверява challenge тялото.

## Проверки

- целеви тестове: 45/45
- пълен тестов пакет: 547/547
- diff: 6 файла, +35/-2

Не се променят secrets, Memory или OpenSearch.