### PR TITLE
Align Supabase health with the user auth connection

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -114,14 +114,19 @@ jobs:
             process.stdin.on("end", () => {
               const report = JSON.parse(input).dependencies;
               const checks = report.checks || {};
+              const allowedSupabaseSources = new Set([
+                "runtime",
+                "public-bootstrap",
+              ]);
               console.log(
-                `storage=${report.status} opensearch=${checks.opensearch?.status} supabase=${checks.supabase?.status}`,
+                `storage=${report.status} opensearch=${checks.opensearch?.status} supabase=${checks.supabase?.status} supabase-source=${checks.supabase?.connectionSource}`,
               );
               if (
                 report.status !== "healthy" ||
                 checks.opensearch?.status !== "healthy" ||
                 checks.opensearch?.memoryIndexReadable !== true ||
-                checks.supabase?.status !== "healthy"
+                checks.supabase?.status !== "healthy" ||
+                !allowedSupabaseSources.has(checks.supabase?.connectionSource)
               ) {
                 process.exit(1);
               }

--- a/src/config/testerAuthBootstrap.js
+++ b/src/config/testerAuthBootstrap.js
@@ -1,7 +1,41 @@
-// Supabase publishable keys are designed for public clients. This file contains
-// no service-role key and no secret. The two private bootstrap values are
-// generated inside production and stored as encrypted DigitalOcean variables.
+// The Supabase URL and publishable key are public client configuration, not
+// secrets. Private session and invite values are derived inside production and
+// are never stored in this file.
 export const TESTER_AUTH_BOOTSTRAP = Object.freeze({
   projectUrl: "https://ahrimuhroxjmtojmhrfl.supabase.co",
   publishableKey: "sb_publishable_loKxmAIkhJiNiGB4HLKX1A_u2WtD44N",
 });
+
+export function normalizeTesterAuthProjectUrl(value) {
+  if (typeof value !== "string" || !value.trim()) return "";
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === "https:" ? url.origin : "";
+  } catch {
+    return "";
+  }
+}
+
+export function normalizeTesterAuthPublishableKey(value) {
+  const key = typeof value === "string" ? value.trim() : "";
+  return key.startsWith("sb_publishable_") || key.split(".").length === 3
+    ? key
+    : "";
+}
+
+export function resolveTesterAuthConnection(env = process.env) {
+  const runtimeProjectUrl = normalizeTesterAuthProjectUrl(env.SUPABASE_URL);
+  const runtimePublishableKey = normalizeTesterAuthPublishableKey(
+    env.SUPABASE_PUBLISHABLE_KEY,
+  );
+  const runtimeReady = Boolean(runtimeProjectUrl && runtimePublishableKey);
+  return Object.freeze({
+    projectUrl: runtimeReady
+      ? runtimeProjectUrl
+      : normalizeTesterAuthProjectUrl(TESTER_AUTH_BOOTSTRAP.projectUrl),
+    publishableKey: runtimeReady
+      ? runtimePublishableKey
+      : normalizeTesterAuthPublishableKey(TESTER_AUTH_BOOTSTRAP.publishableKey),
+    connectionSource: runtimeReady ? "runtime" : "public-bootstrap",
+  });
+}

--- a/src/services/storageHealthService.js
+++ b/src/services/storageHealthService.js
@@ -102,12 +102,18 @@ async function inspectSupabase({ checkSupabase, timeoutMs }) {
       timeoutMs,
       "SUPABASE_TIMEOUT",
     );
+    const connectionSource = ["runtime", "public-bootstrap"].includes(
+      result?.connectionSource,
+    )
+      ? result.connectionSource
+      : null;
     return {
       status: result?.status === "healthy" ? "healthy" : "unavailable",
       responseTimeMs:
         Number.isFinite(result?.responseTimeMs) && result.responseTimeMs >= 0
           ? result.responseTimeMs
           : null,
+      ...(connectionSource ? { connectionSource } : {}),
       errorCode: result?.status === "healthy" ? null : "SUPABASE_UNAVAILABLE",
     };
   } catch (error) {

--- a/src/services/supabaseService.js
+++ b/src/services/supabaseService.js
@@ -1,4 +1,7 @@
-import { TESTER_AUTH_BOOTSTRAP } from "../config/testerAuthBootstrap.js";
+import {
+  normalizeTesterAuthPublishableKey,
+  resolveTesterAuthConnection,
+} from "../config/testerAuthBootstrap.js";
 
 const DEFAULT_TIMEOUT_MS = 10000;
 
@@ -45,58 +48,33 @@ function normalizeProjectUrl(value) {
   return url.origin;
 }
 
-function normalizePublishableKey(value) {
-  const key = typeof value === "string" ? value.trim() : "";
-  return key.startsWith("sb_publishable_") || key.split(".").length === 3
-    ? key
-    : "";
-}
-
-function isAppPlatformEncryptedPlaceholder(value) {
-  const normalized = typeof value === "string" ? value.trim() : "";
-  return /^EV\[\d+:[^\]\r\n]+\]$/u.test(normalized);
-}
-
-function shouldUsePublicBootstrap(value) {
-  const normalized = typeof value === "string" ? value.trim() : "";
-  return !normalized || isAppPlatformEncryptedPlaceholder(normalized);
-}
-
-function resolveRuntimeProjectUrl(env = process.env) {
-  return normalizeProjectUrl(
-    shouldUsePublicBootstrap(env.SUPABASE_URL)
-      ? TESTER_AUTH_BOOTSTRAP.projectUrl
-      : env.SUPABASE_URL,
+export async function checkSupabaseStatus(options = {}) {
+  const {
+    fetchImpl = fetch,
+    timeoutMs,
+    env = process.env,
+  } = options;
+  const hasProjectUrl = Object.hasOwn(options, "projectUrl");
+  const hasPublishableKey = Object.hasOwn(options, "publishableKey");
+  if (hasProjectUrl !== hasPublishableKey) {
+    throw new SupabaseServiceError(
+      "Supabase връзката трябва да съдържа адрес и публичен ключ.",
+      503,
+      "SUPABASE_NOT_CONFIGURED",
+    );
+  }
+  const connection = hasProjectUrl
+    ? {
+        projectUrl: options.projectUrl,
+        publishableKey: options.publishableKey,
+        connectionSource: "explicit",
+      }
+    : resolveTesterAuthConnection(env);
+  const url = normalizeProjectUrl(connection.projectUrl);
+  const resolvedPublishableKey = normalizeTesterAuthPublishableKey(
+    connection.publishableKey,
   );
-}
-
-function resolveRuntimePublishableKey(env = process.env) {
-  return normalizePublishableKey(
-    shouldUsePublicBootstrap(env.SUPABASE_PUBLISHABLE_KEY)
-      ? TESTER_AUTH_BOOTSTRAP.publishableKey
-      : env.SUPABASE_PUBLISHABLE_KEY,
-  );
-}
-
-export async function checkSupabaseStatus({
-  fetchImpl = fetch,
-  projectUrl,
-  publishableKey,
-  timeoutMs,
-  env = process.env,
-} = {}) {
-  const url = normalizeProjectUrl(
-    projectUrl === undefined ? resolveRuntimeProjectUrl(env) : projectUrl,
-  );
-  const resolvedPublishableKey =
-    publishableKey === undefined
-      ? resolveRuntimePublishableKey(env)
-      : publishableKey;
-  if (
-    typeof resolvedPublishableKey !== "string" ||
-    !resolvedPublishableKey.trim() ||
-    isAppPlatformEncryptedPlaceholder(resolvedPublishableKey)
-  ) {
+  if (!resolvedPublishableKey) {
     throw new SupabaseServiceError(
       "Supabase ключът за достъп не е конфигуриран.",
       503,
@@ -134,6 +112,7 @@ export async function checkSupabaseStatus({
       status: "healthy",
       service: "Supabase API",
       responseTimeMs: Date.now() - startedAt,
+      connectionSource: connection.connectionSource,
     });
   } catch (error) {
     if (error instanceof SupabaseServiceError) throw error;

--- a/src/services/userAuthService.js
+++ b/src/services/userAuthService.js
@@ -6,7 +6,7 @@ import {
   randomBytes,
   scryptSync,
 } from "node:crypto";
-import { TESTER_AUTH_BOOTSTRAP } from "../config/testerAuthBootstrap.js";
+import { resolveTesterAuthConnection } from "../config/testerAuthBootstrap.js";
 import {
   approveTesterAccess,
   assertTesterAccess,
@@ -26,23 +26,6 @@ export class UserAuthError extends Error {
     this.status = status;
     this.code = code;
   }
-}
-
-function normalizeProjectUrl(value) {
-  if (typeof value !== "string" || !value.trim()) return "";
-  try {
-    const url = new URL(value.trim());
-    return url.protocol === "https:" ? url.origin : "";
-  } catch {
-    return "";
-  }
-}
-
-function normalizePublishableKey(value) {
-  const key = typeof value === "string" ? value.trim() : "";
-  return key.startsWith("sb_publishable_") || key.split(".").length === 3
-    ? key
-    : "";
 }
 
 function sessionSecret(env = process.env) {
@@ -78,12 +61,7 @@ export function getTesterInviteCode(env = process.env) {
 }
 
 function authConfig(env = process.env) {
-  const projectUrl =
-    normalizeProjectUrl(env.SUPABASE_URL) ||
-    normalizeProjectUrl(TESTER_AUTH_BOOTSTRAP.projectUrl);
-  const publishableKey =
-    normalizePublishableKey(env.SUPABASE_PUBLISHABLE_KEY) ||
-    normalizePublishableKey(TESTER_AUTH_BOOTSTRAP.publishableKey);
+  const { projectUrl, publishableKey } = resolveTesterAuthConnection(env);
   return {
     projectUrl,
     publishableKey,

--- a/tests/productionSmokeWorkflow.test.js
+++ b/tests/productionSmokeWorkflow.test.js
@@ -34,6 +34,10 @@ test("production smoke publishes a readable commit status without a custom secre
     )[0];
   assert.match(dependencyStep, /dependencies_healthy=false/u);
   assert.match(dependencyStep, /for attempt in 1 2 3/u);
+  assert.match(dependencyStep, /"runtime"/u);
+  assert.match(dependencyStep, /"public-bootstrap"/u);
+  assert.match(dependencyStep, /connectionSource/u);
+  assert.match(dependencyStep, /allowedSupabaseSources\.has/u);
   assert.match(dependencyStep, /test "\$\{dependencies_healthy\}" = "true"/u);
   assert.match(
     workflow,

--- a/tests/storageHealthService.test.js
+++ b/tests/storageHealthService.test.js
@@ -56,7 +56,7 @@ test("storage health forwards its timeout to the real Supabase abort signal", as
       checkSupabaseStatus({
         ...options,
         projectUrl: "https://example.supabase.co",
-        publishableKey: "public-test-key",
+        publishableKey: "sb_publishable_public_test_key_1234567890",
         fetchImpl: async (_url, { signal }) =>
           new Promise((_resolve, reject) => {
             signal.addEventListener(
@@ -107,9 +107,17 @@ test("storage health uses the public bootstrap for App Platform placeholders", a
 
   assert.equal(report.status, "healthy");
   assert.equal(report.checks.supabase.status, "healthy");
+  assert.equal(
+    report.checks.supabase.connectionSource,
+    "public-bootstrap",
+  );
   assert.doesNotMatch(
     JSON.stringify(report),
     new RegExp(TESTER_AUTH_BOOTSTRAP.publishableKey, "u"),
+  );
+  assert.doesNotMatch(
+    JSON.stringify(report),
+    new RegExp(new URL(TESTER_AUTH_BOOTSTRAP.projectUrl).hostname, "u"),
   );
 });
 

--- a/tests/supabaseService.test.js
+++ b/tests/supabaseService.test.js
@@ -7,13 +7,15 @@ import {
 } from "../src/services/supabaseService.js";
 import { TESTER_AUTH_BOOTSTRAP } from "../src/config/testerAuthBootstrap.js";
 
+const TEST_PUBLISHABLE_KEY = "sb_publishable_test_key_1234567890";
+
 test("checks Supabase API without returning its key", async () => {
   const result = await checkSupabaseStatus({
     projectUrl: "https://project.supabase.co",
-    publishableKey: "test-publishable-key",
+    publishableKey: TEST_PUBLISHABLE_KEY,
     fetchImpl: async (url, options) => {
       assert.equal(url, "https://project.supabase.co/auth/v1/settings");
-      assert.equal(options.headers.apikey, "test-publishable-key");
+      assert.equal(options.headers.apikey, TEST_PUBLISHABLE_KEY);
       assert.equal(options.headers.Accept, "application/json");
       assert.equal(options.headers.Authorization, undefined);
       return new Response("{}", { status: 200 });
@@ -22,6 +24,7 @@ test("checks Supabase API without returning its key", async () => {
 
   assert.equal(result.status, "healthy");
   assert.equal(result.service, "Supabase API");
+  assert.equal(result.connectionSource, "explicit");
   assert.equal("publishableKey" in result, false);
 });
 
@@ -45,6 +48,7 @@ test("uses the public bootstrap when App Platform exposes encrypted placeholders
   });
 
   assert.equal(result.status, "healthy");
+  assert.equal(result.connectionSource, "public-bootstrap");
 });
 
 test("uses the public bootstrap when optional runtime values are omitted", async () => {
@@ -64,57 +68,76 @@ test("uses the public bootstrap when optional runtime values are omitted", async
   });
 
   assert.equal(result.status, "healthy");
+  assert.equal(result.connectionSource, "public-bootstrap");
 });
 
-test("does not hide an ordinary invalid runtime URL", async () => {
-  await assert.rejects(
-    () =>
-      checkSupabaseStatus({
-        env: {
-          SUPABASE_URL: "not-a-url",
-          SUPABASE_PUBLISHABLE_KEY: TESTER_AUTH_BOOTSTRAP.publishableKey,
-        },
-      }),
-    (error) =>
-      error instanceof SupabaseServiceError &&
-      error.code === "SUPABASE_INVALID_URL",
-  );
+test("uses the whole public bootstrap pair when the runtime URL is invalid", async () => {
+  const result = await checkSupabaseStatus({
+    env: {
+      SUPABASE_URL: "not-a-url",
+      SUPABASE_PUBLISHABLE_KEY: TESTER_AUTH_BOOTSTRAP.publishableKey,
+    },
+    fetchImpl: async (url, options) => {
+      assert.equal(
+        url,
+        `${TESTER_AUTH_BOOTSTRAP.projectUrl}/auth/v1/settings`,
+      );
+      assert.equal(
+        options.headers.apikey,
+        TESTER_AUTH_BOOTSTRAP.publishableKey,
+      );
+      return new Response("{}", { status: 200 });
+    },
+  });
+
+  assert.equal(result.status, "healthy");
+  assert.equal(result.connectionSource, "public-bootstrap");
 });
 
-test("does not hide an insecure runtime URL", async () => {
-  await assert.rejects(
-    () =>
-      checkSupabaseStatus({
-        env: {
-          SUPABASE_URL: "http://project.supabase.co",
-          SUPABASE_PUBLISHABLE_KEY: TESTER_AUTH_BOOTSTRAP.publishableKey,
-        },
-      }),
-    (error) =>
-      error instanceof SupabaseServiceError &&
-      error.code === "SUPABASE_INSECURE_URL",
-  );
+test("uses the whole public bootstrap pair when the runtime URL is insecure", async () => {
+  const result = await checkSupabaseStatus({
+    env: {
+      SUPABASE_URL: "http://project.supabase.co",
+      SUPABASE_PUBLISHABLE_KEY: TESTER_AUTH_BOOTSTRAP.publishableKey,
+    },
+    fetchImpl: async (url, options) => {
+      assert.equal(
+        url,
+        `${TESTER_AUTH_BOOTSTRAP.projectUrl}/auth/v1/settings`,
+      );
+      assert.equal(
+        options.headers.apikey,
+        TESTER_AUTH_BOOTSTRAP.publishableKey,
+      );
+      return new Response("{}", { status: 200 });
+    },
+  });
+
+  assert.equal(result.status, "healthy");
+  assert.equal(result.connectionSource, "public-bootstrap");
 });
 
-test("does not replace an ordinary invalid runtime key", async () => {
-  let fetchCalled = false;
-  await assert.rejects(
-    () =>
-      checkSupabaseStatus({
-        env: {
-          SUPABASE_URL: "https://project.supabase.co",
-          SUPABASE_PUBLISHABLE_KEY: "not-a-publishable-key",
-        },
-        fetchImpl: async () => {
-          fetchCalled = true;
-          return new Response("{}", { status: 200 });
-        },
-      }),
-    (error) =>
-      error instanceof SupabaseServiceError &&
-      error.code === "SUPABASE_NOT_CONFIGURED",
-  );
-  assert.equal(fetchCalled, false);
+test("uses the whole public bootstrap pair when the runtime key is invalid", async () => {
+  const result = await checkSupabaseStatus({
+    env: {
+      SUPABASE_URL: "https://project.supabase.co",
+      SUPABASE_PUBLISHABLE_KEY: "not-a-publishable-key",
+    },
+    fetchImpl: async (url, options) => {
+      assert.equal(
+        url,
+        `${TESTER_AUTH_BOOTSTRAP.projectUrl}/auth/v1/settings`,
+      );
+      assert.equal(
+        options.headers.apikey,
+        TESTER_AUTH_BOOTSTRAP.publishableKey,
+      );
+      return new Response("{}", { status: 200 });
+    },
+  });
+
+  assert.equal(result.status, "healthy");
+  assert.equal(result.connectionSource, "public-bootstrap");
 });
 
 test("prefers a valid runtime connection over the public bootstrap", async () => {
@@ -134,42 +157,27 @@ test("prefers a valid runtime connection over the public bootstrap", async () =>
   });
 
   assert.equal(result.status, "healthy");
+  assert.equal(result.connectionSource, "runtime");
 });
 
-test("resolves partial explicit overrides independently", async () => {
-  const explicitUrlResult = await checkSupabaseStatus({
-    projectUrl: "https://explicit-project.supabase.co",
-    env: {
-      SUPABASE_URL: "not-a-url",
-      SUPABASE_PUBLISHABLE_KEY: "sb_publishable_runtime_key",
+test("rejects partial or explicitly undefined connection overrides", async () => {
+  const cases = [
+    { projectUrl: "https://explicit-project.supabase.co" },
+    { publishableKey: TEST_PUBLISHABLE_KEY },
+    { projectUrl: undefined, publishableKey: TEST_PUBLISHABLE_KEY },
+    {
+      projectUrl: "https://explicit-project.supabase.co",
+      publishableKey: undefined,
     },
-    fetchImpl: async (url, options) => {
-      assert.equal(
-        url,
-        "https://explicit-project.supabase.co/auth/v1/settings",
-      );
-      assert.equal(options.headers.apikey, "sb_publishable_runtime_key");
-      return new Response("{}", { status: 200 });
-    },
-  });
-  const explicitKeyResult = await checkSupabaseStatus({
-    publishableKey: "explicit-test-key",
-    env: {
-      SUPABASE_URL: "https://runtime-project.supabase.co",
-      SUPABASE_PUBLISHABLE_KEY: "not-a-publishable-key",
-    },
-    fetchImpl: async (url, options) => {
-      assert.equal(
-        url,
-        "https://runtime-project.supabase.co/auth/v1/settings",
-      );
-      assert.equal(options.headers.apikey, "explicit-test-key");
-      return new Response("{}", { status: 200 });
-    },
-  });
-
-  assert.equal(explicitUrlResult.status, "healthy");
-  assert.equal(explicitKeyResult.status, "healthy");
+  ];
+  for (const connection of cases) {
+    await assert.rejects(
+      () => checkSupabaseStatus({ ...connection, env: {} }),
+      (error) =>
+        error instanceof SupabaseServiceError &&
+        error.code === "SUPABASE_NOT_CONFIGURED",
+    );
+  }
 });
 
 test("keeps an explicitly supplied invalid project URL fail-closed", async () => {
@@ -177,7 +185,7 @@ test("keeps an explicitly supplied invalid project URL fail-closed", async () =>
     () =>
       checkSupabaseStatus({
         projectUrl: "EV[1:encrypted-placeholder]",
-        publishableKey: "test-key",
+        publishableKey: TEST_PUBLISHABLE_KEY,
       }),
     (error) =>
       error instanceof SupabaseServiceError &&
@@ -223,7 +231,7 @@ test("requires a protected Supabase connection", async () => {
     () =>
       checkSupabaseStatus({
         projectUrl: "http://project.supabase.co",
-        publishableKey: "test-key",
+        publishableKey: TEST_PUBLISHABLE_KEY,
       }),
     (error) =>
       error instanceof SupabaseServiceError &&
@@ -236,7 +244,7 @@ test("aborts a blocked Supabase upstream request", async () => {
     () =>
       checkSupabaseStatus({
         projectUrl: "https://project.supabase.co",
-        publishableKey: "test-key",
+        publishableKey: TEST_PUBLISHABLE_KEY,
         timeoutMs: 5,
         fetchImpl: async (_url, { signal }) =>
           new Promise((_, reject) => {
@@ -259,7 +267,7 @@ test("does not expose an upstream Supabase response body", async () => {
     () =>
       checkSupabaseStatus({
         projectUrl: "https://project.supabase.co",
-        publishableKey: "test-key",
+        publishableKey: TEST_PUBLISHABLE_KEY,
         fetchImpl: async () =>
           new Response('{"secret":"must-not-leak"}', { status: 503 }),
       }),

--- a/tests/userAuthService.test.js
+++ b/tests/userAuthService.test.js
@@ -15,6 +15,10 @@ import {
   userSessionCookie,
   UserAuthError,
 } from "../src/services/userAuthService.js";
+import {
+  resolveTesterAuthConnection,
+  TESTER_AUTH_BOOTSTRAP,
+} from "../src/config/testerAuthBootstrap.js";
 
 const ENV = {
   SUPABASE_URL: "https://project.supabase.co",
@@ -52,6 +56,35 @@ test("detects complete auth and closed/open tester registration", () => {
     }),
     true,
   );
+});
+
+test("auth resolves the Supabase URL and key as one atomic connection", () => {
+  for (const partialRuntime of [
+    {
+      SUPABASE_URL: "not-a-url",
+      SUPABASE_PUBLISHABLE_KEY: ENV.SUPABASE_PUBLISHABLE_KEY,
+    },
+    {
+      SUPABASE_URL: ENV.SUPABASE_URL,
+      SUPABASE_PUBLISHABLE_KEY: "not-a-publishable-key",
+    },
+  ]) {
+    const connection = resolveTesterAuthConnection(partialRuntime);
+    assert.deepEqual(connection, {
+      ...TESTER_AUTH_BOOTSTRAP,
+      connectionSource: "public-bootstrap",
+    });
+    assert.equal(
+      getUserAuthConfigurationStatus({
+        ...partialRuntime,
+        SUPABASE_SESSION_ENCRYPTION_KEY:
+          ENV.SUPABASE_SESSION_ENCRYPTION_KEY,
+      }).projectConnection,
+      true,
+    );
+  }
+
+  assert.equal(resolveTesterAuthConnection(ENV).connectionSource, "runtime");
 });
 
 test("derives isolated tester secrets from the existing owner session secret", () => {


### PR DESCRIPTION
## Реална причина

Exact-SHA production на PR #288 остана с `SUPABASE_INVALID_URL`, въпреки че registration/auth статусът е ready. Owner-safe конфигурационният отчет потвърди, че DigitalOcean променливите съществуват, но не показва стойности. Кодът показа разминаването: user auth вече използва публичния bootstrap при невалидна runtime двойка, докато health имаше отделна по-тясна логика.

## Поправка

- един общ config resolver за user auth и Supabase health;
- URL + publishable key се избират атомарно: цялата валидна runtime двойка или цялата публична bootstrap двойка;
- explicit/partial/undefined overrides остават fail-closed чрез `Object.hasOwn()`;
- публичният health излага само `connectionSource: runtime | public-bootstrap`, никога URL/key;
- production smoke изисква `supabase.status=healthy` и allowlisted source label;
- не се променя DigitalOcean spec и не се добавя/ротира secret.

## Проверка

- таргетирани тестове: 60/60;
- пълен комбиниран пакет: 628/628;
- независим review: без P1/P2 findings;
- `git diff --cached --check`: чист.