### PR TITLE
Keep storage health reports readable through the edge

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -102,15 +102,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          response="$(curl --fail --silent --show-error \
-            --retry 3 --retry-delay 10 --retry-all-errors \
-            --max-time 30 \
-            https://synchron.foundation/health/dependencies)"
-          printf '%s' "${response}" | node -e '
+          dependencies_healthy=false
+          for attempt in 1 2 3; do
+            if response="$(curl --fail --silent --show-error \
+              --retry 2 --retry-delay 2 --retry-all-errors \
+              --max-time 30 \
+              https://synchron.foundation/health/storage-report)" &&
+              printf '%s' "${response}" | node -e '
             let input = "";
             process.stdin.on("data", (chunk) => { input += chunk; });
             process.stdin.on("end", () => {
-              const report = JSON.parse(input);
+              const report = JSON.parse(input).dependencies;
               const checks = report.checks || {};
               console.log(
                 `storage=${report.status} opensearch=${checks.opensearch?.status} supabase=${checks.supabase?.status}`,
@@ -124,7 +126,13 @@ jobs:
                 process.exit(1);
               }
             });
-          '
+            '; then
+              dependencies_healthy=true
+              break
+            fi
+            sleep $((attempt * 10))
+          done
+          test "${dependencies_healthy}" = "true"
 
       - name: Check backup coverage and OpenSearch restore-point inventory
         shell: bash
@@ -132,15 +140,15 @@ jobs:
           set -euo pipefail
           verified=false
           for attempt in 1 2 3; do
-            response="$(curl --silent --show-error \
+            if response="$(curl --fail --silent --show-error \
               --retry 2 --retry-delay 2 --retry-all-errors \
               --max-time 30 \
-              https://synchron.foundation/health/backups)"
-            if printf '%s' "${response}" | node -e '
+              https://synchron.foundation/health/storage-report)" &&
+              printf '%s' "${response}" | node -e '
               let input = "";
               process.stdin.on("data", (chunk) => { input += chunk; });
               process.stdin.on("end", () => {
-                const report = JSON.parse(input);
+                const report = JSON.parse(input).backups;
                 const backup = report.checks?.opensearch;
                 const supabase = report.checks?.supabase;
                 console.log(
@@ -158,7 +166,7 @@ jobs:
                   process.exit(1);
                 }
               });
-            '; then
+              '; then
               verified=true
               break
             fi

--- a/docs/CURRENT_PRODUCT_ACCEPTANCE.md
+++ b/docs/CURRENT_PRODUCT_ACCEPTANCE.md
@@ -44,9 +44,13 @@ production проверките винаги се установяват по
   runtime publishable key не може да докаже provider backup policy, затова
   статусът остава `unverified`. Отделната owner проверка вече доказва, че при
   текущия Free Plan project backup няма.
-- Scheduled production smoke проверява dependency и backup маршрутите. Тези
-  промени стават production доказателство едва след merge, deployment на точния
-  SHA и успешен `synchron/production-smoke` за същия SHA.
+- `GET /health/storage-report` обединява двата безопасни отчета с транспортен
+  HTTP `200`, така че edge 5xx страница да не скрива точния статус. Това не
+  превръща частичния backup отчет в зелено health доказателство.
+- Scheduled production smoke проверява dependency и backup отчетите чрез
+  `/health/storage-report`. Тези промени стават production доказателство едва
+  след merge, deployment на точния SHA и успешен `synchron/production-smoke`
+  за същия SHA.
 
 ## Още не е прието
 

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -61,6 +61,7 @@ curl --fail --silent --show-error https://synchron.foundation/health
 curl --fail --silent --show-error https://synchron.foundation/health/ready
 curl --fail --silent --show-error https://synchron.foundation/health/dependencies
 curl --silent --show-error https://synchron.foundation/health/backups
+curl --fail --silent --show-error https://synchron.foundation/health/storage-report
 curl --fail --silent --show-error https://synchron.foundation/api/auth/session
 ```
 
@@ -71,6 +72,11 @@ curl --fail --silent --show-error https://synchron.foundation/api/auth/session
 точния production cluster, но `provesRestore=false` означава, че възстановяване
 не е изпълнявано. Supabase backup статусът остава `unverified`, докато не бъде
 проверен чрез разрешен owner/management изглед.
+
+`/health/storage-report` връща същите два безопасни отчета в JSON с транспортен
+HTTP `200`, за да не бъдат скривани точните вътрешни статуси от edge 5xx
+страница. Той не променя health семантиката: production smoke оценява
+`dependencies.status` и `backups.status`, а не общия HTTP код на отчета.
 
 MCP каталогът е read-only JSON-RPC заявка:
 

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -225,8 +225,77 @@ export function createStorageBackupsHandler({
   };
 }
 
+function unavailableDependencyReport() {
+  return {
+    status: "unavailable",
+    checkedAt: new Date().toISOString(),
+    checks: {
+      opensearch: {
+        status: "unavailable",
+        errorCode: "STORAGE_DEPENDENCY_REPORT_FAILED",
+      },
+      supabase: {
+        status: "unavailable",
+        errorCode: "STORAGE_DEPENDENCY_REPORT_FAILED",
+      },
+    },
+  };
+}
+
+function unavailableBackupReport() {
+  return {
+    status: "unavailable",
+    checkedAt: new Date().toISOString(),
+    checks: {
+      opensearch: {
+        status: "unverified",
+        errorCode: "STORAGE_BACKUP_REPORT_FAILED",
+        fresh: false,
+        readOnlyCheck: true,
+        provesRestore: false,
+      },
+      supabase: {
+        status: "unverified",
+        errorCode: "SUPABASE_BACKUP_STATUS_NOT_VISIBLE_TO_RUNTIME",
+        readOnlyCheck: true,
+        provesRestore: false,
+      },
+    },
+  };
+}
+
+export function createStorageReportHandler({
+  loadDependencies = loadStorageDependencies,
+  loadBackups = loadStorageBackups,
+  now = () => new Date(),
+} = {}) {
+  return async function storageReportHandler(_req, res) {
+    setPrivateHealthHeaders(res);
+    const [dependenciesResult, backupsResult] = await Promise.allSettled([
+      loadDependencies(),
+      loadBackups(),
+    ]);
+    const dependencies =
+      dependenciesResult.status === "fulfilled"
+        ? dependenciesResult.value
+        : unavailableDependencyReport();
+    const backups =
+      backupsResult.status === "fulfilled"
+        ? publicBackupStatus(backupsResult.value)
+        : unavailableBackupReport();
+
+    res.status(200).json({
+      status: "reported",
+      checkedAt: now().toISOString(),
+      dependencies,
+      backups,
+    });
+  };
+}
+
 router.get("/dependencies", createStorageDependenciesHandler());
 router.get("/backups", createStorageBackupsHandler());
+router.get("/storage-report", createStorageReportHandler());
 
 export async function getBridgeDiagnosticsStatus({
   env = process.env,

--- a/tests/healthRoutes.test.js
+++ b/tests/healthRoutes.test.js
@@ -8,6 +8,7 @@ import {
   createReadinessHandler,
   createStorageBackupsHandler,
   createStorageDependenciesHandler,
+  createStorageReportHandler,
   getBridgeDiagnosticsStatus,
   getReadinessStatus,
   getRuntimeVersion,
@@ -212,6 +213,74 @@ test("backup health exposes status without counts, dates or resource ids", async
     serialized,
     /restorePointCount|oldestCreatedAt|newestCreatedAt|databaseId/u,
   );
+});
+
+test("storage report keeps partial evidence readable without changing health semantics", async () => {
+  const app = express();
+  app.get(
+    "/health/storage-report",
+    createStorageReportHandler({
+      loadDependencies: async () => ({
+        status: "healthy",
+        checkedAt: "2026-08-06T10:00:00.000Z",
+        checks: {
+          opensearch: { status: "healthy", memoryIndexReadable: true },
+          supabase: { status: "healthy" },
+        },
+      }),
+      loadBackups: async () => ({
+        status: "partially-verified",
+        checkedAt: "2026-08-06T10:00:00.000Z",
+        checks: {
+          opensearch: {
+            status: "verified",
+            fresh: true,
+            restorePointCount: 3,
+            newestCreatedAt: "2026-08-06T09:00:00.000Z",
+          },
+          supabase: {
+            status: "unverified",
+            errorCode: "SUPABASE_BACKUP_STATUS_NOT_VISIBLE_TO_RUNTIME",
+          },
+        },
+      }),
+      now: () => new Date("2026-08-06T10:00:01.000Z"),
+    }),
+  );
+
+  const response = await request(app).get("/health/storage-report").expect(200);
+  assert.equal(response.headers["cache-control"], "no-store, max-age=0");
+  assert.equal(response.body.status, "reported");
+  assert.equal(response.body.dependencies.status, "healthy");
+  assert.equal(response.body.backups.status, "partially-verified");
+  assert.equal(response.body.backups.checks.opensearch.provesRestore, false);
+  assert.doesNotMatch(
+    JSON.stringify(response.body.backups),
+    /restorePointCount|newestCreatedAt|databaseId/u,
+  );
+});
+
+test("storage report converts unexpected loader failures into safe fixed codes", async () => {
+  const app = express();
+  app.get(
+    "/health/storage-report",
+    createStorageReportHandler({
+      loadDependencies: async () => {
+        throw new Error("sensitive dependency failure");
+      },
+      loadBackups: async () => {
+        throw new Error("sensitive backup failure");
+      },
+    }),
+  );
+
+  const response = await request(app).get("/health/storage-report").expect(200);
+  const serialized = JSON.stringify(response.body);
+  assert.equal(response.body.dependencies.status, "unavailable");
+  assert.equal(response.body.backups.status, "unavailable");
+  assert.match(serialized, /STORAGE_DEPENDENCY_REPORT_FAILED/u);
+  assert.match(serialized, /STORAGE_BACKUP_REPORT_FAILED/u);
+  assert.doesNotMatch(serialized, /sensitive/u);
 });
 
 test("verified backup cache cannot outlive the remaining freshness window", () => {

--- a/tests/productionSmokeWorkflow.test.js
+++ b/tests/productionSmokeWorkflow.test.js
@@ -25,13 +25,21 @@ test("production smoke publishes a readable commit status without a custom secre
   assert.match(workflow, /ai-core-mark\.png/u);
   assert.match(workflow, /Check MCP tool catalog and OAuth challenge/u);
   assert.match(workflow, /Check OpenSearch and Supabase dependencies/u);
-  assert.match(workflow, /\/health\/dependencies/u);
+  assert.match(workflow, /\/health\/storage-report/u);
   assert.match(workflow, /memoryIndexReadable/u);
+  const dependencyStep = workflow
+    .split("- name: Check OpenSearch and Supabase dependencies")[1]
+    .split(
+      "- name: Check backup coverage and OpenSearch restore-point inventory",
+    )[0];
+  assert.match(dependencyStep, /dependencies_healthy=false/u);
+  assert.match(dependencyStep, /for attempt in 1 2 3/u);
+  assert.match(dependencyStep, /test "\$\{dependencies_healthy\}" = "true"/u);
   assert.match(
     workflow,
     /Check backup coverage and OpenSearch restore-point inventory/u,
   );
-  assert.match(workflow, /\/health\/backups/u);
+  assert.match(workflow, /JSON\.parse\(input\)\.backups/u);
   assert.match(workflow, /provesRestore/u);
   assert.match(workflow, /report\.status !== "partially-verified"/u);
   assert.match(workflow, /backup\?\.fresh !== true/u);
@@ -41,7 +49,8 @@ test("production smoke publishes a readable commit status without a custom secre
       "- name: Check backup coverage and OpenSearch restore-point inventory",
     )[1]
     .split("- name: Check production memory acceptance")[0];
-  assert.doesNotMatch(backupStep, /curl --fail/u);
+  assert.match(backupStep, /curl --fail/u);
+  assert.match(backupStep, /if response="\$\(curl --fail/u);
   assert.match(workflow, /get_github_copilot_task_status/u);
   assert.match(workflow, /names\.length === expected\.length/u);
   assert.match(workflow, /challenge_headers/u);


### PR DESCRIPTION
## Причина

Production smoke получава Cloudflare HTTP 504 за `/health/dependencies` и `/health/backups`, което скрива безопасния JSON отчет и точната вътрешна причина.

## Промяна

- добавя `GET /health/storage-report` с HTTP 200 транспортен envelope и fail-closed вложени статуси;
- запазва оригиналната 200/503 семантика на canonical health маршрутите;
- филтрира backup IDs, бройки, дати и exception текст;
- насочва production smoke към вложените dependency/backup статуси;
- повтаря както транспортните, така и логическите временни откази;
- обновява runbook и текущото production acceptance описание.

## Проверка

- таргетирани тестове: 16/16
- пълен пакет: 585/585
- `git diff --cached --check`: чист

Продуктовите UI насоки не са смесени в този emergency health PR; те остават за отделен последващ етап.