### PR TITLE
Fix ChatGPT OAuth callback handoff

### DIFF
--- a/src/routes/mcpOAuthRouter.js
+++ b/src/routes/mcpOAuthRouter.js
@@ -14,6 +14,14 @@ import {
 
 const formParser = express.urlencoded({ extended: false, limit: "16kb" });
 const passThrough = (_req, _res, next) => next();
+const CHATGPT_OAUTH_CALLBACK_ORIGIN = "https://chatgpt.com";
+const MCP_OAUTH_CONTENT_SECURITY_POLICY = [
+  "default-src 'none'",
+  "base-uri 'none'",
+  `form-action 'self' ${CHATGPT_OAUTH_CALLBACK_ORIGIN}`,
+  "frame-ancestors 'none'",
+  "style-src 'unsafe-inline'",
+].join("; ");
 const SCOPE_LABELS = Object.freeze({
   "synchron:read": "Четене на разрешените данни и системни статуси",
   "synchron:agent.chat": "Разговор с AI CORE в собствения профил",
@@ -34,6 +42,10 @@ function noStore(res) {
 
 function preserveOAuthPopupHandoff(res) {
   res.set("Cross-Origin-Opener-Policy", "unsafe-none");
+  // The consent form posts to this origin, then redirects to ChatGPT's exact
+  // validated OAuth callback. The global form-action 'self' policy blocks that
+  // redirect before ChatGPT can exchange the authorization code.
+  res.set("Content-Security-Policy", MCP_OAUTH_CONTENT_SECURITY_POLICY);
 }
 
 function escapeHtml(value) {

--- a/tests/mcpOAuthRouter.test.js
+++ b/tests/mcpOAuthRouter.test.js
@@ -368,7 +368,7 @@ test("authorization consent issues a code bound to the browser profile", async (
   else process.env.MCP_ACCESS_TOKEN = previous;
 });
 
-test("authorization flow overrides global COOP so ChatGPT can complete the popup handoff", async () => {
+test("authorization flow permits only the ChatGPT callback through global browser isolation", async () => {
   resetMcpOAuthStateForTests();
   const previous = process.env.MCP_ACCESS_TOKEN;
   process.env.MCP_ACCESS_TOKEN = SECRET;
@@ -384,6 +384,10 @@ test("authorization flow overrides global COOP so ChatGPT can complete the popup
     };
     const app = express();
     app.use((_req, res, next) => {
+      res.setHeader(
+        "Content-Security-Policy",
+        "default-src 'self'; form-action 'self'; frame-ancestors 'none'",
+      );
       res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
       res.setHeader("Cross-Origin-Resource-Policy", "same-origin");
       next();
@@ -406,6 +410,14 @@ test("authorization flow overrides global COOP so ChatGPT can complete the popup
     )?.[1];
     assert.ok(consentToken);
     assert.equal(consent.headers["cross-origin-opener-policy"], "unsafe-none");
+    assert.match(
+      consent.headers["content-security-policy"],
+      /form-action 'self' https:\/\/chatgpt\.com/u,
+    );
+    assert.doesNotMatch(
+      consent.headers["content-security-policy"],
+      /attacker\.example/u,
+    );
 
     const approved = await request(app)
       .post("/oauth/authorize")
@@ -418,6 +430,10 @@ test("authorization flow overrides global COOP so ChatGPT can complete the popup
     assert.equal(callback.searchParams.get("state"), oauthRequest.state);
     assert.match(callback.searchParams.get("code"), /^sx-code\./u);
     assert.equal(approved.headers["cross-origin-opener-policy"], "unsafe-none");
+    assert.match(
+      approved.headers["content-security-policy"],
+      /form-action 'self' https:\/\/chatgpt\.com/u,
+    );
     assert.equal(
       approved.headers["cross-origin-resource-policy"],
       "same-origin",


### PR DESCRIPTION
## Какво се променя

- добавя тесен OAuth CSP за consent екрана;
- разрешава `form-action` само към собствения домейн и `https://chatgpt.com`;
- запазва останалата browser isolation защита;
- добавя регресионен тест за реалния ChatGPT callback.

## Причина

Глобалният `form-action 'self'` позволяваше POST към `/oauth/authorize`, но блокираше последващото пренасочване към валидирания ChatGPT OAuth callback. Затова ChatGPT никога не стигаше до `/oauth/token` и плъгинът оставаше без инструменти.

## Проверка

- `pnpm test`
- 650 теста: 649 успешни, 1 пропуснат, 0 грешки
- `git diff --check` без грешки
