### PR TITLE
Make owner acceptance confirmations reviewable

### DIFF
--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -19,6 +19,13 @@ rollback. Историческите audit документи пазят кон�
 Не обявявай deployment за успешен само защото `/health` отговаря. Exact SHA,
 readiness и production smoke трябва да сочат една и съща версия.
 
+## Owner acceptance
+
+След зелен production baseline изпълнявай реалните ChatGPT MCP, GitHub и Google
+проверки само по [`OWNER_ACCEPTANCE_RUNBOOK.md`](./OWNER_ACCEPTANCE_RUNBOOK.md).
+Този цикъл започва read-only; всяко външно write действие има отделно точно
+потвърждение, проверка на резултата и cleanup.
+
 ## Read-only проверка
 
 Изпълни от чисто копие на хранилището:

--- a/docs/OWNER_ACCEPTANCE_RUNBOOK.md
+++ b/docs/OWNER_ACCEPTANCE_RUNBOOK.md
@@ -1,0 +1,169 @@
+# SYNCHRON-X owner acceptance runbook
+
+Този runbook доказва реалната owner връзка към ChatGPT MCP, GitHub и Google.
+Той не променя production конфигурация и не е разрешение за write действие.
+
+## Задължителни граници
+
+- Изпълнявай acceptance само с owner профила на SYNCHRON-X.
+- Започвай с read-only проверките.
+- За всяко външно write действие следвай отделно:
+  `prepare → преглед на въздействието → точно потвърждение → execute → verify → cleanup`.
+- Не приемай общо „да“, старо потвърждение или потвърждение за друг ресурс.
+- Не записвай access token, refresh token, cookie, authorization code, secret,
+  лично писмо, календарно съдържание или лична памет в PR, issue, screenshot или log.
+- Не стартирай write acceptance от CI, scheduled workflow или production smoke.
+- Не променяй secret, OAuth scope или `COPILOT_AUTOMATION_ENABLED`, за да накараш
+  теста да мине.
+- Спри при грешен owner, различен target, липсващ cleanup план или неочакван
+  write резултат.
+
+## Предварителна проверка
+
+Преди всяка acceptance сесия изпълни read-only реда от
+[`OPERATIONS_RUNBOOK.md`](./OPERATIONS_RUNBOOK.md) и запиши само:
+
+- UTC дата и кратък acceptance run ID;
+- SHA на `main`;
+- SHA от `/health`;
+- `status` от `/health/ready`;
+- състоянието на `synchron/production-smoke` за същия SHA.
+
+Продължи само ако двата SHA съвпадат, readiness е `ready`, memory acceptance е
+изолиран и production smoke е успешен.
+
+## 1. ChatGPT MCP — read-only owner acceptance
+
+Официалният OpenAI процес за developer връзка е описан в
+[Connect and test your plugin](https://developers.openai.com/plugins/deploy/connect-chatgpt).
+
+1. В ChatGPT отвори **Settings → Security and login** и включи Developer mode.
+   Наличността може да зависи от профила или workspace policy.
+2. Отвори ChatGPT Plugins, добави нова връзка и въведи публичния Streamable
+   HTTP адрес `https://synchron.foundation/mcp`.
+3. Прегледай откритите инструменти и техните annotations. Не продължавай, ако
+   каталогът е различен от production smoke договора.
+4. Започни нов разговор, избери връзката и поискай точно read-only инструмента
+   `get_system_configuration`.
+5. Завърши OAuth входа със SYNCHRON-X owner профила. Не копирай token или code.
+6. Провери, че резултатът е model-readable, не съдържа secret и съответства на
+   read-only production диагностиката.
+7. Изпрати неподдържана заявка и провери, че не е избран write инструмент.
+
+Успех има само ако OAuth discovery, consent, tool selection и read резултатът
+работят край до край с owner identity. Публичен `tools/list` или static bearer
+проверка сами по себе си не са owner acceptance.
+
+След нормален бъдещ deployment отвори съществуващата връзка, избери **Refresh**,
+провери metadata и повтори read-only заявката в нов разговор. Не стартирай
+deployment само за този тест и не ротирай OAuth secret.
+
+## 2. GitHub — owner acceptance
+
+### Read-only
+
+1. Влез в SYNCHRON-X като owner и отвори **Връзки**.
+2. Свържи разрешения GitHub профил през `/api/github/connect`.
+3. Провери `/api/github/status`: връзката трябва да е owner-authorized.
+4. В чата поискай read-only проверка на текущия `main` commit за
+   `radostinvgeorgiev-commits/sunchron-backend`.
+5. Сравни върнатия SHA с предварителната проверка.
+
+Това са две отделни доказателства. `/api/github/status` проверява owner OAuth
+сесията. GitHub read adapter-ът използва сървърния read достъп/публичния API, а
+не owner OAuth сесията; неговият успешен SHA не трябва да се отчита като OAuth
+tool call.
+
+### Write — само когато мостът е изрично разрешен
+
+Production режимът без Copilot трябва да върне
+`COPILOT_AUTOMATION_DISABLED`. Това е успешна отрицателна контрола: не трябва да
+се създават issue, branch, commit или Pull Request.
+
+Не включвай Copilot automation само за acceptance. Реален GitHub write тест се
+прави в отделна сесия едва когато има наличен Copilot достъп, изрично разрешена
+production настройка и предварително одобрен test ресурс.
+
+Преди точното потвърждение запиши:
+
+- repository и base ref;
+- пълния test prompt;
+- очакваните issue, branch, Pull Request и неговото очаквано състояние;
+- забрана за merge и deployment;
+- кой и как ще затвори test issue/PR и ще премахне test branch.
+
+SYNCHRON-X първо трябва да покаже подготвената задача и еднократното
+потвърждение, включително ред `Задача: <пълния test prompt>`. Ако точният prompt
+липсва, запиши `GITHUB_PROMPT_NOT_SHOWN` и не потвърждавай. Едва след копирано
+точно потвърждение се проверява, че е създаден само описаният ресурс, Copilot е
+реалният assignee и няма merge в `main`. Acceptance остава незавършен, докато
+cleanup не е проверен.
+
+## 3. Google — owner acceptance
+
+### Read-only
+
+1. Влез в SYNCHRON-X като owner и свържи Google през `/api/google/connect`.
+2. Провери `/api/google/status`, без да записваш account данни в доказателството.
+3. Изпълни по една read-only заявка за Calendar, Drive и Gmail.
+4. Запиши само кой capability е извикан и дали е успял. Не записвай заглавия,
+   участници, имена на файлове или съдържание на писма.
+
+### Calendar write с точно потвърждение
+
+Избери бъдещ свободен час и уникално заглавие без лични данни. Подготвящата
+заявка е във формата:
+
+```text
+Създай събитие: SYNCHRON-X acceptance <run-id> | ГГГГ-ММ-ДД ЧЧ:ММ | 5 | | Изолиран acceptance тест; изтрий след проверката
+```
+
+Първият отговор трябва ясно да каже, че събитието още не е записано, да покаже
+точните полета, включително target календара, и да върне еднократна фраза:
+
+```text
+Потвърждавам календарно събитие: <confirmation-id>
+```
+
+`prepareCalendarEvent()` обвързва потвърждението с `primary` calendar и трябва
+да покаже `Календар: основен (primary)` в отговора. Ако редът липсва, запиши
+`CALENDAR_TARGET_NOT_SHOWN`, не изпращай фразата и отчети Calendar write като
+`blocked`.
+
+Едва когато title, start, duration, timezone и target calendar са видими и
+проверени, след отделното точно потвърждение:
+
+1. провери, че е създадено точно едно събитие;
+2. провери заглавието и времето през Google Calendar;
+3. изтрий test събитието ръчно от Google Calendar;
+4. провери, че събитието вече липсва.
+
+SYNCHRON-X няма Calendar delete адаптер. Затова cleanup не се автоматизира и
+write тестът не започва, ако owner няма достъп да изтрие събитието ръчно.
+
+## Доказателство и резултат
+
+За всяка секция запиши минимален ред без лични данни:
+
+| Run ID | UTC | Production SHA | Provider | Read/write | Ресурс | Резултат | Cleanup |
+| ------ | --- | -------------- | -------- | ---------- | ------ | -------- | ------- |
+
+Допустими резултати: `passed`, `failed`, `blocked`, `not-run`. `blocked` не е
+`passed`. GitHub write в режим `COPILOT_AUTOMATION_DISABLED` се записва като
+`blocked` с успешна отрицателна контрола, а не като работещ write adapter.
+
+Owner acceptance е завършен само когато:
+
+- ChatGPT MCP read работи с owner OAuth identity;
+- GitHub owner OAuth status е connected, а отделният read adapter връща точния
+  SHA, без двете проверки да се смесват;
+- GitHub write е реално проверен след точно потвърждение; ако е `blocked`,
+  общият owner acceptance остава незавършен;
+- Google read работи за Calendar, Drive и Gmail;
+- Calendar write е проверен след видим target и точно потвърждение; ако target
+  липсва, общият owner acceptance остава незавършен;
+- всички временни външни ресурси са почистени и cleanup е проверен.
+
+При failure първо запиши provider, стъпка, безопасен error code и run ID. Не
+прави несвързана архитектурна промяна и не публикувай tokens или response body с
+лични данни.

--- a/src/services/calendarService.js
+++ b/src/services/calendarService.js
@@ -266,6 +266,7 @@ export async function prepareCalendarEvent({
         ? "Подготвих календарното напомняне, но още не съм го записал."
         : "Подготвих календарното събитие, но още не съм го записал.",
       `Заглавие: ${draft.title}`,
+      "Календар: основен (primary)",
       `Начало: ${draft.start.replace("T", " ")} (${draft.timeZone})`,
       ...(isReminder
         ? [`Напомняне: ${draft.reminderMinutes} минути преди`]

--- a/src/services/copilotTaskService.js
+++ b/src/services/copilotTaskService.js
@@ -807,11 +807,19 @@ export async function prepareCopilotTask({
   }
   splitRepository(repository);
   assertBaseRef(baseRef);
+  const cleanPrompt = typeof prompt === "string" ? prompt.trim() : "";
+  if (!cleanPrompt) {
+    throw new CopilotTaskError(
+      "Липсва кодова задача за Copilot.",
+      400,
+      "MISSING_COPILOT_PROMPT",
+    );
+  }
   const confirmation = await createDurableConfirmation({
     sessionId,
     action: "github.copilot:start_task",
     resource: { repository, baseRef },
-    params: { prompt },
+    params: { prompt: cleanPrompt },
   });
   return {
     confirmationId: confirmation.id,
@@ -820,6 +828,7 @@ export async function prepareCopilotTask({
       "Подготвих кодовата задача за GitHub Copilot.",
       `Хранилище: ${repository}`,
       `Начален клон: ${baseRef}`,
+      `Задача: ${cleanPrompt}`,
       "Copilot ще работи в отделен клон и ще създаде Pull Request. Няма да слива в main.",
       "За изпълнение изпрати точно:",
       `${CONFIRM_PREFIX} ${confirmation.id}`,

--- a/tests/calendarService.test.js
+++ b/tests/calendarService.test.js
@@ -111,6 +111,7 @@ test("prepares an exact one-time confirmation without creating an event", async 
   );
   assert.doesNotMatch(JSON.stringify(confirmations[0]), /google-session/u);
   assert.match(prepared.output, /още не съм го записал/u);
+  assert.match(prepared.output, /Календар: основен \(primary\)/u);
   assert.match(prepared.output, /confirmation-calendar/u);
 });
 

--- a/tests/copilotTaskService.test.js
+++ b/tests/copilotTaskService.test.js
@@ -425,6 +425,7 @@ test("requires an exact one-time confirmation before starting Copilot", async ()
     prompt: "Промени цвета на бутона Памет.",
   });
   assert.match(prepared.output, /Потвърждавам GitHub задача:/u);
+  assert.match(prepared.output, /Задача: Промени цвета на бутона Памет\./u);
   assert.equal(
     extractCopilotConfirmationId(
       `Потвърждавам GitHub задача: ${prepared.confirmationId}`,
@@ -457,6 +458,20 @@ test("requires an exact one-time confirmation before starting Copilot", async ()
         fetchImpl: copilotGraphqlFetch(),
       }),
     (error) => error.code === "CONFIRMATION_NOT_FOUND",
+  );
+});
+
+test("does not prepare a Copilot confirmation without an exact task", async () => {
+  const session = await connectedSession();
+
+  await assert.rejects(
+    () =>
+      prepareCopilotTask({
+        sessionId: "chat-session",
+        githubSessionId: session.id,
+        prompt: "   ",
+      }),
+    (error) => error.code === "MISSING_COPILOT_PROMPT",
   );
 });
 

--- a/tests/operationalDocumentation.test.js
+++ b/tests/operationalDocumentation.test.js
@@ -6,6 +6,7 @@ const read = (path) => readFileSync(new URL(path, import.meta.url), "utf8");
 const readme = read("../README.md");
 const agentInstructions = read("../AGENTS.md");
 const runbook = read("../docs/OPERATIONS_RUNBOOK.md");
+const ownerAcceptanceRunbook = read("../docs/OWNER_ACCEPTANCE_RUNBOOK.md");
 
 test("current documentation names the real chat provider and operations source", () => {
   assert.match(readme, /OpenAI Responses API/u);
@@ -33,4 +34,27 @@ test("operations runbook keeps rollback and destructive boundaries explicit", ()
     assert.match(runbook, new RegExp(marker, "u"));
   }
   assert.doesNotMatch(runbook, /rm\s+-rf|git\s+push\s+--force/u);
+});
+
+test("owner acceptance is repeatable, exact and never an unattended write", () => {
+  assert.match(runbook, /OWNER_ACCEPTANCE_RUNBOOK\.md/u);
+
+  for (const marker of [
+    "https://synchron.foundation/mcp",
+    "get_system_configuration",
+    "COPILOT_AUTOMATION_DISABLED",
+    "GitHub read adapter-ът използва сървърния read достъп/публичния API",
+    "GITHUB_PROMPT_NOT_SHOWN",
+    "Потвърждавам календарно събитие:",
+    "CALENDAR_TARGET_NOT_SHOWN",
+    "prepare → преглед на въздействието → точно потвърждение → execute → verify → cleanup",
+    "Не стартирай write acceptance от CI",
+  ]) {
+    assert.match(ownerAcceptanceRunbook, new RegExp(marker, "u"));
+  }
+
+  assert.doesNotMatch(
+    ownerAcceptanceRunbook,
+    /Authorization:\s*Bearer|MCP_ACCESS_TOKEN\s*=|refresh_token\s*=/u,
+  );
 });


### PR DESCRIPTION
## Какво променя

- добавя повторим owner acceptance runbook за ChatGPT MCP, GitHub и Google;
- показва точния Calendar target (`primary`) преди еднократното потвърждение;
- показва точната Copilot задача преди потвърждение и отхвърля празна задача;
- разграничава owner GitHub OAuth статуса от server-side/public GitHub read адаптера.

## Защо

Owner acceptance е следващата незавършена проверка. Прегледът показа, че target-ът и задачата са били обвързани с confirmation, но не са били достатъчно видими за човека преди външното write действие.

## Safety

- няма външно write действие, secret/config промяна, merge или deploy;
- Copilot automation остава изключена;
- няма промени в AI Core, Chat, Memory или OpenSearch;
- няма промени в production данни.

## Проверка

- `pnpm test`: 551/551;
- Prettier и `git diff --check`: успешно;
- независим review: няма P1/P2 забележки;
- production baseline остава на `32aab93e905984b5095266a2a832e31da5c7fa23`, със зелен production smoke.