### PR TITLE
Fix public site health check

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -19,7 +19,7 @@ services:
     instance_size_slug: apps-s-1vcpu-0.5gb
     http_port: 8080
     health_check:
-      http_path: /health/ready
+      http_path: /health
       initial_delay_seconds: 20
       period_seconds: 10
       timeout_seconds: 5


### PR DESCRIPTION
Променя DigitalOcean health check от dependency readiness към базовия /health endpoint, за да не се сваля публичният сайт при временен проблем с OpenAI или паметта.