### PR TITLE
Fix MCP OAuth production smoke validation

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -230,26 +230,16 @@ jobs:
             exit 1
           fi
 
-          challenge="$(curl --silent --show-error \
+          challenge_headers="$(curl --silent --show-error \
             --max-time 30 \
+            --dump-header - \
+            --output /dev/null \
             --header 'Content-Type: application/json' \
             --header 'Accept: application/json, text/event-stream' \
             --data '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_github_copilot_task_status","arguments":{"issueNumber":83}}}' \
             https://synchron.foundation/mcp)"
-          printf '%s' "${challenge}" | node -e '
-            let input = "";
-            process.stdin.on("data", (chunk) => { input += chunk; });
-            process.stdin.on("end", () => {
-              const result = JSON.parse(input).result;
-              const challenges = result?._meta?.["mcp/www_authenticate"] || [];
-              const valid =
-                result?.isError === true &&
-                challenges.some(
-                  (value) => value.includes("Bearer") && value.includes("synchron:read"),
-                );
-              if (!valid) process.exit(1);
-            });
-          '
+          printf '%s' "${challenge_headers}" \
+            | grep -Eiq '^www-authenticate:.*Bearer.*synchron:read'
 
       - name: Check tester auth readiness
         shell: bash

--- a/tests/productionSmokeWorkflow.test.js
+++ b/tests/productionSmokeWorkflow.test.js
@@ -23,13 +23,16 @@ test("production smoke publishes a readable commit status without a custom secre
   assert.match(workflow, /Check MCP tool catalog and OAuth challenge/u);
   assert.match(workflow, /get_github_copilot_task_status/u);
   assert.match(workflow, /names\.length === expected\.length/u);
-  assert.match(workflow, /mcp\/www_authenticate/u);
+  assert.match(workflow, /challenge_headers/u);
   assert.match(workflow, /synchron:read/u);
-  assert.match(workflow, /challenge="\$\(curl --silent --show-error/u);
+  assert.match(workflow, /--dump-header -/u);
+  assert.match(workflow, /--output \/dev\/null/u);
+  assert.match(workflow, /\^www-authenticate:/u);
   assert.doesNotMatch(
     workflow,
-    /challenge="\$\(curl --fail --silent --show-error/u,
+    /challenge_headers="\$\(curl --fail --silent --show-error/u,
   );
+  assert.doesNotMatch(workflow, /mcp\/www_authenticate/u);
   assert.match(workflow, /Check workspace authentication boundary/u);
   assert.match(workflow, /\/api\/workspaces/u);
   assert.match(workflow, /AUTH_REQUIRED/u);


### PR DESCRIPTION
Проверява реалния OAuth `WWW-Authenticate` header при очакван `401`, вместо да търси несъществуващо `mcp/www_authenticate` поле в JSON-RPC body.

Проверка: `tests/productionSmokeWorkflow.test.js` — 1/1 зелен.

Обхват: 2 файла, +11/-18; няма промяна в production OAuth поведението.