### PR TITLE
Добавяне на robots.txt и sitemap.xml за публично индексиране

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://synchron.foundation/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://synchron.foundation/</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Промяна

- добавя `public/robots.txt`, който разрешава публично обхождане;
- добавя `public/sitemap.xml` с началната страница `https://synchron.foundation/`;
- `robots.txt` сочи към sitemap-а.

## Цел

Да дадем на търсачките стандартните crawl файлове, които липсват в production.

## Ограничения

- няма промяна по DNS, Cloudflare или DigitalOcean;
- няма промяна по OpenAI, памет, auth или MCP;
- без merge и без deployment до изрично потвърждение.