### PR TITLE
Fix ChatGPT Secure MCP Tunnel OAuth resource binding

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -62,6 +62,9 @@ services:
       - key: MCP_RESOURCE_URL
         value: https://synchron.foundation/mcp
         scope: RUN_TIME
+      - key: MCP_OPENAI_TUNNEL_RESOURCE_URL
+        value: https://tunnel-service.gateway.unified-0.internal.api.openai.org/v1/mcp/tunnel_6a72f3d764848191958716862a10ce6a
+        scope: RUN_TIME
       - key: MEMORY_OWNER_ID
         scope: RUN_TIME
         type: SECRET

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ MCP_ACCESS_TOKEN=your-long-random-mcp-access-token
 MCP_OAUTH_SECRET=
 # Optional canonical HTTPS MCP resource. Production defaults to this URL.
 MCP_RESOURCE_URL=https://synchron.foundation/mcp
+# Optional exact resource URL generated for the approved OpenAI Secure MCP Tunnel.
+MCP_OPENAI_TUNNEL_RESOURCE_URL=
 # Optional OpenSearch index for one-time OAuth grant consumption.
 MCP_OAUTH_REPLAY_INDEX=synchron-mcp-oauth-replay-v1
 

--- a/src/config/environmentCatalog.js
+++ b/src/config/environmentCatalog.js
@@ -145,6 +145,11 @@ export const ENVIRONMENT_CATALOG = Object.freeze(
       { hasDefault: true },
     ),
     general(
+      "MCP_OPENAI_TUNNEL_RESOURCE_URL",
+      "ChatGPT / MCP",
+      "Точният ресурс на одобрения OpenAI Secure MCP Tunnel.",
+    ),
+    general(
       "MCP_OAUTH_REPLAY_INDEX",
       "ChatGPT / MCP",
       "Индекс за устойчивата еднократна OAuth защита.",

--- a/src/services/mcpOAuthService.js
+++ b/src/services/mcpOAuthService.js
@@ -104,6 +104,29 @@ export function resolveMcpResourceUrl(env = process.env) {
   );
 }
 
+function resolveOpenAiTunnelResourceUrl(env = process.env) {
+  const resource = normalizeHttpsUrl(env.MCP_OPENAI_TUNNEL_RESOURCE_URL);
+  if (!resource) return "";
+
+  const url = new URL(resource);
+  if (
+    !/^tunnel-service\.gateway\.[a-z0-9-]+\.internal\.api\.openai\.org$/u.test(
+      url.hostname,
+    ) ||
+    !/^\/v1\/mcp\/tunnel_[A-Za-z0-9_-]+$/u.test(url.pathname)
+  ) {
+    return "";
+  }
+  return resource;
+}
+
+function isAllowedMcpResourceUrl(resource, env = process.env) {
+  const requested = String(resource || "");
+  const canonical = resolveMcpResourceUrl(env);
+  const tunnel = resolveOpenAiTunnelResourceUrl(env);
+  return requested === canonical || Boolean(tunnel && requested === tunnel);
+}
+
 export function resolveMcpIssuerUrl(env = process.env) {
   return new URL(resolveMcpResourceUrl(env)).origin;
 }
@@ -454,7 +477,7 @@ export async function validateMcpAuthorizationRequest(
   input,
   { env = process.env, fetchImpl = fetch } = {},
 ) {
-  const resource = resolveMcpResourceUrl(env);
+  const resource = String(input?.resource || "");
   const clientId = String(input?.client_id || "").trim();
   const redirectUri = String(input?.redirect_uri || "").trim();
   const state = String(input?.state || "").trim();
@@ -475,7 +498,7 @@ export async function validateMcpAuthorizationRequest(
   ) {
     throw new McpOAuthError("Изисква се PKCE S256.");
   }
-  if (String(input?.resource || "") !== resource) {
+  if (!isAllowedMcpResourceUrl(resource, env)) {
     throw new McpOAuthError("Невалиден MCP resource.", 400, "invalid_target");
   }
 
@@ -625,7 +648,7 @@ export function resolveMcpConsentRequest(
     payload.exp - payload.iat !== CONSENT_TOKEN_TTL_SECONDS ||
     !safeStringEqual(payload.subject, String(identity?.id || "")) ||
     !payload.request ||
-    payload.request.resource !== resolveMcpResourceUrl(env) ||
+    !isAllowedMcpResourceUrl(payload.request.resource, env) ||
     !Array.isArray(payload.request.scopes)
   ) {
     throw new McpOAuthError("Невалидно потвърждение.", 403, "access_denied");
@@ -1425,7 +1448,7 @@ export async function exchangeMcpAuthorizationCode(
     !payload ||
     payload.typ !== "authorization_code" ||
     payload.iss !== resolveMcpIssuerUrl(env) ||
-    payload.aud !== resolveMcpResourceUrl(env) ||
+    !isAllowedMcpResourceUrl(payload.aud, env) ||
     payload.exp <= now
   ) {
     throw new McpOAuthError(
@@ -1501,7 +1524,7 @@ export async function exchangeMcpRefreshToken(
     !payload ||
     payload.typ !== "refresh_token" ||
     payload.iss !== resolveMcpIssuerUrl(env) ||
-    payload.aud !== resolveMcpResourceUrl(env) ||
+    !isAllowedMcpResourceUrl(payload.aud, env) ||
     payload.exp <= now ||
     !safeStringEqual(input?.client_id, payload.clientId) ||
     !safeStringEqual(input?.resource, payload.aud)
@@ -1623,7 +1646,7 @@ export function verifyMcpAccessToken(
     !payload ||
     payload.typ !== "access_token" ||
     payload.iss !== resolveMcpIssuerUrl(env) ||
-    payload.aud !== resolveMcpResourceUrl(env) ||
+    !isAllowedMcpResourceUrl(payload.aud, env) ||
     payload.nbf > now ||
     payload.exp <= now ||
     !Array.isArray(payload.scopes) ||

--- a/tests/mcpOAuthService.test.js
+++ b/tests/mcpOAuthService.test.js
@@ -38,6 +38,12 @@ const ENV = {
   MCP_ACCESS_TOKEN: "mcp-oauth-test-secret-with-more-than-32-characters",
   MCP_RESOURCE_URL: "https://synchron.foundation/mcp",
 };
+const TUNNEL_RESOURCE =
+  "https://tunnel-service.gateway.unified-0.internal.api.openai.org/v1/mcp/tunnel_test123";
+const TUNNEL_ENV = {
+  ...ENV,
+  MCP_OPENAI_TUNNEL_RESOURCE_URL: TUNNEL_RESOURCE,
+};
 const DEDICATED_ENV = {
   ...ENV,
   MCP_OAUTH_SECRET: "dedicated-oauth-test-secret-with-more-than-32-characters",
@@ -485,6 +491,86 @@ test("validates OpenAI CIMD metadata and exact callback and resource", async () 
     validateMcpAuthorizationRequest(
       { ...authorizationInput(), resource: "https://attacker.example/mcp" },
       { env: ENV, fetchImpl: clientMetadataFetch },
+    ),
+    (error) => error.code === "invalid_target",
+  );
+});
+
+test("accepts only the configured OpenAI secure tunnel resource through the full token flow", async () => {
+  const tunnelInput = {
+    ...authorizationInput(),
+    resource: TUNNEL_RESOURCE,
+  };
+  const request = await validateMcpAuthorizationRequest(tunnelInput, {
+    env: TUNNEL_ENV,
+    fetchImpl: clientMetadataFetch,
+  });
+  assert.equal(request.resource, TUNNEL_RESOURCE);
+
+  const code = createMcpAuthorizationCode(
+    request,
+    { id: "owner-id", memoryOwnerId: "primary-user", role: "owner" },
+    TUNNEL_ENV,
+  );
+  const token = await exchangeMcpAuthorizationCode(
+    {
+      grant_type: "authorization_code",
+      code,
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+      code_verifier: VERIFIER,
+      resource: TUNNEL_RESOURCE,
+    },
+    TUNNEL_ENV,
+  );
+  assert.equal(
+    verifyMcpAccessToken(
+      `Bearer ${token.access_token}`,
+      [MCP_READ_SCOPE],
+      TUNNEL_ENV,
+    ).memoryOwnerId,
+    "primary-user",
+  );
+
+  const refreshed = await exchangeMcpRefreshToken(
+    {
+      grant_type: "refresh_token",
+      refresh_token: token.refresh_token,
+      client_id: CLIENT_ID,
+      resource: TUNNEL_RESOURCE,
+    },
+    TUNNEL_ENV,
+  );
+  assert.equal(
+    verifyMcpAccessToken(
+      `Bearer ${refreshed.access_token}`,
+      [MCP_READ_SCOPE],
+      TUNNEL_ENV,
+    ).memoryOwnerId,
+    "primary-user",
+  );
+
+  await assert.rejects(
+    validateMcpAuthorizationRequest(
+      {
+        ...tunnelInput,
+        resource:
+          "https://tunnel-service.gateway.unified-0.internal.api.openai.org/v1/mcp/tunnel_other",
+      },
+      { env: TUNNEL_ENV, fetchImpl: clientMetadataFetch },
+    ),
+    (error) => error.code === "invalid_target",
+  );
+  await assert.rejects(
+    validateMcpAuthorizationRequest(
+      { ...tunnelInput, resource: "https://attacker.example/mcp" },
+      {
+        env: {
+          ...ENV,
+          MCP_OPENAI_TUNNEL_RESOURCE_URL: "https://attacker.example/mcp",
+        },
+        fetchImpl: clientMetadataFetch,
+      },
     ),
     (error) => error.code === "invalid_target",
   );

--- a/tests/productionSmokeWorkflow.test.js
+++ b/tests/productionSmokeWorkflow.test.js
@@ -27,7 +27,7 @@ function extractMcpChallengeStep(workflow) {
   )[1];
   assert.ok(namedStep, "MCP OAuth challenge step is missing");
   const block = namedStep.split(/^      - name:/mu)[0];
-  const run = block.split("        run: |\n")[1];
+  const run = block.split(/        run: \|\r?\n/u)[1];
   assert.ok(run, "MCP OAuth challenge bash block is missing");
   return run.replace(/^ {10}/gmu, "").trimEnd();
 }


### PR DESCRIPTION
## Причина
ChatGPT Secure MCP Tunnel изпраща точния OpenAI-hosted tunnel URL като OAuth `resource`, а backend-ът приемаше само публичния каноничен `https://synchron.foundation/mcp`. Това прекъсваше authorization заявката с `invalid_target` преди consent/token exchange.

## Поправка
- добавя един точен, конфигуриран OpenAI Secure MCP Tunnel resource alias;
- запазва каноничния публичен MCP resource и всички PKCE/CIMD/redirect/state/scope проверки;
- пренася точния заявен resource през consent, code, access token, refresh token и bearer validation;
- отхвърля друг tunnel ID и произволен външен URL;
- добавя production конфигурацията за текущия одобрен tunnel;
- прави production-smoke теста CRLF-съвместим в Windows.

## Проверки
- targeted OAuth + production-smoke tests: зелени;
- full test suite: 644 pass, 0 fail, 1 skip (Bash unavailable в локалната Windows среда);
- production dependency audit: 0 vulnerabilities;
- `git diff --check`: clean.