### PR TITLE
Normalize Cloudflare API token format

### DIFF
--- a/src/services/cloudflareService.js
+++ b/src/services/cloudflareService.js
@@ -25,7 +25,10 @@ function normalizeZoneName(value) {
 }
 
 function requiredConfig(env = process.env) {
-  const token = env.CLOUDFLARE_API_TOKEN;
+  const token = String(env.CLOUDFLARE_API_TOKEN || "")
+    .trim()
+    .replace(/^(?:Bearer\s+)+/iu, "")
+    .trim();
   const zoneId = String(env.CLOUDFLARE_ZONE_ID || "").trim() || null;
   const zoneName = normalizeZoneName(
     env.CLOUDFLARE_ZONE_NAME || DEFAULT_ZONE_NAME,

--- a/tests/infrastructureBridges.test.js
+++ b/tests/infrastructureBridges.test.js
@@ -515,7 +515,10 @@ test("Cloudflare bridge reads zone and DNS without writes", async () => {
     });
   };
   const status = await getCloudflareZoneStatus({
-    env: { CLOUDFLARE_API_TOKEN: "secret", CLOUDFLARE_ZONE_ID: "zone-1" },
+    env: {
+      CLOUDFLARE_API_TOKEN: "  Bearer secret  ",
+      CLOUDFLARE_ZONE_ID: "zone-1",
+    },
     fetchImpl,
   });
   assert.equal(status.status, "active");
@@ -524,6 +527,11 @@ test("Cloudflare bridge reads zone and DNS without writes", async () => {
   assert.ok(
     calls.every(
       (call) => !call.options.method || call.options.method === "GET",
+    ),
+  );
+  assert.ok(
+    calls.every(
+      (call) => call.options.headers.Authorization === "Bearer secret",
     ),
   );
   assert.doesNotMatch(JSON.stringify(status), /secret/u);


### PR DESCRIPTION
## Summary
- trim the configured Cloudflare API token
- remove accidental Bearer prefixes before building the authorization header
- verify that the outgoing header contains exactly one Bearer prefix

## Verification
- pnpm test: 650 passed, 1 skipped, 0 failed