### PR TITLE
Поправка на cross-platform маршрутите за AI CORE

### DIFF
--- a/server.js
+++ b/server.js
@@ -96,20 +96,20 @@ app.get("/assets/:version/:asset", (req, res, next) => {
   }
 
   res.setHeader("Cache-Control", "no-store, max-age=0");
-  res.sendFile(`${process.cwd()}/${assetPath}`);
+  res.sendFile(assetPath, { root: process.cwd() });
 });
 app.get(
   `/assets/${mobileLayoutAssetVersion}/synchron-vision.css`,
   (_req, res) => {
     res.setHeader("Cache-Control", "no-store, max-age=0");
-    res.sendFile(`${process.cwd()}/public/synchron-vision.css`);
+    res.sendFile("public/synchron-vision.css", { root: process.cwd() });
   },
 );
 app.get(
   `/assets/${mobileLayoutAssetVersion}/synchron-vision.js`,
   (_req, res) => {
     res.setHeader("Cache-Control", "no-store, max-age=0");
-    res.sendFile(`${process.cwd()}/public/synchron-vision.js`);
+    res.sendFile("public/synchron-vision.js", { root: process.cwd() });
   },
 );
 app.use("/", mcpOAuthRouter);
@@ -214,11 +214,11 @@ app.use(
 );
 
 app.get("/", (_req, res) => {
-  res.sendFile(`${process.cwd()}/public/index.html`);
+  res.sendFile("public/index.html", { root: process.cwd() });
 });
 
 app.get("/register", (_req, res) => {
-  res.sendFile(`${process.cwd()}/public/index.html`);
+  res.sendFile("public/index.html", { root: process.cwd() });
 });
 
 if (process.env.NODE_ENV !== "test") {


### PR DESCRIPTION
## Промяна

- Express вече подава статичните AI CORE файлове чрез `root` и относителен път.
- Поправени са `/register` и versioned asset маршрутите на Windows без промяна на allowlist логиката.

## Проверка

- `npm test`: 647 успешни, 1 пропуснат, 0 неуспешни
- `npm audit --omit=dev --audit-level=high`: 0 уязвимости
- Production read-only проверка: `/health`, `/health/ready`, `/health/bridge`, `/health/mcp-status` и MCP catalog са успешни.

Cloudflare API token не е добавян; production инструментът остава `unavailable`, докато не бъде разрешено добавяне/ротация на secret.