### PR TITLE
Fix ChatGPT MCP OAuth linking and grant controls

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -345,16 +345,39 @@ jobs:
             exit 1
           fi
 
-          challenge_headers="$(curl --silent --show-error \
+          challenge_headers="$(mktemp)"
+          challenge_body="$(mktemp)"
+          challenge_status="$(curl --silent --show-error \
             --max-time 30 \
-            --dump-header - \
-            --output /dev/null \
+            --dump-header "${challenge_headers}" \
+            --output "${challenge_body}" \
+            --write-out '%{http_code}' \
             --header 'Content-Type: application/json' \
             --header 'Accept: application/json, text/event-stream' \
             --data '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_github_copilot_task_status","arguments":{"issueNumber":83}}}' \
             https://synchron.foundation/mcp)"
-          printf '%s' "${challenge_headers}" \
-            | grep -Eiq '^www-authenticate:.*Bearer.*synchron:read'
+          test "${challenge_status}" = "401"
+          grep -Eiq '^www-authenticate:.*Bearer.*synchron:read.*error="invalid_token".*error_description="' "${challenge_headers}"
+          node -e '
+            const { readFileSync } = require("node:fs");
+            const response = JSON.parse(readFileSync(process.argv[1], "utf8"));
+            const result = response.result;
+            const challenges = result?._meta?.["mcp/www_authenticate"];
+            const valid =
+              result?.isError === true &&
+              Array.isArray(result.content) &&
+              result.content.some((item) => item?.type === "text") &&
+              Array.isArray(challenges) &&
+              challenges.some(
+                (challenge) =>
+                  typeof challenge === "string" &&
+                  challenge.includes("oauth-protected-resource") &&
+                  challenge.includes("synchron:read") &&
+                  challenge.includes("error=\"invalid_token\"") &&
+                  challenge.includes("error_description=\""),
+              );
+            process.exit(valid ? 0 : 1);
+          ' "${challenge_body}"
 
       - name: Check tester auth readiness
         shell: bash

--- a/public/app.js
+++ b/public/app.js
@@ -768,9 +768,41 @@ function permissionAction(item, toolMap, googleConnected, githubConnected) {
   return "";
 }
 
-function connectionControls(googleConnected, githubConnected) {
+function connectionControls(
+  googleConnected,
+  githubConnected,
+  chatgptConnection = {},
+) {
+  const chatgptConnected = Boolean(chatgptConnection.connected);
+  const chatgptConfigured = chatgptConnection.configured !== false;
+  const chatgptUnavailable = Boolean(chatgptConnection.unavailable);
+  const chatgptGrants = Array.isArray(chatgptConnection.grants)
+    ? chatgptConnection.grants
+    : [];
+  const chatgptScopes = [
+    ...new Set(
+      chatgptGrants.flatMap((grant) => grant.scopes || []),
+    ),
+  ];
+  const chatgptDescription = chatgptUnavailable
+    ? "Състоянието временно не е достъпно"
+    : chatgptConnected
+      ? `${chatgptGrants.length} активни MCP връзки · ${chatgptScopes.length} разрешения`
+      : chatgptConfigured
+        ? "Няма активна MCP връзка"
+        : "OAuth връзката не е конфигурирана";
   return `
     <section class="connection-control-grid" aria-label="Управление на връзките">
+      <article class="connection-control-card">
+        <div>
+          <strong>ChatGPT</strong>
+          <p>${escapeHtml(chatgptDescription)}</p>
+          ${chatgptScopes.length ? `<small>${escapeHtml(chatgptScopes.join(" · "))}</small>` : ""}
+        </div>
+        <button type="button" class="tool-connect-btn" data-${chatgptConnected ? "disconnect" : "connect"}-service="chatgpt" ${chatgptConfigured ? "" : "disabled"}>
+          ${chatgptConnected ? "Спри достъпа" : "Отвори ChatGPT"}
+        </button>
+      </article>
       <article class="connection-control-card">
         <div><strong>Google</strong><p>Drive, Gmail, Calendar и Contacts</p></div>
         <button type="button" class="tool-connect-btn" data-${googleConnected ? "disconnect" : "connect"}-service="google">
@@ -790,10 +822,18 @@ async function openToolsDrawer() {
   openDataDrawer("Инструменти");
   renderDrawerLoading();
   try {
-    const [healthResponse, googleResponse, githubResponse] = await Promise.all([
+    const [
+      healthResponse,
+      googleResponse,
+      githubResponse,
+      chatgptResponse,
+    ] = await Promise.all([
       fetch("/health/integrations", { cache: "no-store" }),
       fetch("/api/google/status", { cache: "no-store" }).catch(() => null),
       fetch("/api/github/status", { cache: "no-store" }).catch(() => null),
+      fetch("/permissions/oauth/chatgpt", { cache: "no-store" }).catch(
+        () => null,
+      ),
     ]);
     if (!healthResponse.ok) {
       throw new Error("Състоянието на инструментите не е достъпно.");
@@ -805,6 +845,15 @@ async function openToolsDrawer() {
     const githubData = githubResponse?.ok
       ? await githubResponse.json().catch(() => ({}))
       : {};
+    const chatgptData = chatgptResponse?.ok
+      ? await chatgptResponse
+          .json()
+          .catch(() => ({
+            configured: false,
+            connected: false,
+            unavailable: true,
+          }))
+      : { configured: false, connected: false, unavailable: true };
     const tools = Array.isArray(data.tools) ? data.tools : [];
     const descriptions = {
       "github-read": "Проверява commit-и и файлове. Само за четене.",
@@ -831,7 +880,11 @@ async function openToolsDrawer() {
       <div class="permission-default">
         Показано е реалното състояние. „Регистриран“ не означава автоматично „работи“.
       </div>
-      ${connectionControls(Boolean(googleData.connected), Boolean(githubData.connected))}
+      ${connectionControls(
+        Boolean(googleData.connected),
+        Boolean(githubData.connected),
+        chatgptData,
+      )}
       <section class="drawer-section permission-list">
         <button type="button" class="permission-card tool-status-card system-control-link" data-system-configuration>
           <div>
@@ -1087,11 +1140,15 @@ async function openPermissionsDrawer() {
       healthResponse,
       googleResponse,
       githubResponse,
+      chatgptResponse,
     ] = await Promise.all([
       fetch("/permissions", { cache: "no-store" }),
       fetch("/health/integrations", { cache: "no-store" }),
       fetch("/api/google/status", { cache: "no-store" }).catch(() => null),
       fetch("/api/github/status", { cache: "no-store" }).catch(() => null),
+      fetch("/permissions/oauth/chatgpt", { cache: "no-store" }).catch(
+        () => null,
+      ),
     ]);
     if (!permissionsResponse.ok || !healthResponse.ok) {
       throw new Error("Разрешенията временно не са достъпни.");
@@ -1106,6 +1163,15 @@ async function openPermissionsDrawer() {
     const githubData = githubResponse?.ok
       ? await githubResponse.json().catch(() => ({}))
       : {};
+    const chatgptData = chatgptResponse?.ok
+      ? await chatgptResponse
+          .json()
+          .catch(() => ({
+            configured: false,
+            connected: false,
+            unavailable: true,
+          }))
+      : { configured: false, connected: false, unavailable: true };
     const toolMap = new Map(
       (healthData.tools || []).map((tool) => [tool.id, tool]),
     );
@@ -1119,7 +1185,11 @@ async function openPermissionsDrawer() {
                 Зеленото е активно. Оранжевото също работи, но пита преди рисково действие.
                 Несвързаните услуги имат отделен бутон за вход.
             </div>
-            ${connectionControls(Boolean(googleData.connected), Boolean(githubData.connected))}
+            ${connectionControls(
+              Boolean(googleData.connected),
+              Boolean(githubData.connected),
+              chatgptData,
+            )}
             <section class="drawer-section permission-list">
                 ${(data.permissions || [])
                   .map(
@@ -1244,6 +1314,8 @@ async function handleDataDrawerAction(event) {
       window.location.href = "/api/google/connect";
     } else if (connectionButton.dataset.connectService === "github") {
       window.location.href = "/api/github/connect";
+    } else if (connectionButton.dataset.connectService === "chatgpt") {
+      window.open("https://chatgpt.com/", "_blank", "noopener,noreferrer");
     }
     return;
   }
@@ -1251,9 +1323,17 @@ async function handleDataDrawerAction(event) {
   const disconnectButton = event.target.closest("[data-disconnect-service]");
   if (disconnectButton) {
     const service = disconnectButton.dataset.disconnectService;
+    const serviceName =
+      service === "google"
+        ? "Google"
+        : service === "github"
+          ? "GitHub"
+          : "ChatGPT";
     if (
       !window.confirm(
-        `Да спра ли достъпа на AI CORE до ${service === "google" ? "Google" : "GitHub"}?`,
+        service === "chatgpt"
+          ? "Да отнема ли всички активни права на ChatGPT до AI CORE?"
+          : `Да спра ли достъпа на AI CORE до ${serviceName}?`,
       )
     ) {
       return;
@@ -1263,14 +1343,20 @@ async function handleDataDrawerAction(event) {
       const response = await fetch(
         service === "google"
           ? "/api/google/disconnect"
-          : "/api/github/disconnect",
-        { method: "POST" },
+          : service === "github"
+            ? "/api/github/disconnect"
+            : "/permissions/oauth/chatgpt/revoke",
+        service === "chatgpt"
+          ? {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ all: true }),
+            }
+          : { method: "POST" },
       );
       if (!response.ok) throw new Error("Връзката не можа да бъде прекъсната.");
       await openPermissionsDrawer();
-      logAction(
-        `Прекъсната е връзката с ${service === "google" ? "Google" : "GitHub"}`,
-      );
+      logAction(`Прекъсната е връзката с ${serviceName}`);
     } catch (error) {
       renderDrawerError(error.message);
     }

--- a/src/routes/mcpOAuthRouter.js
+++ b/src/routes/mcpOAuthRouter.js
@@ -73,7 +73,7 @@ function consentPage(request, identity, consentToken) {
     )
     .join("");
   const callbackHost = new URL(request.redirectUri).hostname;
-  return `<!doctype html><html lang="bg"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>AI CORE OAuth</title><style>body{font-family:system-ui;background:#08111f;color:#eef4ff;display:grid;place-items:center;min-height:100vh;margin:0}.card{max-width:520px;background:#111e31;padding:28px;border-radius:18px}button{font-size:18px;padding:12px 18px;border:0;border-radius:10px;margin-right:8px}.allow{background:#4f8cff;color:white}.deny{background:#26364d;color:white}</style></head><body><main class="card"><h1>Свързване на ChatGPT със AI CORE</h1><p>Влязъл си като <strong>${escapeHtml(identity.displayName || identity.id)}</strong>.</p><p>Клиент: <strong>${escapeHtml(request.clientName || "ChatGPT")}</strong> · callback: <strong>${escapeHtml(callbackHost)}</strong></p><p>ChatGPT иска следните права:</p><ul>${rights}</ul><p>Всяко действие за запис продължава да изисква отделно точно потвърждение.</p><form method="post" action="/oauth/authorize">${hidden}<button class="allow" name="decision" value="allow" type="submit">Разреши</button><button class="deny" name="decision" value="deny" type="submit">Откажи</button></form></main></body></html>`;
+  return `<!doctype html><html lang="bg"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>AI CORE OAuth</title><style>body{font-family:system-ui;background:#08111f;color:#eef4ff;display:grid;place-items:center;min-height:100vh;margin:0}.card{max-width:520px;background:#111e31;padding:28px;border-radius:18px}button{font-size:18px;padding:12px 18px;border:0;border-radius:10px;margin-right:8px}.allow{background:#4f8cff;color:white}.deny{background:#26364d;color:white}</style></head><body><main class="card"><h1>Свързване на ChatGPT със AI CORE</h1><p>Влязъл си като <strong>${escapeHtml(identity.displayName || identity.id)}</strong>.</p><p>Клиент: <strong>${escapeHtml(request.clientName || "ChatGPT")}</strong> · callback: <strong>${escapeHtml(callbackHost)}</strong></p><p>ChatGPT иска следните права:</p><ul>${rights}</ul><p>Всяко действие за запис продължава да изисква отделно точно потвърждение.</p><p>Връзката може да се подновява, докато я използваш. Можеш да видиш правата и да спреш достъпа по всяко време от AI CORE → Разрешения.</p><form method="post" action="/oauth/authorize">${hidden}<button class="allow" name="decision" value="allow" type="submit">Разреши</button><button class="deny" name="decision" value="deny" type="submit">Откажи</button></form></main></body></html>`;
 }
 
 function loginRequiredPage() {
@@ -146,6 +146,7 @@ export function createMcpOAuthRouter({
           });
           callback.searchParams.set("error", "access_denied");
           callback.searchParams.set("state", request.state);
+          noStore(res);
           return res.redirect(callback.href);
         }
         const code = createMcpAuthorizationCode(request, identity);

--- a/src/routes/mcpRouter.js
+++ b/src/routes/mcpRouter.js
@@ -6,6 +6,7 @@ import {
 } from "../services/mcpReadService.js";
 import {
   allowsAnonymousMcpTool,
+  assertMcpGrantActive,
   buildMcpAuthenticateChallenge,
   McpOAuthError,
   requiredScopesForMcpTool,
@@ -78,7 +79,31 @@ export function mcpJsonParseErrorHandler(error, req, res, next) {
   });
 }
 
-export function requireMcpAuthorization(
+function sendMcpAuthorizationError(req, res, { challenge, message, status }) {
+  res.set("WWW-Authenticate", challenge);
+  return res.status(status).json({
+    jsonrpc: "2.0",
+    id: req.body?.id ?? null,
+    result: {
+      content: [{ type: "text", text: message }],
+      _meta: { "mcp/www_authenticate": [challenge] },
+      isError: true,
+    },
+  });
+}
+
+function sendMcpAuthorizationUnavailable(req, res) {
+  return res.status(503).json({
+    jsonrpc: "2.0",
+    id: req.body?.id ?? null,
+    error: {
+      code: -32002,
+      message: "MCP OAuth validation is temporarily unavailable.",
+    },
+  });
+}
+
+export async function requireMcpAuthorization(
   req,
   res,
   next,
@@ -115,7 +140,9 @@ export function requireMcpAuthorization(
   let oauthError = null;
   try {
     identity = verifyMcpAccessToken(authorization, requiredScopes, env);
+    if (identity) await assertMcpGrantActive(identity, { env });
   } catch (error) {
+    identity = null;
     oauthError =
       error instanceof McpOAuthError
         ? error
@@ -130,35 +157,30 @@ export function requireMcpAuthorization(
     req.mcpAuthentication = { mode: "oauth2", ...identity };
     return next();
   }
+  if (oauthError?.status >= 500) {
+    return sendMcpAuthorizationUnavailable(req, res);
+  }
 
-  const challenge = buildMcpAuthenticateChallenge(
-    requiredScopes,
-    env,
-    oauthError
-      ? {
-          error: oauthError.code,
-          description: oauthError.description,
-        }
-      : {},
-  );
-  res.set("WWW-Authenticate", challenge);
+  const challengeError = oauthError?.code || "invalid_token";
+  const challengeDescription =
+    challengeError === "insufficient_scope"
+      ? "The access token does not include the required scope."
+      : "The access token is missing, invalid, expired, or revoked.";
+  const challenge = buildMcpAuthenticateChallenge(requiredScopes, env, {
+    error: challengeError,
+    description: challengeDescription,
+  });
   if (authorization) {
-    return res.status(oauthError?.status === 403 ? 403 : 401).json({
-      jsonrpc: "2.0",
-      id: req.body?.id ?? null,
-      error: {
-        code: -32001,
-        message: oauthError?.message || "Невалиден или изтекъл MCP token.",
-      },
+    return sendMcpAuthorizationError(req, res, {
+      challenge,
+      message: oauthError?.message || "Невалиден или изтекъл MCP token.",
+      status: oauthError?.status === 403 ? 403 : 401,
     });
   }
-  return res.status(401).json({
-    jsonrpc: "2.0",
-    id: req.body?.id ?? null,
-    error: {
-      code: -32001,
-      message: "Нужно е OAuth свързване със AI CORE.",
-    },
+  return sendMcpAuthorizationError(req, res, {
+    challenge,
+    message: "Нужно е OAuth свързване със AI CORE.",
+    status: 401,
   });
 }
 

--- a/src/routes/permissionsRouter.js
+++ b/src/routes/permissionsRouter.js
@@ -3,33 +3,221 @@ import {
   evaluatePermission,
   listAuditEvents,
   listPermissions,
+  recordAuditEvent,
 } from "../services/permissionService.js";
+import {
+  isMcpOAuthConfigured,
+  listActiveMcpGrants,
+  revokeMcpGrants,
+} from "../services/mcpOAuthService.js";
 import { logSafeError } from "../utils/safeLogging.js";
 
-const router = express.Router();
+function noStore(res) {
+  res.setHeader("Cache-Control", "no-store, max-age=0");
+  res.setHeader("Pragma", "no-cache");
+}
 
-router.get("/", (_req, res) => {
-  res.json({
-    defaultDecision: "deny",
-    permissions: listPermissions(),
-  });
-});
+function ownerSubject(req) {
+  return typeof req.owner?.id === "string" ? req.owner.id.trim() : "";
+}
 
-router.get("/check", (req, res) => {
-  res.json(evaluatePermission(req.query.action));
-});
+function cleanText(value, maxLength = 2048) {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  return text ? text.slice(0, maxLength) : null;
+}
 
-router.get("/audit", async (req, res) => {
+function requestedGrantId(body) {
+  if (!Object.hasOwn(body || {}, "grantId")) {
+    return { provided: false, value: null };
+  }
+  if (typeof body.grantId !== "string") {
+    return { provided: true, value: null };
+  }
+  const value = body.grantId.trim();
+  return {
+    provided: true,
+    value:
+      value.length <= 256 && /^[A-Za-z0-9_-]+$/u.test(value) ? value : null,
+  };
+}
+
+function safeGrant(grant) {
+  const grantId = cleanText(grant?.grantId || grant?.id, 256);
+  const clientId = cleanText(grant?.clientId, 2048);
+  const scopes = Array.isArray(grant?.scopes)
+    ? grant.scopes
+        .map((scope) => cleanText(scope, 128))
+        .filter(Boolean)
+        .slice(0, 32)
+    : [];
+  const issuedAt = cleanText(grant?.issuedAt, 64);
+  const lastUsedAt = cleanText(grant?.lastUsedAt, 64);
+  const expiresAt = cleanText(grant?.expiresAt, 64);
+
+  return {
+    grantId,
+    clientId,
+    scopes,
+    issuedAt,
+    lastUsedAt,
+    expiresAt,
+  };
+}
+
+async function safeAudit(audit, event) {
   try {
-    const events = await listAuditEvents(req.query.limit);
-    res.json({ events });
+    await audit(event);
   } catch (error) {
-    logSafeError("[Audit] Read failure", error);
-    res.status(503).json({
-      error: "Дневникът на действията временно не е достъпен.",
-      code: "AUDIT_UNAVAILABLE",
+    logSafeError("[Permissions OAuth] Audit failure", error);
+  }
+}
+
+function revokedCount(result) {
+  const value =
+    typeof result === "number"
+      ? result
+      : result?.revoked ?? result?.revokedCount ?? result?.count;
+  return Number.isSafeInteger(value) && value >= 0 ? value : 0;
+}
+
+function oauthError(res, error, action) {
+  logSafeError(`[Permissions OAuth] ${action} failure`, error);
+  if (error?.code === "MCP_OAUTH_GRANT_NOT_FOUND") {
+    return res.status(404).json({
+      error: "ChatGPT връзката не е намерена или вече е прекъсната.",
+      code: "MCP_OAUTH_GRANT_NOT_FOUND",
     });
   }
-});
 
-export default router;
+  return res.status(503).json({
+    error:
+      action === "list"
+        ? "ChatGPT връзките временно не са достъпни."
+        : "ChatGPT достъпът временно не може да бъде прекъснат.",
+    code:
+      action === "list"
+        ? "MCP_OAUTH_GRANTS_UNAVAILABLE"
+        : "MCP_OAUTH_REVOCATION_UNAVAILABLE",
+  });
+}
+
+export function createPermissionsRouter({
+  evaluate = evaluatePermission,
+  listAudit = listAuditEvents,
+  listPolicy = listPermissions,
+  isOAuthConfigured = isMcpOAuthConfigured,
+  listGrants = listActiveMcpGrants,
+  revokeGrants = revokeMcpGrants,
+  recordAudit = recordAuditEvent,
+} = {}) {
+  const router = express.Router();
+
+  router.get("/", (_req, res) => {
+    res.json({
+      defaultDecision: "deny",
+      permissions: listPolicy(),
+    });
+  });
+
+  router.get("/check", (req, res) => {
+    res.json(evaluate(req.query.action));
+  });
+
+  router.get("/audit", async (req, res) => {
+    try {
+      const events = await listAudit(req.query.limit);
+      res.json({ events });
+    } catch (error) {
+      logSafeError("[Audit] Read failure", error);
+      res.status(503).json({
+        error: "Дневникът на действията временно не е достъпен.",
+        code: "AUDIT_UNAVAILABLE",
+      });
+    }
+  });
+
+  router.get("/oauth/chatgpt", async (req, res) => {
+    noStore(res);
+    const subject = ownerSubject(req);
+    if (!subject) {
+      return res.status(401).json({
+        error: "Нужен е вход в профила.",
+        code: "AUTH_REQUIRED",
+      });
+    }
+
+    try {
+      const configured = Boolean(await isOAuthConfigured());
+      const grants = configured ? await listGrants({ subject }) : [];
+      if (!Array.isArray(grants)) throw new TypeError("Invalid OAuth grants");
+      const safeGrants = grants.map(safeGrant).filter((grant) => grant.grantId);
+      return res.json({
+        configured,
+        connected: safeGrants.length > 0,
+        grants: safeGrants,
+      });
+    } catch (error) {
+      return oauthError(res, error, "list");
+    }
+  });
+
+  router.post("/oauth/chatgpt/revoke", async (req, res) => {
+    noStore(res);
+    const subject = ownerSubject(req);
+    if (!subject) {
+      return res.status(401).json({
+        error: "Нужен е вход в профила.",
+        code: "AUTH_REQUIRED",
+      });
+    }
+
+    const requestedGrant = requestedGrantId(req.body);
+    const grantId = requestedGrant.value;
+    const revokeAll = req.body?.all === true;
+    if (
+      (requestedGrant.provided && !grantId) ||
+      Number(Boolean(grantId)) + Number(revokeAll) !== 1
+    ) {
+      return res.status(400).json({
+        error: "Избери една ChatGPT връзка или потвърди прекъсване на всички.",
+        code: "INVALID_MCP_OAUTH_REVOCATION_TARGET",
+      });
+    }
+
+    try {
+      const result = await revokeGrants({
+        subject,
+        ...(grantId ? { grantId } : {}),
+      });
+      const revoked = revokedCount(result);
+      if (grantId && revoked === 0) {
+        return res.status(404).json({
+          error: "ChatGPT връзката не е намерена или вече е прекъсната.",
+          code: "MCP_OAUTH_GRANT_NOT_FOUND",
+        });
+      }
+      await safeAudit(recordAudit, {
+        actor: subject,
+        action: "oauth.revoke",
+        capability: "oauth.manage",
+        decision: "confirmed",
+        outcome: "succeeded",
+        resource: "chatgpt-mcp",
+        details: grantId ? "single_grant" : "all_grants",
+        sessionId: subject,
+      });
+      return res.json({
+        status: "ok",
+        revoked,
+        grantId: grantId || null,
+      });
+    } catch (error) {
+      return oauthError(res, error, "revoke");
+    }
+  });
+
+  return router;
+}
+
+export default createPermissionsRouter();

--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -47,11 +47,16 @@ const AUTHORIZATION_CODE_TTL_SECONDS = 5 * 60;
 const CONSENT_TOKEN_TTL_SECONDS = 10 * 60;
 const MAX_CONSUMED_TOKEN_RECORDS = 10_000;
 const REPLAY_CLEANUP_INTERVAL_SECONDS = 6 * 60 * 60;
+const MCP_GRANT_REVOKE_MAX_ATTEMPTS = 3;
 const MCP_OAUTH_REPLAY_INDEX =
   process.env.MCP_OAUTH_REPLAY_INDEX || "synchron-mcp-oauth-replay-v1";
+const MCP_OAUTH_GRANT_INDEX =
+  process.env.MCP_OAUTH_GRANT_INDEX || "synchron-mcp-oauth-grants-v1";
 const consumedAuthorizationCodes = new Map();
 const consumedRefreshTokens = new Map();
+const localMcpGrants = new Map();
 let replayIndexPromise = null;
+let grantIndexPromise = null;
 let lastReplayCleanupAt = 0;
 let activeReplayCleanup = null;
 let oauthRuntimeStatus = Object.freeze({
@@ -544,6 +549,7 @@ export function createMcpAuthorizationCode(
     {
       typ: "authorization_code",
       jti: randomBytes(18).toString("base64url"),
+      grantId: randomBytes(18).toString("base64url"),
       iss: resolveMcpIssuerUrl(env),
       aud: request.resource,
       clientId: request.clientId,
@@ -722,6 +728,543 @@ function openSearchStatus(error) {
   return error?.statusCode || error?.meta?.statusCode || 0;
 }
 
+function mcpGrantIndex(env = process.env) {
+  return env.MCP_OAUTH_GRANT_INDEX || MCP_OAUTH_GRANT_INDEX;
+}
+
+function mcpGrantUnavailable(message) {
+  return new McpOAuthError(
+    message || "MCP OAuth разрешенията временно не са достъпни.",
+    503,
+    "temporarily_unavailable",
+  );
+}
+
+function inactiveMcpGrant(errorCode = "invalid_grant") {
+  return new McpOAuthError(
+    "MCP OAuth разрешението липсва или е отнето.",
+    errorCode === "invalid_token" ? 401 : 400,
+    errorCode,
+  );
+}
+
+function normalizeGrantRecord(source, fallbackId = "") {
+  if (!source || typeof source !== "object") return null;
+  const scopes = Array.isArray(source.scopes)
+    ? [...new Set(source.scopes.map(String))]
+    : [];
+  const issuedAtMs = Date.parse(String(source.issuedAt || ""));
+  if (!Number.isFinite(issuedAtMs)) return null;
+  const expiresAtMs = source.expiresAt
+    ? Date.parse(String(source.expiresAt))
+    : issuedAtMs + REFRESH_TOKEN_TTL_SECONDS * 1_000;
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs <= issuedAtMs) return null;
+  const issuedAt = new Date(issuedAtMs).toISOString();
+  const expiresAt = new Date(expiresAtMs).toISOString();
+  const record = {
+    grantId: String(source.grantId || fallbackId),
+    subject: String(source.subject || ""),
+    memoryOwnerId: String(source.memoryOwnerId || ""),
+    role: String(source.role || ""),
+    clientId: String(source.clientId || ""),
+    scopes,
+    issuedAt,
+    expiresAt,
+    lastUsedAt: source.lastUsedAt ? String(source.lastUsedAt) : null,
+    revokedAt: source.revokedAt ? String(source.revokedAt) : null,
+  };
+  return record.grantId &&
+    record.subject &&
+    record.memoryOwnerId &&
+    record.role &&
+    record.clientId &&
+    record.scopes.length > 0 &&
+    record.issuedAt &&
+    record.expiresAt
+    ? record
+    : null;
+}
+
+function mcpGrantRecord(
+  payload,
+  issuedAt = payload.iat,
+  expiresAt = payload.exp,
+) {
+  return normalizeGrantRecord({
+    grantId: payload.grantId,
+    subject: payload.subject,
+    memoryOwnerId: payload.memoryOwnerId,
+    role: payload.role,
+    clientId: payload.clientId,
+    scopes: payload.scopes,
+    issuedAt: new Date(Number(issuedAt) * 1_000).toISOString(),
+    expiresAt: new Date(Number(expiresAt) * 1_000).toISOString(),
+    lastUsedAt: null,
+    revokedAt: null,
+  });
+}
+
+function mcpGrantMatches(record, identity) {
+  const subject = String(identity?.subject || identity?.id || "");
+  const scopes = Array.isArray(identity?.scopes)
+    ? [...new Set(identity.scopes.map(String))].sort()
+    : null;
+  return Boolean(
+    record &&
+      (!subject || record.subject === subject) &&
+      (!identity?.memoryOwnerId ||
+        record.memoryOwnerId === String(identity.memoryOwnerId)) &&
+      (!identity?.role || record.role === String(identity.role)) &&
+      (!identity?.clientId || record.clientId === String(identity.clientId)) &&
+      (!scopes ||
+        safeStringEqual(
+          JSON.stringify([...record.scopes].sort()),
+          JSON.stringify(scopes),
+        )),
+  );
+}
+
+function legacyGrantId(payload) {
+  return `legacy_${createHash("sha256")
+    .update(String(payload.iss))
+    .update("\0")
+    .update(String(payload.clientId))
+    .update("\0")
+    .update(String(payload.subject))
+    .update("\0")
+    .update(String(payload.jti))
+    .digest("base64url")}`;
+}
+
+function withMcpGrantId(payload) {
+  return payload.grantId
+    ? payload
+    : { ...payload, grantId: legacyGrantId(payload) };
+}
+
+async function ensureMcpGrantIndex(client, env = process.env) {
+  if (
+    !client?.indices ||
+    typeof client.indices.exists !== "function" ||
+    typeof client.indices.create !== "function"
+  ) {
+    return;
+  }
+  if (!grantIndexPromise) {
+    const index = mcpGrantIndex(env);
+    grantIndexPromise = (async () => {
+      const existsResponse = await client.indices.exists({ index });
+      const exists = existsResponse.body ?? existsResponse;
+      if (exists) return;
+      try {
+        await client.indices.create({
+          index,
+          body: {
+            mappings: {
+              properties: {
+                grantId: { type: "keyword" },
+                subject: { type: "keyword" },
+                memoryOwnerId: { type: "keyword" },
+                role: { type: "keyword" },
+                clientId: { type: "keyword" },
+                scopes: { type: "keyword" },
+                issuedAt: { type: "date" },
+                expiresAt: { type: "date" },
+                lastUsedAt: { type: "date" },
+                revokedAt: { type: "date" },
+              },
+            },
+          },
+        });
+      } catch (error) {
+        const status = openSearchStatus(error);
+        const type = error?.meta?.body?.error?.type;
+        if (status !== 400 || type !== "resource_already_exists_exception") {
+          throw error;
+        }
+      }
+    })().catch((error) => {
+      grantIndexPromise = null;
+      throw error;
+    });
+  }
+  await grantIndexPromise;
+}
+
+export function requiresPersistentMcpGrantStore(env = process.env) {
+  return env.NODE_ENV === "production";
+}
+
+async function loadMcpGrant(
+  grantId,
+  { env = process.env, client = getOpenSearchClient() } = {},
+) {
+  const local = localMcpGrants.get(grantId) || null;
+  if (client && typeof client.get === "function") {
+    try {
+      const response = await client.get({
+        index: mcpGrantIndex(env),
+        id: grantId,
+      });
+      const source = response.body?._source ?? response._source;
+      const record = normalizeGrantRecord(source, grantId);
+      if (source && !record) {
+        return { grantId, invalid: true, revokedAt: "invalid" };
+      }
+      if (record) localMcpGrants.set(grantId, record);
+      return record;
+    } catch (error) {
+      if (openSearchStatus(error) === 404) {
+        return requiresPersistentMcpGrantStore(env) ? null : local;
+      }
+      if (requiresPersistentMcpGrantStore(env)) {
+        throw mcpGrantUnavailable();
+      }
+    }
+  } else if (requiresPersistentMcpGrantStore(env)) {
+    throw mcpGrantUnavailable(
+      "MCP OAuth хранилището за разрешения не е конфигурирано.",
+    );
+  }
+  return local;
+}
+
+async function persistMcpGrant(
+  payload,
+  {
+    env = process.env,
+    client = getOpenSearchClient(),
+    issuedAt = payload.iat,
+    expiresAt = payload.exp,
+  } = {},
+) {
+  const record = mcpGrantRecord(payload, issuedAt, expiresAt);
+  if (!record) throw inactiveMcpGrant();
+
+  const local = localMcpGrants.get(record.grantId);
+  if (local && !requiresPersistentMcpGrantStore(env)) {
+    if (!mcpGrantMatches(local, record) || local.revokedAt) {
+      throw inactiveMcpGrant();
+    }
+    return local;
+  }
+  if (local && requiresPersistentMcpGrantStore(env)) {
+    const durable = await loadMcpGrant(record.grantId, { env, client });
+    if (!mcpGrantMatches(durable, record) || durable?.revokedAt) {
+      throw inactiveMcpGrant();
+    }
+    return durable;
+  }
+
+  if (client && typeof client.create === "function") {
+    try {
+      await ensureMcpGrantIndex(client, env);
+      await client.create({
+        index: mcpGrantIndex(env),
+        id: record.grantId,
+        body: record,
+        refresh: true,
+      });
+      localMcpGrants.set(record.grantId, record);
+      return record;
+    } catch (error) {
+      if (openSearchStatus(error) === 409) {
+        const existing = await loadMcpGrant(record.grantId, { env, client });
+        if (mcpGrantMatches(existing, record) && !existing.revokedAt) {
+          return existing;
+        }
+        throw inactiveMcpGrant();
+      }
+      if (requiresPersistentMcpGrantStore(env)) {
+        throw mcpGrantUnavailable();
+      }
+    }
+  } else if (requiresPersistentMcpGrantStore(env)) {
+    throw mcpGrantUnavailable(
+      "MCP OAuth хранилището за разрешения не е конфигурирано.",
+    );
+  }
+
+  localMcpGrants.set(record.grantId, record);
+  return record;
+}
+
+async function touchMcpGrant(
+  record,
+  {
+    env = process.env,
+    client = getOpenSearchClient(),
+    now = Date.now(),
+    expiresAt = record.expiresAt,
+  } = {},
+) {
+  const lastUsedAt = new Date(now).toISOString();
+  const updated = {
+    ...record,
+    lastUsedAt,
+    expiresAt: new Date(expiresAt).toISOString(),
+  };
+  if (client && typeof client.update === "function") {
+    try {
+      await client.update({
+        index: mcpGrantIndex(env),
+        id: record.grantId,
+        body: { doc: { lastUsedAt, expiresAt: updated.expiresAt } },
+        refresh: false,
+      });
+    } catch (error) {
+      if (openSearchStatus(error) === 404) throw inactiveMcpGrant();
+      if (requiresPersistentMcpGrantStore(env)) {
+        throw mcpGrantUnavailable();
+      }
+    }
+  } else if (requiresPersistentMcpGrantStore(env)) {
+    throw mcpGrantUnavailable(
+      "MCP OAuth хранилището за разрешения не е конфигурирано.",
+    );
+  }
+  localMcpGrants.set(record.grantId, updated);
+  return updated;
+}
+
+export async function assertMcpGrantActive(
+  identity,
+  {
+    env = process.env,
+    client = getOpenSearchClient(),
+    touch = false,
+    now = Date.now(),
+    expiresAt,
+    errorCode = "invalid_token",
+  } = {},
+) {
+  if (!identity?.grantId) {
+    // Tokens minted before grant management expire within one hour. Let those
+    // already-active access tokens finish naturally; every legacy refresh is
+    // migrated to a durable grant before new tokens are issued.
+    return {
+      grantId: null,
+      subject: String(identity?.subject || identity?.id || ""),
+      memoryOwnerId: String(identity?.memoryOwnerId || ""),
+      role: String(identity?.role || ""),
+      clientId: String(identity?.clientId || ""),
+      scopes: Array.isArray(identity?.scopes) ? [...identity.scopes] : [],
+      issuedAt: null,
+      expiresAt: null,
+      lastUsedAt: null,
+      revokedAt: null,
+      legacy: true,
+    };
+  }
+
+  let record = await loadMcpGrant(String(identity.grantId), { env, client });
+  if (!record && !requiresPersistentMcpGrantStore(env)) {
+    record = mcpGrantRecord(
+      {
+        ...identity,
+        subject: identity.subject || identity.id,
+        iat: Math.floor(now / 1_000),
+        exp: Math.floor(now / 1_000) + REFRESH_TOKEN_TTL_SECONDS,
+      },
+      Math.floor(now / 1_000),
+    );
+    if (record) localMcpGrants.set(record.grantId, record);
+  }
+  if (
+    !record ||
+    record.revokedAt ||
+    Date.parse(record.expiresAt) <= now ||
+    !mcpGrantMatches(record, identity)
+  ) {
+    throw inactiveMcpGrant(errorCode);
+  }
+  return touch
+    ? touchMcpGrant(record, { env, client, now, expiresAt })
+    : record;
+}
+
+export async function listActiveMcpGrants({
+  subject,
+  env = process.env,
+  client = getOpenSearchClient(),
+  limit = 100,
+  now = Date.now(),
+} = {}) {
+  const cleanSubject = String(subject || "").trim();
+  if (!cleanSubject) {
+    throw new McpOAuthError("Липсва собственик на MCP OAuth разрешенията.");
+  }
+  const safeLimit = Math.min(Math.max(Number.parseInt(limit, 10) || 100, 1), 100);
+
+  if (client && typeof client.search === "function") {
+    try {
+      const response = await client.search({
+        index: mcpGrantIndex(env),
+        body: {
+          size: safeLimit,
+          query: {
+            bool: {
+              filter: [
+                { term: { subject: cleanSubject } },
+                {
+                  range: {
+                    expiresAt: { gt: new Date(now).toISOString() },
+                  },
+                },
+              ],
+              must_not: [{ exists: { field: "revokedAt" } }],
+            },
+          },
+          sort: [{ issuedAt: { order: "desc" } }],
+        },
+      });
+      const hits = response.body?.hits?.hits ?? response.hits?.hits ?? [];
+      return hits
+        .map((hit) => normalizeGrantRecord(hit._source, hit._id))
+        .filter(Boolean);
+    } catch (error) {
+      if (openSearchStatus(error) === 404) return [];
+      if (requiresPersistentMcpGrantStore(env)) {
+        throw mcpGrantUnavailable();
+      }
+    }
+  } else if (requiresPersistentMcpGrantStore(env)) {
+    throw mcpGrantUnavailable(
+      "MCP OAuth хранилището за разрешения не е конфигурирано.",
+    );
+  }
+
+  return [...localMcpGrants.values()]
+    .filter(
+      (record) =>
+        record.subject === cleanSubject &&
+        !record.revokedAt &&
+        Date.parse(record.expiresAt) > now,
+    )
+    .sort((left, right) => String(right.issuedAt).localeCompare(left.issuedAt))
+    .slice(0, safeLimit);
+}
+
+function activeMcpGrantRevokeQuery(subject, grantId = "") {
+  const filter = [{ term: { subject } }];
+  if (grantId) filter.push({ term: { grantId } });
+  return {
+    bool: {
+      filter,
+      must_not: [{ exists: { field: "revokedAt" } }],
+    },
+  };
+}
+
+async function hasActiveMcpGrantForRevoke({ subject, grantId, env, client }) {
+  if (!client || typeof client.search !== "function") {
+    if (requiresPersistentMcpGrantStore(env)) {
+      throw mcpGrantUnavailable(
+        "MCP OAuth отнемането не може да бъде потвърдено.",
+      );
+    }
+    return null;
+  }
+  try {
+    const response = await client.search({
+      index: mcpGrantIndex(env),
+      body: {
+        size: 1,
+        _source: false,
+        query: activeMcpGrantRevokeQuery(subject, grantId),
+      },
+    });
+    const hits = response.body?.hits?.hits ?? response.hits?.hits ?? [];
+    return hits.length > 0;
+  } catch (error) {
+    if (openSearchStatus(error) === 404) return false;
+    if (requiresPersistentMcpGrantStore(env)) {
+      throw mcpGrantUnavailable(
+        "MCP OAuth отнемането не може да бъде потвърдено.",
+      );
+    }
+    return null;
+  }
+}
+
+export async function revokeMcpGrants({
+  subject,
+  grantId,
+  env = process.env,
+  client = getOpenSearchClient(),
+  now = Date.now(),
+} = {}) {
+  const cleanSubject = String(subject || "").trim();
+  const cleanGrantId = String(grantId || "").trim();
+  if (!cleanSubject) {
+    throw new McpOAuthError("Липсва собственик на MCP OAuth разрешенията.");
+  }
+  const revokedAt = new Date(now).toISOString();
+  let localRevoked = 0;
+  for (const [id, record] of localMcpGrants) {
+    if (
+      record.subject === cleanSubject &&
+      !record.revokedAt &&
+      (!cleanGrantId || id === cleanGrantId)
+    ) {
+      localMcpGrants.set(id, { ...record, revokedAt });
+      localRevoked += 1;
+    }
+  }
+
+  if (client && typeof client.updateByQuery === "function") {
+    try {
+      let updated = 0;
+      for (
+        let attempt = 1;
+        attempt <= MCP_GRANT_REVOKE_MAX_ATTEMPTS;
+        attempt += 1
+      ) {
+        const response = await client.updateByQuery({
+          index: mcpGrantIndex(env),
+          conflicts: "proceed",
+          refresh: true,
+          body: {
+            query: activeMcpGrantRevokeQuery(cleanSubject, cleanGrantId),
+            script: {
+              source: "ctx._source.revokedAt = params.revokedAt",
+              params: { revokedAt },
+            },
+          },
+        });
+        const body = response.body ?? response;
+        updated += Number(body?.updated ?? 0);
+        const versionConflicts = Number(body?.version_conflicts ?? 0);
+        const stillActive = await hasActiveMcpGrantForRevoke({
+          subject: cleanSubject,
+          grantId: cleanGrantId,
+          env,
+          client,
+        });
+        if (stillActive === false) return updated;
+        if (stillActive === null && versionConflicts === 0) return updated;
+        if (attempt === MCP_GRANT_REVOKE_MAX_ATTEMPTS) {
+          throw mcpGrantUnavailable(
+            "MCP OAuth отнемането не можа да бъде потвърдено.",
+          );
+        }
+      }
+    } catch (error) {
+      if (openSearchStatus(error) === 404) return 0;
+      if (error instanceof McpOAuthError) throw error;
+      if (requiresPersistentMcpGrantStore(env)) {
+        throw mcpGrantUnavailable();
+      }
+      return localRevoked;
+    }
+  } else if (requiresPersistentMcpGrantStore(env)) {
+    throw mcpGrantUnavailable(
+      "MCP OAuth хранилището за разрешения не е конфигурирано.",
+    );
+  }
+  return localRevoked;
+}
+
 export function requiresPersistentMcpReplayGuard(env = process.env) {
   return env.NODE_ENV === "production";
 }
@@ -822,6 +1365,7 @@ function createAccessAndRefreshTokens(payload, env, now) {
     "sx-token",
     {
       typ: "access_token",
+      grantId: payload.grantId,
       iss: payload.iss,
       aud: payload.aud,
       clientId: payload.clientId,
@@ -840,6 +1384,7 @@ function createAccessAndRefreshTokens(payload, env, now) {
     {
       typ: "refresh_token",
       jti: randomBytes(18).toString("base64url"),
+      grantId: payload.grantId,
       iss: payload.iss,
       aud: payload.aud,
       clientId: payload.clientId,
@@ -864,7 +1409,10 @@ function createAccessAndRefreshTokens(payload, env, now) {
 export async function exchangeMcpAuthorizationCode(
   input,
   env = process.env,
-  { consumeGrant = consumeMcpGrantOnce } = {},
+  {
+    consumeGrant = consumeMcpGrantOnce,
+    client = getOpenSearchClient(),
+  } = {},
 ) {
   const code = String(input?.code || "");
   const payload = decryptPayloadWithFallback(
@@ -911,11 +1459,19 @@ export async function exchangeMcpAuthorizationCode(
     );
   }
 
+  const grantPayload = withMcpGrantId(payload);
+  await persistMcpGrant(grantPayload, {
+    env,
+    client,
+    issuedAt: payload.iat,
+    expiresAt: now + REFRESH_TOKEN_TTL_SECONDS,
+  });
   const consumed = await consumeGrant({
     grantType: "authorization_code",
     tokenId: payload.jti,
     expiresAt: payload.exp,
     env,
+    client,
   });
   if (!consumed) {
     throw new McpOAuthError(
@@ -924,13 +1480,16 @@ export async function exchangeMcpAuthorizationCode(
       "invalid_grant",
     );
   }
-  return createAccessAndRefreshTokens(payload, env, now);
+  return createAccessAndRefreshTokens(grantPayload, env, now);
 }
 
 export async function exchangeMcpRefreshToken(
   input,
   env = process.env,
-  { consumeGrant = consumeMcpGrantOnce } = {},
+  {
+    consumeGrant = consumeMcpGrantOnce,
+    client = getOpenSearchClient(),
+  } = {},
 ) {
   const payload = decryptPayloadWithFallback(
     String(input?.refresh_token || ""),
@@ -953,11 +1512,32 @@ export async function exchangeMcpRefreshToken(
       "invalid_grant",
     );
   }
+  const grantPayload = withMcpGrantId(payload);
+  if (payload.grantId) {
+    await assertMcpGrantActive(payload, {
+      env,
+      client,
+      touch: true,
+      now: now * 1_000,
+      expiresAt: (now + REFRESH_TOKEN_TTL_SECONDS) * 1_000,
+      errorCode: "invalid_grant",
+    });
+  } else {
+    // Pre-grant refresh tokens get one replay-protected migration to a durable
+    // grant. The deterministic ID makes a retry idempotent.
+    await persistMcpGrant(grantPayload, {
+      env,
+      client,
+      issuedAt: payload.iat,
+      expiresAt: now + REFRESH_TOKEN_TTL_SECONDS,
+    });
+  }
   const consumed = await consumeGrant({
     grantType: "refresh_token",
     tokenId: payload.jti,
     expiresAt: payload.exp,
     env,
+    client,
   });
   if (!consumed) {
     throw new McpOAuthError(
@@ -966,7 +1546,7 @@ export async function exchangeMcpRefreshToken(
       "invalid_grant",
     );
   }
-  return createAccessAndRefreshTokens(payload, env, now);
+  return createAccessAndRefreshTokens(grantPayload, env, now);
 }
 
 export async function exchangeMcpToken(input, env = process.env) {
@@ -1073,13 +1653,16 @@ export function verifyMcpAccessToken(
     role: payload.role,
     scopes: payload.scopes,
     clientId: payload.clientId,
+    grantId: payload.grantId || null,
   };
 }
 
 export function resetMcpOAuthStateForTests() {
   consumedAuthorizationCodes.clear();
   consumedRefreshTokens.clear();
+  localMcpGrants.clear();
   replayIndexPromise = null;
+  grantIndexPromise = null;
   lastReplayCleanupAt = 0;
   activeReplayCleanup = null;
   oauthRuntimeStatus = Object.freeze({

--- a/tests/connectionActionsUi.test.js
+++ b/tests/connectionActionsUi.test.js
@@ -12,6 +12,13 @@ test("connection and permission controls lead to real setup actions", async () =
   assert.match(app, /window\.location\.href = "\/api\/google\/connect"/u);
   assert.match(app, /data-connect-service="github"/u);
   assert.match(app, /window\.location\.href = "\/api\/github\/connect"/u);
+  assert.match(app, /<strong>ChatGPT<\/strong>/u);
+  assert.match(app, /chatgptConnected \? "disconnect" : "connect"/u);
+  assert.match(app, /window\.open\("https:\/\/chatgpt\.com\/"/u);
+  assert.match(app, /fetch\("\/permissions\/oauth\/chatgpt"/u);
+  assert.match(app, /\/permissions\/oauth\/chatgpt\/revoke/u);
+  assert.match(app, /JSON\.stringify\(\{ all: true \}\)/u);
+  assert.match(app, /Да отнема ли всички активни права на ChatGPT/u);
   assert.match(app, /data-disconnect-service/u);
   assert.match(app, /\/api\/google\/disconnect/u);
   assert.match(app, /\/api\/github\/disconnect/u);

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -8,6 +8,7 @@ import { createMcpOAuthRouter } from "../src/routes/mcpOAuthRouter.js";
 import {
   getMcpOAuthRuntimeStatus,
   resetMcpOAuthStateForTests,
+  revokeMcpGrants,
 } from "../src/services/mcpOAuthService.js";
 import mcpRouter, {
   mcpJsonParseErrorHandler,
@@ -17,6 +18,17 @@ import mcpRouter, {
 const SECRET = "router-test-secret-with-more-than-thirty-two-characters";
 const DEDICATED_SECRET =
   "router-dedicated-oauth-secret-with-more-than-thirty-two-characters";
+
+function assertMcpOAuthChallenge(response) {
+  const challenge = response.headers["www-authenticate"];
+  assert.equal(response.body.result?.isError, true);
+  assert.equal(response.body.result?.content?.[0]?.type, "text");
+  assert.ok(response.body.result?.content?.[0]?.text);
+  assert.deepEqual(response.body.result?._meta?.["mcp/www_authenticate"], [
+    challenge,
+  ]);
+  return challenge;
+}
 
 test("OAuth discovery is public and describes the exact MCP resource", async () => {
   const previous = process.env.MCP_ACCESS_TOKEN;
@@ -159,12 +171,11 @@ test("an unauthenticated tool call returns the ChatGPT OAuth challenge", async (
       params: { name: "get_personal_context", arguments: {} },
     })
     .expect(401);
-  assert.equal(response.body.error.code, -32001);
-  assert.match(
-    response.headers["www-authenticate"],
-    /oauth-protected-resource/u,
-  );
-  assert.match(response.headers["www-authenticate"], /synchron:read/u);
+  const challenge = assertMcpOAuthChallenge(response);
+  assert.match(challenge, /oauth-protected-resource/u);
+  assert.match(challenge, /synchron:read/u);
+  assert.match(challenge, /error="invalid_token"/u);
+  assert.match(challenge, /error_description="[^"]+"/u);
   if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
   else process.env.MCP_ACCESS_TOKEN = previous;
 });
@@ -185,8 +196,9 @@ test("an invalid bearer token is rejected with HTTP 401", async () => {
       params: { name: "get_personal_context", arguments: {} },
     })
     .expect(401);
-  assert.equal(response.body.error.code, -32001);
-  assert.match(response.headers["www-authenticate"], /invalid_token/u);
+  const challenge = assertMcpOAuthChallenge(response);
+  assert.match(challenge, /invalid_token/u);
+  assert.match(challenge, /error_description="[^"]+"/u);
   if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
   else process.env.MCP_ACCESS_TOKEN = previous;
 });
@@ -210,7 +222,7 @@ test("the dedicated OAuth secret is never accepted as a legacy static bearer", a
         params: { name: "get_personal_context", arguments: {} },
       })
       .expect(401);
-    assert.equal(response.body.error.code, -32001);
+    assertMcpOAuthChallenge(response);
   } finally {
     if (previousAccess === undefined) delete process.env.MCP_ACCESS_TOKEN;
     else process.env.MCP_ACCESS_TOKEN = previousAccess;
@@ -250,6 +262,7 @@ test("authorization consent issues a code bound to the browser profile", async (
   assert.match(consent.text, /Свързване на ChatGPT със AI CORE/u);
   assert.match(consent.text, /Четене на разрешените данни/u);
   assert.match(consent.text, /отделно точно потвърждение/u);
+  assert.match(consent.text, /AI CORE → Разрешения/u);
   const consentToken = consent.text.match(
     /name="consent_token" value="([^"]+)"/u,
   )?.[1];
@@ -288,6 +301,69 @@ test("authorization consent issues a code bound to the browser profile", async (
     .expect(200);
   assert.equal(token.body.token_type, "Bearer");
   assert.ok(token.body.refresh_token);
+
+  const protectedApp = express();
+  protectedApp.use(express.json());
+  protectedApp.post("/mcp", requireMcpAuthorization, (_req, res) =>
+    res.json({ ok: true }),
+  );
+  const insufficientScope = await request(protectedApp)
+    .post("/mcp")
+    .set("Authorization", `Bearer ${token.body.access_token}`)
+    .send({
+      jsonrpc: "2.0",
+      id: 6,
+      method: "tools/call",
+      params: {
+        name: "confirm_github_merged_branch_cleanup",
+        arguments: {},
+      },
+    })
+    .expect(403);
+  const insufficientChallenge = assertMcpOAuthChallenge(insufficientScope);
+  assert.match(insufficientChallenge, /insufficient_scope/u);
+  assert.match(insufficientChallenge, /synchron:github\.write/u);
+  assert.match(insufficientChallenge, /error_description="[^"]+"/u);
+
+  const unavailableApp = express();
+  unavailableApp.use(express.json());
+  unavailableApp.post(
+    "/mcp",
+    (req, res, next) =>
+      requireMcpAuthorization(req, res, next, {
+        env: { ...process.env, NODE_ENV: "production", MCP_ACCESS_TOKEN: SECRET },
+      }),
+    (_req, res) => res.json({ ok: true }),
+  );
+  const unavailable = await request(unavailableApp)
+    .post("/mcp")
+    .set("Authorization", `Bearer ${token.body.access_token}`)
+    .send({
+      jsonrpc: "2.0",
+      id: 8,
+      method: "tools/call",
+      params: { name: "get_personal_context", arguments: {} },
+    })
+    .expect(503);
+  assert.equal(unavailable.body.error.code, -32002);
+  assert.equal(unavailable.headers["www-authenticate"], undefined);
+
+  assert.equal(
+    await revokeMcpGrants({ subject: "owner-id", client: null }),
+    1,
+  );
+  const revokedAccess = await request(protectedApp)
+    .post("/mcp")
+    .set("Authorization", `Bearer ${token.body.access_token}`)
+    .send({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: { name: "get_personal_context", arguments: {} },
+    })
+    .expect(401);
+  const revokedChallenge = assertMcpOAuthChallenge(revokedAccess);
+  assert.match(revokedChallenge, /error="invalid_token"/u);
   if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
   else process.env.MCP_ACCESS_TOKEN = previous;
 });
@@ -346,6 +422,57 @@ test("authorization flow overrides global COOP so ChatGPT can complete the popup
       approved.headers["cross-origin-resource-policy"],
       "same-origin",
     );
+  } finally {
+    if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
+    else process.env.MCP_ACCESS_TOKEN = previous;
+  }
+});
+
+test("authorization denial returns a no-store error to the exact ChatGPT callback", async () => {
+  resetMcpOAuthStateForTests();
+  const previous = process.env.MCP_ACCESS_TOKEN;
+  process.env.MCP_ACCESS_TOKEN = SECRET;
+  try {
+    const oauthRequest = {
+      clientId: "https://chatgpt.com/oauth/synchron/client.json",
+      clientName: "ChatGPT",
+      redirectUri: "https://chatgpt.com/connector/oauth/test-callback",
+      state: "state-denied",
+      codeChallenge: "c".repeat(43),
+      resource: "https://synchron.foundation/mcp",
+      scopes: ["synchron:read"],
+    };
+    const app = express();
+    app.use(
+      createMcpOAuthRouter({
+        resolveIdentity: async () => ({
+          id: "owner-id",
+          displayName: "Радко",
+          role: "owner",
+          memoryOwnerId: "primary-user",
+        }),
+        validateRequest: async () => oauthRequest,
+      }),
+    );
+    const consent = await request(app).get("/oauth/authorize").expect(200);
+    const consentToken = consent.text.match(
+      /name="consent_token" value="([^"]+)"/u,
+    )?.[1];
+    assert.ok(consentToken);
+
+    const denied = await request(app)
+      .post("/oauth/authorize")
+      .type("form")
+      .send({ consent_token: consentToken, decision: "deny" })
+      .expect(302);
+    const callback = new URL(denied.headers.location);
+    assert.equal(callback.origin, "https://chatgpt.com");
+    assert.equal(callback.pathname, "/connector/oauth/test-callback");
+    assert.equal(callback.searchParams.get("state"), oauthRequest.state);
+    assert.equal(callback.searchParams.get("error"), "access_denied");
+    assert.equal(callback.searchParams.has("code"), false);
+    assert.equal(denied.headers["cache-control"], "no-store");
+    assert.equal(denied.headers.pragma, "no-cache");
   } finally {
     if (previous === undefined) delete process.env.MCP_ACCESS_TOKEN;
     else process.env.MCP_ACCESS_TOKEN = previous;

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
+import { createCipheriv, createHash, randomBytes } from "node:crypto";
 import test from "node:test";
 
 import {
+  assertMcpGrantActive,
   cleanupExpiredMcpReplayRecords,
   consumeMcpGrantOnce,
   createMcpAuthorizationCode,
@@ -14,6 +15,7 @@ import {
   getMcpAuthorizationServerMetadata,
   getMcpProtectedResourceMetadata,
   isMcpOAuthConfigured,
+  listActiveMcpGrants,
   MCP_AGENT_CHAT_SCOPE,
   MCP_AUDIT_READ_SCOPE,
   MCP_GITHUB_WRITE_SCOPE,
@@ -25,7 +27,9 @@ import {
   MCP_READ_SCOPE,
   MCP_TASKS_WRITE_SCOPE,
   requiresPersistentMcpReplayGuard,
+  requiresPersistentMcpGrantStore,
   resetMcpOAuthStateForTests,
+  revokeMcpGrants,
   validateMcpAuthorizationRequest,
   verifyMcpAccessToken,
 } from "../src/services/mcpOAuthService.js";
@@ -41,6 +45,187 @@ const DEDICATED_ENV = {
 const CLIENT_ID = "https://chatgpt.com/oauth/synchron/client.json";
 const REDIRECT_URI = "https://chatgpt.com/connector/oauth/test-callback";
 const VERIFIER = "v".repeat(64);
+
+function openSearchError(statusCode, type) {
+  const error = new Error(`OpenSearch ${statusCode}`);
+  error.meta = {
+    statusCode,
+    ...(type ? { body: { error: { type } } } : {}),
+  };
+  return error;
+}
+
+function matchesOpenSearchQuery(source, query = {}) {
+  const bool = query.bool || {};
+  for (const clause of bool.filter || []) {
+    if (clause.term) {
+      const [field, value] = Object.entries(clause.term)[0];
+      if (source[field] !== value) return false;
+    }
+    if (clause.range) {
+      const [field, bounds] = Object.entries(clause.range)[0];
+      const value = Date.parse(source[field]);
+      if (bounds.gt && !(value > Date.parse(bounds.gt))) return false;
+      if (bounds.lte && !(value <= Date.parse(bounds.lte))) return false;
+    }
+  }
+  for (const clause of bool.must_not || []) {
+    if (clause.exists && source[clause.exists.field] != null) return false;
+  }
+  if (query.range) {
+    const [field, bounds] = Object.entries(query.range)[0];
+    const value = Date.parse(source[field]);
+    if (bounds.gt && !(value > Date.parse(bounds.gt))) return false;
+    if (bounds.lte && !(value <= Date.parse(bounds.lte))) return false;
+  }
+  return true;
+}
+
+function createFakeOpenSearch() {
+  const indexes = new Map();
+  const mappings = new Map();
+  const indexRecords = (index) => {
+    const records = indexes.get(index);
+    if (!records) throw openSearchError(404);
+    return records;
+  };
+  const client = {
+    indexes,
+    mappings,
+    indices: {
+      async exists({ index }) {
+        return { body: indexes.has(index) };
+      },
+      async create({ index, body }) {
+        if (indexes.has(index)) {
+          throw openSearchError(400, "resource_already_exists_exception");
+        }
+        indexes.set(index, new Map());
+        mappings.set(index, structuredClone(body?.mappings || {}));
+        return { body: { acknowledged: true } };
+      },
+    },
+    async create({ index, id, body }) {
+      const records = indexRecords(index);
+      if (records.has(id)) throw openSearchError(409);
+      records.set(id, structuredClone(body));
+      return { body: { result: "created" } };
+    },
+    async get({ index, id }) {
+      const record = indexRecords(index).get(id);
+      if (!record) throw openSearchError(404);
+      return { body: { _id: id, _source: structuredClone(record) } };
+    },
+    async search({ index, body }) {
+      const records = indexRecords(index);
+      const hits = [...records]
+        .filter(([, source]) => matchesOpenSearchQuery(source, body.query))
+        .map(([id, source]) => ({ _id: id, _source: structuredClone(source) }))
+        .sort((left, right) =>
+          String(right._source.issuedAt || "").localeCompare(
+            String(left._source.issuedAt || ""),
+          ),
+        )
+        .slice(0, body.size);
+      return { body: { hits: { hits } } };
+    },
+    async update({ index, id, body }) {
+      const records = indexRecords(index);
+      const record = records.get(id);
+      if (!record) throw openSearchError(404);
+      records.set(id, { ...record, ...structuredClone(body.doc || {}) });
+      return { body: { result: "updated" } };
+    },
+    async updateByQuery({ index, body }) {
+      const records = indexRecords(index);
+      let updated = 0;
+      for (const [id, source] of records) {
+        if (!matchesOpenSearchQuery(source, body.query)) continue;
+        records.set(id, { ...source, revokedAt: body.script.params.revokedAt });
+        updated += 1;
+      }
+      return { body: { updated } };
+    },
+    async deleteByQuery({ index, body }) {
+      const records = indexRecords(index);
+      let deleted = 0;
+      for (const [id, source] of records) {
+        if (!matchesOpenSearchQuery(source, body.query)) continue;
+        records.delete(id);
+        deleted += 1;
+      }
+      return { body: { deleted } };
+    },
+  };
+  return client;
+}
+
+function legacyOAuthKey(env = ENV) {
+  return createHash("sha256")
+    .update("synchron-mcp-oauth-v1\0")
+    .update(env.MCP_ACCESS_TOKEN)
+    .digest();
+}
+
+function legacyGrantKey(env = ENV) {
+  return createHash("sha256")
+    .update(legacyOAuthKey(env))
+    .update("synchron-mcp-oauth-grants-v2\0")
+    .digest();
+}
+
+function encryptLegacyToken(prefix, payload, key) {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(payload), "utf8"),
+    cipher.final(),
+  ]);
+  return `${prefix}.${Buffer.concat([
+    iv,
+    cipher.getAuthTag(),
+    ciphertext,
+  ]).toString("base64url")}`;
+}
+
+function legacyIdentityPayload(now = Math.floor(Date.now() / 1_000)) {
+  return {
+    iss: "https://synchron.foundation",
+    aud: ENV.MCP_RESOURCE_URL,
+    clientId: CLIENT_ID,
+    scopes: [MCP_READ_SCOPE],
+    subject: "owner-id",
+    memoryOwnerId: "primary-user",
+    role: "owner",
+    iat: now,
+  };
+}
+
+function createLegacyAccessToken(now = Math.floor(Date.now() / 1_000)) {
+  return encryptLegacyToken(
+    "sx-token",
+    {
+      typ: "access_token",
+      ...legacyIdentityPayload(now),
+      nbf: now - 5,
+      exp: now + 60 * 60,
+    },
+    legacyOAuthKey(),
+  );
+}
+
+function createLegacyRefreshToken(now = Math.floor(Date.now() / 1_000)) {
+  return encryptLegacyToken(
+    "sx-refresh",
+    {
+      typ: "refresh_token",
+      jti: randomBytes(18).toString("base64url"),
+      ...legacyIdentityPayload(now),
+      exp: now + 30 * 24 * 60 * 60,
+    },
+    legacyGrantKey(),
+  );
+}
 
 function authorizationInput(scopes = [MCP_READ_SCOPE]) {
   return {
@@ -70,7 +255,7 @@ function clientMetadataFetch(url) {
   );
 }
 
-async function issueTokens(env = ENV) {
+async function issueTokens(env = ENV, options = {}) {
   const request = await validateMcpAuthorizationRequest(authorizationInput(), {
     env,
     fetchImpl: clientMetadataFetch,
@@ -90,6 +275,7 @@ async function issueTokens(env = ENV) {
       resource: ENV.MCP_RESOURCE_URL,
     },
     env,
+    options,
   );
 }
 
@@ -408,18 +594,21 @@ test("exchanges a one-time PKCE code for an opaque owner-scoped token", async ()
   const token = await exchangeMcpAuthorizationCode(input, ENV);
   assert.equal(token.token_type, "Bearer");
   assert.doesNotMatch(token.access_token, /owner-id|primary-user/u);
+  const identity = verifyMcpAccessToken(
+    `Bearer ${token.access_token}`,
+    [MCP_GITHUB_WRITE_SCOPE],
+    ENV,
+  );
+  assert.match(identity.grantId, /^[A-Za-z0-9_-]+$/u);
   assert.deepEqual(
-    verifyMcpAccessToken(
-      `Bearer ${token.access_token}`,
-      [MCP_GITHUB_WRITE_SCOPE],
-      ENV,
-    ),
+    { ...identity, grantId: undefined },
     {
       id: "owner-id",
       memoryOwnerId: "primary-user",
       role: "owner",
       scopes: [MCP_READ_SCOPE, MCP_GITHUB_WRITE_SCOPE],
       clientId: CLIENT_ID,
+      grantId: undefined,
     },
   );
   const refreshed = await exchangeMcpRefreshToken(
@@ -591,6 +780,429 @@ test("refresh tokens survive a fresh application module instance", async () => {
     ENV,
   );
   assert.ok(refreshed.access_token);
+});
+
+test("persists a bounded owner grant and extends it on refresh", async () => {
+  const env = {
+    ...ENV,
+    NODE_ENV: "production",
+    MCP_OAUTH_GRANT_INDEX: "oauth-grants-persist-test",
+    MCP_OAUTH_REPLAY_INDEX: "oauth-replay-persist-test",
+  };
+  const client = createFakeOpenSearch();
+  const realDateNow = Date.now;
+  let now = realDateNow();
+  Date.now = () => now;
+  try {
+    const token = await issueTokens(env, { client });
+    const identity = verifyMcpAccessToken(
+      `Bearer ${token.access_token}`,
+      [MCP_READ_SCOPE],
+      env,
+    );
+    const initial = await assertMcpGrantActive(identity, { env, client, now });
+
+    assert.equal(requiresPersistentMcpGrantStore(env), true);
+    assert.deepEqual(
+      {
+        grantId: initial.grantId,
+        subject: initial.subject,
+        memoryOwnerId: initial.memoryOwnerId,
+        role: initial.role,
+        clientId: initial.clientId,
+        scopes: initial.scopes,
+        lastUsedAt: initial.lastUsedAt,
+        revokedAt: initial.revokedAt,
+      },
+      {
+        grantId: identity.grantId,
+        subject: "owner-id",
+        memoryOwnerId: "primary-user",
+        role: "owner",
+        clientId: CLIENT_ID,
+        scopes: [MCP_READ_SCOPE],
+        lastUsedAt: null,
+        revokedAt: null,
+      },
+    );
+    assert.match(initial.issuedAt, /^\d{4}-\d{2}-\d{2}T/u);
+    assert.ok(Date.parse(initial.expiresAt) > now);
+    assert.deepEqual(
+      client.mappings.get(env.MCP_OAUTH_GRANT_INDEX).properties.expiresAt,
+      { type: "date" },
+    );
+    assert.deepEqual(await listActiveMcpGrants({ subject: "owner-id", env, client, now }), [
+      initial,
+    ]);
+
+    now += 60_000;
+    const refreshed = await exchangeMcpRefreshToken(
+      {
+        grant_type: "refresh_token",
+        refresh_token: token.refresh_token,
+        client_id: CLIENT_ID,
+        resource: ENV.MCP_RESOURCE_URL,
+      },
+      env,
+      { client },
+    );
+    const refreshedIdentity = verifyMcpAccessToken(
+      `Bearer ${refreshed.access_token}`,
+      [MCP_READ_SCOPE],
+      env,
+    );
+    assert.equal(refreshedIdentity.grantId, identity.grantId);
+    const [extended] = await listActiveMcpGrants({
+      subject: "owner-id",
+      env,
+      client,
+      now,
+    });
+    assert.ok(Date.parse(extended.expiresAt) > Date.parse(initial.expiresAt));
+    assert.equal(
+      extended.lastUsedAt,
+      new Date(Math.floor(now / 1_000) * 1_000).toISOString(),
+    );
+
+    client.indexes.get(env.MCP_OAUTH_GRANT_INDEX).set(identity.grantId, {
+      ...extended,
+      expiresAt: new Date(now - 1).toISOString(),
+    });
+    assert.deepEqual(
+      await listActiveMcpGrants({ subject: "owner-id", env, client, now }),
+      [],
+    );
+  } finally {
+    Date.now = realDateNow;
+  }
+});
+
+test("a transient grant update failure does not consume the refresh token", async () => {
+  const env = {
+    ...ENV,
+    NODE_ENV: "production",
+    MCP_OAUTH_GRANT_INDEX: "oauth-grants-refresh-retry-test",
+    MCP_OAUTH_REPLAY_INDEX: "oauth-replay-refresh-retry-test",
+  };
+  const client = createFakeOpenSearch();
+  const token = await issueTokens(env, { client });
+  const update = client.update.bind(client);
+  let failUpdate = true;
+  client.update = async (input) => {
+    if (failUpdate) {
+      failUpdate = false;
+      throw openSearchError(503);
+    }
+    return update(input);
+  };
+  const refreshInput = {
+    grant_type: "refresh_token",
+    refresh_token: token.refresh_token,
+    client_id: CLIENT_ID,
+    resource: ENV.MCP_RESOURCE_URL,
+  };
+
+  await assert.rejects(
+    exchangeMcpRefreshToken(refreshInput, env, { client }),
+    (error) => error.code === "temporarily_unavailable" && error.status === 503,
+  );
+  const retried = await exchangeMcpRefreshToken(refreshInput, env, { client });
+  assert.ok(retried.access_token);
+  assert.ok(retried.refresh_token);
+});
+
+test("revokes one or all owner grants and blocks access and refresh", async () => {
+  const env = {
+    ...ENV,
+    NODE_ENV: "production",
+    MCP_OAUTH_GRANT_INDEX: "oauth-grants-revoke-test",
+    MCP_OAUTH_REPLAY_INDEX: "oauth-replay-revoke-test",
+  };
+  const client = createFakeOpenSearch();
+  const first = await issueTokens(env, { client });
+  const second = await issueTokens(env, { client });
+  const firstIdentity = verifyMcpAccessToken(
+    `Bearer ${first.access_token}`,
+    [MCP_READ_SCOPE],
+    env,
+  );
+  const secondIdentity = verifyMcpAccessToken(
+    `Bearer ${second.access_token}`,
+    [MCP_READ_SCOPE],
+    env,
+  );
+
+  assert.equal(
+    await revokeMcpGrants({
+      subject: "owner-id",
+      grantId: firstIdentity.grantId,
+      env,
+      client,
+    }),
+    1,
+  );
+  assert.deepEqual(
+    (await listActiveMcpGrants({ subject: "owner-id", env, client })).map(
+      ({ grantId }) => grantId,
+    ),
+    [secondIdentity.grantId],
+  );
+  await assert.rejects(
+    assertMcpGrantActive(firstIdentity, { env, client }),
+    (error) => error.code === "invalid_token" && error.status === 401,
+  );
+  await assert.rejects(
+    exchangeMcpRefreshToken(
+      {
+        grant_type: "refresh_token",
+        refresh_token: first.refresh_token,
+        client_id: CLIENT_ID,
+        resource: ENV.MCP_RESOURCE_URL,
+      },
+      env,
+      { client },
+    ),
+    (error) => error.code === "invalid_grant" && error.status === 400,
+  );
+  assert.equal(
+    await revokeMcpGrants({ subject: "owner-id", env, client }),
+    1,
+  );
+  assert.deepEqual(
+    await listActiveMcpGrants({ subject: "owner-id", env, client }),
+    [],
+  );
+});
+
+test("retries and verifies a target revoke after a version conflict", async () => {
+  const env = {
+    ...ENV,
+    NODE_ENV: "production",
+    MCP_OAUTH_GRANT_INDEX: "oauth-grants-revoke-conflict-test",
+    MCP_OAUTH_REPLAY_INDEX: "oauth-replay-revoke-conflict-test",
+  };
+  const client = createFakeOpenSearch();
+  const token = await issueTokens(env, { client });
+  const identity = verifyMcpAccessToken(
+    `Bearer ${token.access_token}`,
+    [MCP_READ_SCOPE],
+    env,
+  );
+  const updateByQuery = client.updateByQuery.bind(client);
+  let attempts = 0;
+  client.updateByQuery = async (input) => {
+    attempts += 1;
+    if (attempts === 1) {
+      return { body: { updated: 0, version_conflicts: 1 } };
+    }
+    const response = await updateByQuery(input);
+    response.body.version_conflicts = 0;
+    return response;
+  };
+
+  assert.equal(
+    await revokeMcpGrants({
+      subject: "owner-id",
+      grantId: identity.grantId,
+      env,
+      client,
+    }),
+    1,
+  );
+  assert.equal(attempts, 2);
+  assert.deepEqual(
+    await listActiveMcpGrants({ subject: "owner-id", env, client }),
+    [],
+  );
+  await assert.rejects(
+    assertMcpGrantActive(identity, { env, client }),
+    (error) => error.code === "invalid_token" && error.status === 401,
+  );
+});
+
+test("fails closed when revoke-all version conflicts remain active", async () => {
+  const env = {
+    ...ENV,
+    NODE_ENV: "production",
+    MCP_OAUTH_GRANT_INDEX: "oauth-grants-revoke-conflict-fail-test",
+    MCP_OAUTH_REPLAY_INDEX: "oauth-replay-revoke-conflict-fail-test",
+  };
+  const client = createFakeOpenSearch();
+  await issueTokens(env, { client });
+  let attempts = 0;
+  client.updateByQuery = async () => {
+    attempts += 1;
+    return { body: { updated: 0, version_conflicts: 1 } };
+  };
+
+  await assert.rejects(
+    revokeMcpGrants({ subject: "owner-id", env, client }),
+    (error) =>
+      error.code === "temporarily_unavailable" && error.status === 503,
+  );
+  assert.equal(attempts, 3);
+});
+
+test("production grant checks fail closed for missing durable state", async () => {
+  const token = await issueTokens(ENV, {
+    client: null,
+    consumeGrant: async () => true,
+  });
+  const env = {
+    ...ENV,
+    NODE_ENV: "production",
+    MCP_OAUTH_GRANT_INDEX: "oauth-grants-missing-test",
+    MCP_OAUTH_REPLAY_INDEX: "oauth-replay-missing-test",
+  };
+  const client = createFakeOpenSearch();
+  const identity = verifyMcpAccessToken(
+    `Bearer ${token.access_token}`,
+    [MCP_READ_SCOPE],
+    env,
+  );
+  resetMcpOAuthStateForTests();
+
+  await assert.rejects(
+    assertMcpGrantActive(identity, { env, client }),
+    (error) => error.code === "invalid_token" && error.status === 401,
+  );
+  await assert.rejects(
+    exchangeMcpRefreshToken(
+      {
+        grant_type: "refresh_token",
+        refresh_token: token.refresh_token,
+        client_id: CLIENT_ID,
+        resource: ENV.MCP_RESOURCE_URL,
+      },
+      env,
+      { client },
+    ),
+    (error) => error.code === "invalid_grant" && error.status === 400,
+  );
+  await assert.rejects(
+    assertMcpGrantActive(identity, { env, client: null }),
+    (error) => error.code === "temporarily_unavailable" && error.status === 503,
+  );
+});
+
+test("migrates pre-grant tokens without abruptly invalidating access", async () => {
+  const env = {
+    ...ENV,
+    NODE_ENV: "production",
+    MCP_OAUTH_GRANT_INDEX: "oauth-grants-legacy-test",
+    MCP_OAUTH_REPLAY_INDEX: "oauth-replay-legacy-test",
+  };
+  const client = createFakeOpenSearch();
+  const legacyIdentity = verifyMcpAccessToken(
+    `Bearer ${createLegacyAccessToken()}`,
+    [MCP_READ_SCOPE],
+    env,
+  );
+  assert.equal(legacyIdentity.grantId, null);
+  assert.equal(
+    (await assertMcpGrantActive(legacyIdentity, { env, client })).legacy,
+    true,
+  );
+
+  const migrated = await exchangeMcpRefreshToken(
+    {
+      grant_type: "refresh_token",
+      refresh_token: createLegacyRefreshToken(),
+      client_id: CLIENT_ID,
+      resource: ENV.MCP_RESOURCE_URL,
+    },
+    env,
+    { client },
+  );
+  const migratedIdentity = verifyMcpAccessToken(
+    `Bearer ${migrated.access_token}`,
+    [MCP_READ_SCOPE],
+    env,
+  );
+  assert.match(migratedIdentity.grantId, /^legacy_[A-Za-z0-9_-]+$/u);
+  assert.deepEqual(
+    (await listActiveMcpGrants({ subject: "owner-id", env, client })).map(
+      ({ grantId }) => grantId,
+    ),
+    [migratedIdentity.grantId],
+  );
+});
+
+test("a revoked local grant stays revoked when a dev store returns 404", async () => {
+  const env = {
+    ...ENV,
+    MCP_OAUTH_GRANT_INDEX: "oauth-grants-dev-404-test",
+    MCP_OAUTH_REPLAY_INDEX: "oauth-replay-dev-404-test",
+  };
+  const client = createFakeOpenSearch();
+  const token = await issueTokens(env, { client });
+  const identity = verifyMcpAccessToken(
+    `Bearer ${token.access_token}`,
+    [MCP_READ_SCOPE],
+    env,
+  );
+  assert.equal(
+    await revokeMcpGrants({
+      subject: "owner-id",
+      grantId: identity.grantId,
+      env,
+      client,
+    }),
+    1,
+  );
+  client.indexes.get(env.MCP_OAUTH_GRANT_INDEX).delete(identity.grantId);
+
+  await assert.rejects(
+    assertMcpGrantActive(identity, { env, client }),
+    (error) => error.code === "invalid_token" && error.status === 401,
+  );
+});
+
+test("rejects durable grants with malformed security timestamps", async () => {
+  const env = {
+    ...ENV,
+    NODE_ENV: "production",
+    MCP_OAUTH_GRANT_INDEX: "oauth-grants-invalid-time-test",
+    MCP_OAUTH_REPLAY_INDEX: "oauth-replay-invalid-time-test",
+  };
+  const client = createFakeOpenSearch();
+
+  for (const field of ["issuedAt", "expiresAt"]) {
+    const token = await issueTokens(env, { client });
+    const identity = verifyMcpAccessToken(
+      `Bearer ${token.access_token}`,
+      [MCP_READ_SCOPE],
+      env,
+    );
+    const records = client.indexes.get(env.MCP_OAUTH_GRANT_INDEX);
+    records.set(identity.grantId, {
+      ...records.get(identity.grantId),
+      [field]: "not-a-timestamp",
+    });
+
+    await assert.rejects(
+      assertMcpGrantActive(identity, { env, client }),
+      (error) => error.code === "invalid_token" && error.status === 401,
+    );
+    await assert.rejects(
+      exchangeMcpRefreshToken(
+        {
+          grant_type: "refresh_token",
+          refresh_token: token.refresh_token,
+          client_id: CLIENT_ID,
+          resource: ENV.MCP_RESOURCE_URL,
+        },
+        env,
+        { client },
+      ),
+      (error) => error.code === "invalid_grant" && error.status === 400,
+    );
+  }
+
+  assert.deepEqual(
+    await listActiveMcpGrants({ subject: "owner-id", env, client }),
+    [],
+  );
 });
 
 test("production replay guard is atomic across local state resets", async () => {

--- a/tests/permissionsRouter.test.js
+++ b/tests/permissionsRouter.test.js
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import express from "express";
+import request from "supertest";
+
+import { createPermissionsRouter } from "../src/routes/permissionsRouter.js";
+
+function testApp(options, owner = { id: "owner-1" }) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.owner = owner;
+    next();
+  });
+  app.use("/permissions", createPermissionsRouter(options));
+  return app;
+}
+
+test("lists only safe ChatGPT OAuth grant metadata for the signed-in owner", async () => {
+  let input;
+  const app = testApp({
+    isOAuthConfigured: () => true,
+    listGrants: async (options) => {
+      input = options;
+      return [
+        {
+          grantId: "grant-1",
+          subject: "owner-1",
+          memoryOwnerId: "private-memory-owner",
+          role: "owner",
+          clientId: "https://chatgpt.com/oauth/synchron/client.json",
+          scopes: ["synchron:read", "offline_access"],
+          issuedAt: "2026-08-06T10:00:00.000Z",
+          lastUsedAt: "2026-08-06T10:05:00.000Z",
+          expiresAt: "2026-09-05T10:00:00.000Z",
+          accessToken: "secret-access-token",
+          refreshToken: "secret-refresh-token",
+          revokedAt: null,
+        },
+      ];
+    },
+  });
+
+  const response = await request(app)
+    .get("/permissions/oauth/chatgpt?subject=attacker")
+    .expect(200);
+
+  assert.deepEqual(input, { subject: "owner-1" });
+  assert.equal(response.body.configured, true);
+  assert.equal(response.body.connected, true);
+  assert.deepEqual(response.body.grants, [
+    {
+      grantId: "grant-1",
+      clientId: "https://chatgpt.com/oauth/synchron/client.json",
+      scopes: ["synchron:read", "offline_access"],
+      issuedAt: "2026-08-06T10:00:00.000Z",
+      lastUsedAt: "2026-08-06T10:05:00.000Z",
+      expiresAt: "2026-09-05T10:00:00.000Z",
+    },
+  ]);
+  assert.match(response.headers["cache-control"], /no-store/u);
+  assert.equal(response.headers.pragma, "no-cache");
+  assert.doesNotMatch(JSON.stringify(response.body), /secret|memory-owner/u);
+  assert.equal(Object.hasOwn(response.body.grants[0], "subject"), false);
+  assert.equal(Object.hasOwn(response.body.grants[0], "role"), false);
+});
+
+test("revokes all ChatGPT OAuth grants only for the signed-in owner", async () => {
+  let input;
+  let auditEvent;
+  const app = testApp({
+    revokeGrants: async (options) => {
+      input = options;
+      return { revoked: 2 };
+    },
+    recordAudit: async (event) => {
+      auditEvent = event;
+    },
+  });
+  const response = await request(app)
+    .post("/permissions/oauth/chatgpt/revoke")
+    .send({ subject: "attacker", all: true })
+    .expect(200);
+
+  assert.deepEqual(input, { subject: "owner-1" });
+  assert.deepEqual(response.body, {
+    status: "ok",
+    revoked: 2,
+    grantId: null,
+  });
+  assert.deepEqual(auditEvent, {
+    actor: "owner-1",
+    action: "oauth.revoke",
+    capability: "oauth.manage",
+    decision: "confirmed",
+    outcome: "succeeded",
+    resource: "chatgpt-mcp",
+    details: "all_grants",
+    sessionId: "owner-1",
+  });
+  assert.match(response.headers["cache-control"], /no-store/u);
+});
+
+test("revokes one exact ChatGPT OAuth grant without accepting another subject", async () => {
+  let input;
+  const app = testApp({
+    revokeGrants: async (options) => {
+      input = options;
+      return 1;
+    },
+    recordAudit: async () => {},
+  });
+
+  const response = await request(app)
+    .post("/permissions/oauth/chatgpt/revoke")
+    .send({ subject: "attacker", grantId: "grant-2" })
+    .expect(200);
+
+  assert.deepEqual(input, { subject: "owner-1", grantId: "grant-2" });
+  assert.deepEqual(response.body, {
+    status: "ok",
+    revoked: 1,
+    grantId: "grant-2",
+  });
+});
+
+test("returns safe OAuth management errors without leaking service details", async () => {
+  const listApp = testApp({
+    isOAuthConfigured: () => true,
+    listGrants: async () => {
+      throw new Error("OpenSearch password=private-list-secret");
+    },
+  });
+  const listResponse = await request(listApp)
+    .get("/permissions/oauth/chatgpt")
+    .expect(503);
+  assert.equal(listResponse.body.code, "MCP_OAUTH_GRANTS_UNAVAILABLE");
+  assert.doesNotMatch(JSON.stringify(listResponse.body), /password|secret/u);
+
+  const revokeApp = testApp({
+    revokeGrants: async () => {
+      throw new Error("OpenSearch password=private-revoke-secret");
+    },
+    recordAudit: async () => {},
+  });
+  const revokeResponse = await request(revokeApp)
+    .post("/permissions/oauth/chatgpt/revoke")
+    .send({ grantId: "grant-1" })
+    .expect(503);
+  assert.equal(
+    revokeResponse.body.code,
+    "MCP_OAUTH_REVOCATION_UNAVAILABLE",
+  );
+  assert.doesNotMatch(JSON.stringify(revokeResponse.body), /password|secret/u);
+});
+
+test("does not turn a missing or invalid target into revoke-all", async () => {
+  let called = false;
+  const app = testApp({
+    revokeGrants: async () => {
+      called = true;
+      return 1;
+    },
+    recordAudit: async () => {},
+  });
+
+  const response = await request(app)
+    .post("/permissions/oauth/chatgpt/revoke")
+    .send({ grantId: "   " })
+    .expect(400);
+
+  assert.equal(
+    response.body.code,
+    "INVALID_MCP_OAUTH_REVOCATION_TARGET",
+  );
+  assert.equal(called, false);
+
+  await request(app)
+    .post("/permissions/oauth/chatgpt/revoke")
+    .send({})
+    .expect(400);
+  assert.equal(called, false);
+
+  await request(app)
+    .post("/permissions/oauth/chatgpt/revoke")
+    .send({ grantId: "x".repeat(257) })
+    .expect(400);
+  assert.equal(called, false);
+
+  await request(app)
+    .post("/permissions/oauth/chatgpt/revoke")
+    .send({ all: true, grantId: "grant-1" })
+    .expect(400);
+  assert.equal(called, false);
+});

--- a/tests/productionSmokeWorkflow.test.js
+++ b/tests/productionSmokeWorkflow.test.js
@@ -1,6 +1,45 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFile, readdir } from "node:fs/promises";
+import { delimiter, dirname } from "node:path";
 import test from "node:test";
+
+function bashEnvironment() {
+  return {
+    ...process.env,
+    PATH: [dirname(process.execPath), process.env.PATH]
+      .filter(Boolean)
+      .join(delimiter),
+  };
+}
+
+function runBash(script, args = ["-s"]) {
+  return spawnSync("bash", args, {
+    input: script,
+    encoding: "utf8",
+    env: bashEnvironment(),
+  });
+}
+
+function extractMcpChallengeStep(workflow) {
+  const namedStep = workflow.split(
+    "- name: Check MCP tool catalog and OAuth challenge",
+  )[1];
+  assert.ok(namedStep, "MCP OAuth challenge step is missing");
+  const block = namedStep.split(/^      - name:/mu)[0];
+  const run = block.split("        run: |\n")[1];
+  assert.ok(run, "MCP OAuth challenge bash block is missing");
+  return run.replace(/^ {10}/gmu, "").trimEnd();
+}
+
+function extractChallengeValidator(step) {
+  const start = step.lastIndexOf("node -e '");
+  const endMarker = `' "\${challenge_body}"`;
+  const end = step.indexOf(endMarker, start);
+  assert.notEqual(start, -1, "challenge validator is missing");
+  assert.notEqual(end, -1, "challenge validator argument is missing");
+  return step.slice(start, end + endMarker.length);
+}
 
 test("production smoke publishes a readable commit status without a custom secret", async () => {
   const workflow = await readFile(
@@ -71,20 +110,85 @@ test("production smoke publishes a readable commit status without a custom secre
   assert.doesNotMatch(workflow, /names\.length === expected\.length/u);
   assert.match(workflow, /synchron:audit\.read/u);
   assert.match(workflow, /synchron:tasks\.write/u);
-  assert.match(workflow, /challenge_headers/u);
+  assert.match(workflow, /challenge_headers="\$\(mktemp\)"/u);
+  assert.match(workflow, /challenge_body="\$\(mktemp\)"/u);
+  assert.match(workflow, /challenge_status/u);
   assert.match(workflow, /synchron:read/u);
-  assert.match(workflow, /--dump-header -/u);
-  assert.match(workflow, /--output \/dev\/null/u);
+  assert.match(workflow, /--dump-header "\$\{challenge_headers\}"/u);
+  assert.match(workflow, /--output "\$\{challenge_body\}"/u);
+  assert.match(workflow, /--write-out '%\{http_code\}'/u);
   assert.match(workflow, /\^www-authenticate:/u);
-  assert.doesNotMatch(
+  assert.match(workflow, /mcp\/www_authenticate/u);
+  assert.match(workflow, /result\?\.isError === true/u);
+  assert.match(
     workflow,
-    /challenge_headers="\$\(curl --fail --silent --show-error/u,
+    /challenge\.includes\("error=\\"invalid_token\\""\)/u,
   );
-  assert.doesNotMatch(workflow, /mcp\/www_authenticate/u);
+  assert.match(workflow, /challenge\.includes\("error_description=\\""\)/u);
+  assert.doesNotMatch(workflow, /challenge\.includes\('error=/u);
   assert.match(workflow, /Check workspace authentication boundary/u);
   assert.match(workflow, /\/api\/workspaces/u);
   assert.match(workflow, /AUTH_REQUIRED/u);
   assert.doesNotMatch(workflow, /secrets\./u);
+});
+
+test("MCP OAuth challenge validator is valid and executable bash", async (t) => {
+  const workflow = await readFile(
+    new URL("../.github/workflows/production-smoke.yml", import.meta.url),
+    "utf8",
+  );
+  const step = extractMcpChallengeStep(workflow);
+  const probe = runBash("command -v node >/dev/null 2>&1\n");
+  if (probe.error?.code === "ENOENT" || probe.status !== 0) {
+    t.skip("bash with Node.js is unavailable in this environment");
+    return;
+  }
+
+  const syntax = runBash(step, ["-n"]);
+  assert.equal(
+    syntax.status,
+    0,
+    `MCP challenge step is not valid bash:\n${syntax.stderr}`,
+  );
+
+  const validator = extractChallengeValidator(step);
+  const challenge =
+    'Bearer resource_metadata="https://synchron.foundation/.well-known/oauth-protected-resource", scope="synchron:read", error="invalid_token", error_description="Invalid token"';
+  const response = JSON.stringify({
+    result: {
+      content: [{ type: "text", text: "OAuth входът е необходим." }],
+      _meta: { "mcp/www_authenticate": [challenge] },
+      isError: true,
+    },
+  });
+  const executableScript = `set -euo pipefail
+challenge_body="$(mktemp)"
+trap 'rm -f "\${challenge_body}"' EXIT
+cat > "\${challenge_body}" <<'JSON'
+${response}
+JSON
+${validator}
+`;
+  const execution = runBash(executableScript);
+  assert.equal(
+    execution.status,
+    0,
+    `MCP challenge validator cannot execute:\n${execution.stderr}`,
+  );
+
+  const oldBrokenValidator = validator.replace(
+    'challenge.includes("error=\\"invalid_token\\"")',
+    `challenge.includes('error="invalid_token"')`,
+  );
+  assert.notEqual(oldBrokenValidator, validator);
+  const brokenExecution = runBash(
+    executableScript.replace(validator, oldBrokenValidator),
+  );
+  assert.notEqual(
+    brokenExecution.status,
+    0,
+    "the executable test must detect the former single-quote defect",
+  );
 });
 
 test("DigitalOcean remains the only production deployment channel", async () => {


### PR DESCRIPTION
## Какво е променено

- връща OAuth challenge и в MCP runtime `_meta["mcp/www_authenticate"]`, както изисква ChatGPT;
- добавя устойчиви owner-scoped OAuth grants в OpenSearch, безопасен refresh и fail-closed revoke;
- добавя екран в AI CORE → „Разрешения“ за преглед и спиране на ChatGPT достъпа;
- разширява production smoke теста за HTTP 401, header и JSON-RPC challenge body.

## Причина

Consent страницата се отваряше, но ChatGPT не довършваше token exchange, защото runtime tool error не съдържаше MCP `_meta` challenge. Освен това нямаше видимо управление и отнемане на активните ChatGPT разрешения.

## Проверка

- `pnpm test`: 644 total, 643 pass, 0 fail, 1 skip (локално липсва Bash за executable workflow validator);
- `git diff --check`: clean;
- независим combined review: няма P1/P2 находки.

Не е правен merge или deployment.