### PR TITLE
Bound tester access requests during registration

### DIFF
--- a/src/services/testerAccessService.js
+++ b/src/services/testerAccessService.js
@@ -3,6 +3,10 @@ import { createHash, createHmac } from "node:crypto";
 import { getOpenSearchClient } from "../config/opensearch.js";
 
 const DEFAULT_INDEX = "synchron-tester-access-v1";
+const ACCESS_REQUEST_OPTIONS = Object.freeze({
+  requestTimeout: 5_000,
+  maxRetries: 0,
+});
 
 export class TesterAccessError extends Error {
   constructor(message, status, code) {
@@ -88,16 +92,19 @@ export async function approveTesterAccess(
   const userId = cleanUserId(user);
   const approvedAt = new Date().toISOString();
   try {
-    await requireClient(client).index({
-      index: accessIndex(env),
-      id: userId,
-      body: {
-        userId,
-        status: "approved",
-        approvedAt,
+    await requireClient(client).index(
+      {
+        index: accessIndex(env),
+        id: userId,
+        body: {
+          userId,
+          status: "approved",
+          approvedAt,
+        },
+        refresh: true,
       },
-      refresh: true,
-    });
+      ACCESS_REQUEST_OPTIONS,
+    );
   } catch (error) {
     if (error instanceof TesterAccessError) throw error;
     throw new TesterAccessError(
@@ -123,16 +130,19 @@ export async function approveTesterEmail(
   }
   const approvedAt = new Date().toISOString();
   try {
-    await requireClient(client).index({
-      index: accessIndex(env),
-      id: emailApprovalId(emailHash),
-      body: {
-        emailHash,
-        status: "approved",
-        approvedAt,
+    await requireClient(client).index(
+      {
+        index: accessIndex(env),
+        id: emailApprovalId(emailHash),
+        body: {
+          emailHash,
+          status: "approved",
+          approvedAt,
+        },
+        refresh: true,
       },
-      refresh: true,
-    });
+      ACCESS_REQUEST_OPTIONS,
+    );
   } catch (error) {
     if (error instanceof TesterAccessError) throw error;
     throw new TesterAccessError(
@@ -157,10 +167,13 @@ export async function assertTesterAccess(
 
   const accessClient = requireClient(client);
   try {
-    const response = await accessClient.get({
-      index: accessIndex(env),
-      id: userId,
-    });
+    const response = await accessClient.get(
+      {
+        index: accessIndex(env),
+        id: userId,
+      },
+      ACCESS_REQUEST_OPTIONS,
+    );
     const source = response.body?._source ?? response._source;
     if (source?.userId === userId && source?.status === "approved") {
       return true;
@@ -179,10 +192,13 @@ export async function assertTesterAccess(
   const emailHash = cleanEmailHash(user?.email, env);
   if (emailHash) {
     try {
-      const response = await accessClient.get({
-        index: accessIndex(env),
-        id: emailApprovalId(emailHash),
-      });
+      const response = await accessClient.get(
+        {
+          index: accessIndex(env),
+          id: emailApprovalId(emailHash),
+        },
+        ACCESS_REQUEST_OPTIONS,
+      );
       const source = response.body?._source ?? response._source;
       if (source?.emailHash === emailHash && source?.status === "approved") {
         return true;

--- a/tests/testerAccessService.test.js
+++ b/tests/testerAccessService.test.js
@@ -11,13 +11,17 @@ import {
 
 function createClient() {
   const records = new Map();
+  const requestOptions = [];
   return {
     records,
-    async index({ id, body }) {
+    requestOptions,
+    async index({ id, body }, options) {
+      requestOptions.push({ operation: "index", options });
       records.set(id, structuredClone(body));
       return { body: { result: "created" } };
     },
-    async get({ id }) {
+    async get({ id }, options) {
+      requestOptions.push({ operation: "get", options });
       if (!records.has(id)) {
         const error = new Error("not found");
         error.statusCode = 404;
@@ -48,6 +52,35 @@ test("invite-approved registration stores a server-side access record", async ()
   assert.equal(
     await assertTesterAccess({ id: "user-approved" }, { client }),
     true,
+  );
+  assert.deepEqual(client.requestOptions, [
+    {
+      operation: "index",
+      options: { requestTimeout: 5_000, maxRetries: 0 },
+    },
+    {
+      operation: "get",
+      options: { requestTimeout: 5_000, maxRetries: 0 },
+    },
+  ]);
+});
+
+test("approval timeout fails closed with a bounded service error", async () => {
+  const client = {
+    async index(_request, options) {
+      assert.deepEqual(options, { requestTimeout: 5_000, maxRetries: 0 });
+      const error = new Error("Request timed out");
+      error.name = "TimeoutError";
+      throw error;
+    },
+  };
+
+  await assert.rejects(
+    approveTesterAccess({ id: "slow-user" }, { client }),
+    (error) =>
+      error instanceof TesterAccessError &&
+      error.code === "TESTER_ACCESS_PERSISTENCE_FAILED" &&
+      error.status === 503,
   );
 });
 


### PR DESCRIPTION
Предотвратява gateway `504` при регистрация, като ограничава OpenSearch approval/read заявките до 5 секунди и изключва автоматичните retry опити. Fail-closed защитата и `refresh: true` се запазват.

Проверки: `testerAccessService` + `userAuthService` — 25/25 зелени.

Не променя профили, пароли, AI Core или Memory.