### PR TITLE
Allow the production smoke check to accept the expanded MCP catalog

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -261,6 +261,11 @@ jobs:
                     "get_github_copilot_task_status",
                     "prepare_github_merged_branch_cleanup",
                     "confirm_github_merged_branch_cleanup",
+                    "list_available_capabilities",
+                    "list_action_history",
+                    "list_tasks",
+                    "create_task_draft",
+                    "list_projects",
                   ];
                   const names = Array.isArray(tools) ? tools.map((tool) => tool.name) : [];
                   const tracker = tools?.find(
@@ -281,8 +286,26 @@ jobs:
                   const confirmWwwScopes = confirmWww?.securitySchemes?.flatMap(
                     (scheme) => scheme.scopes || [],
                   ) || [];
+                  const capabilities = tools?.find(
+                    (tool) => tool.name === "list_available_capabilities",
+                  );
+                  const capabilitiesScopes = capabilities?.securitySchemes?.flatMap(
+                    (scheme) => scheme.scopes || [],
+                  ) || [];
+                  const actionHistory = tools?.find(
+                    (tool) => tool.name === "list_action_history",
+                  );
+                  const actionHistoryScopes = actionHistory?.securitySchemes?.flatMap(
+                    (scheme) => scheme.scopes || [],
+                  ) || [];
+                  const taskDraft = tools?.find(
+                    (tool) => tool.name === "create_task_draft",
+                  );
+                  const taskDraftScopes = taskDraft?.securitySchemes?.flatMap(
+                    (scheme) => scheme.scopes || [],
+                  ) || [];
                   const valid =
-                    names.length === expected.length &&
+                    names.length >= expected.length &&
                     new Set(names).size === names.length &&
                     expected.every((name) => names.includes(name)) &&
                     tracker?.annotations?.readOnlyHint === true &&
@@ -290,8 +313,19 @@ jobs:
                     conversation?.annotations?.destructiveHint === false &&
                     conversationScopes.includes("synchron:agent.chat") &&
                     confirmWww?.annotations?.destructiveHint === true &&
-                    confirmWwwScopes.includes("synchron:infrastructure.write");
-                  console.log(JSON.stringify({ names, trackerReadOnly: tracker?.annotations?.readOnlyHint }));
+                    confirmWwwScopes.includes("synchron:infrastructure.write") &&
+                    capabilities?.annotations?.readOnlyHint === true &&
+                    capabilitiesScopes.includes("synchron:read") &&
+                    actionHistory?.annotations?.readOnlyHint === true &&
+                    actionHistoryScopes.includes("synchron:audit.read") &&
+                    taskDraft?.annotations?.readOnlyHint === false &&
+                    taskDraft?.annotations?.destructiveHint === false &&
+                    taskDraftScopes.includes("synchron:tasks.write");
+                  console.log(JSON.stringify({
+                    catalogSize: names.length,
+                    missingExpected: expected.filter((name) => !names.includes(name)),
+                    trackerReadOnly: tracker?.annotations?.readOnlyHint,
+                  }));
                   process.exit(valid ? 0 : 1);
                 } catch {
                   process.exit(1);

--- a/tests/productionSmokeWorkflow.test.js
+++ b/tests/productionSmokeWorkflow.test.js
@@ -56,7 +56,21 @@ test("production smoke publishes a readable commit status without a custom secre
   assert.match(backupStep, /curl --fail/u);
   assert.match(backupStep, /if response="\$\(curl --fail/u);
   assert.match(workflow, /get_github_copilot_task_status/u);
-  assert.match(workflow, /names\.length === expected\.length/u);
+  for (const toolName of [
+    "list_available_capabilities",
+    "list_action_history",
+    "list_tasks",
+    "create_task_draft",
+    "list_projects",
+  ]) {
+    assert.match(workflow, new RegExp(toolName, "u"));
+  }
+  assert.match(workflow, /names\.length >= expected\.length/u);
+  assert.match(workflow, /new Set\(names\)\.size === names\.length/u);
+  assert.match(workflow, /expected\.every\(\(name\) => names\.includes\(name\)\)/u);
+  assert.doesNotMatch(workflow, /names\.length === expected\.length/u);
+  assert.match(workflow, /synchron:audit\.read/u);
+  assert.match(workflow, /synchron:tasks\.write/u);
   assert.match(workflow, /challenge_headers/u);
   assert.match(workflow, /synchron:read/u);
   assert.match(workflow, /--dump-header -/u);


### PR DESCRIPTION
## Причина
Production работи на точния SHA и всички health проверки минават, но smoke очакваше MCP каталог с точно 14 инструмента. След Action Center реалният защитен каталог съдържа 50 инструмента.

## Поправка
- допуска допълнителни бъдещи инструменти;
- продължава да изисква уникални имена и целия задължителен набор;
- добавя ключовите Action Center инструменти към задължителния набор;
- проверява read/write annotations и OAuth scopes за capabilities, audit history и task drafts;
- обновява regression теста да забранява връщане към exact-count договора.

## Проверка
- целеви тест: 2/2;
- пълен пакет: 628/628;
- `git diff --check`: clean;
- реален production каталог: 50 инструмента, 19 задължителни, 0 липсващи, 0 дублирани, договорът минава;
- независим review: няма P1/P2 findings.