### PR TITLE
Show actionable registration HTTP errors

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -147,9 +147,16 @@ async function submitAuth(path, body) {
   });
   const data = await response.json().catch(() => null);
   if (!response.ok) {
-    const error = new Error(data?.error || "Входът не беше успешен.");
+    const action = path.endsWith("/register") ? "Регистрацията" : "Входът";
+    const error = new Error(
+      data?.error || `${action} не беше успешен (HTTP ${response.status}).`,
+    );
     error.code = data?.code || "AUTH_REQUEST_FAILED";
+    error.status = response.status;
     throw error;
+  }
+  if (!data) {
+    throw new Error(`Невалиден отговор от услугата (HTTP ${response.status}).`);
   }
   return data;
 }

--- a/tests/authUi.test.js
+++ b/tests/authUi.test.js
@@ -38,6 +38,13 @@ test("registration does not send an invitation code", () => {
   assert.match(app, /password: elements\.registerPassword\.value/u);
 });
 
+test("registration errors identify the failed action and HTTP status", () => {
+  assert.match(app, /path\.endsWith\("\/register"\)/u);
+  assert.match(app, /Регистрацията/u);
+  assert.match(app, /HTTP \$\{response\.status\}/u);
+  assert.match(app, /Невалиден отговор от услугата/u);
+});
+
 test("direct registration address opens the registration form", () => {
   assert.match(app, /const REGISTRATION_PATH = "\/register"/u);
   assert.match(app, /isDirectRegistrationPage\(\)/u);


### PR DESCRIPTION
Заменя общото „Входът не беше успешен“ при не-JSON registration response с конкретно „Регистрацията … (HTTP N)“ и валидира празен/невалиден успешен отговор.

Проверка: `tests/authUi.test.js` — 8/8 зелени.

Не променя Supabase, профили, пароли или auth разрешения.