### PR TITLE
Support direct pull request status checks

### DIFF
--- a/src/services/copilotTaskService.js
+++ b/src/services/copilotTaskService.js
@@ -396,6 +396,9 @@ export async function getCopilotTaskStatus({
               }
             }
           }
+          pullRequest(number: $issueNumber) {
+            ...CopilotPullRequestStatus
+          }
         }
       }
 
@@ -456,17 +459,31 @@ export async function getCopilotTaskStatus({
     { owner, name, issueNumber: cleanIssueNumber },
     fetchImpl,
   );
-  const issue = data?.repository?.issue;
-  if (!issue?.number || !issue?.url) {
+  const issue = data?.repository?.issue || null;
+  const directPullRequest = data?.repository?.pullRequest || null;
+  if (
+    (!issue?.number || !issue?.url) &&
+    (!directPullRequest?.number || !directPullRequest?.url)
+  ) {
     throw new CopilotTaskError(
-      "GitHub задачата не е намерена в разрешеното хранилище.",
+      "GitHub задачата или Pull Request-ът не е намерен в разрешеното хранилище.",
       404,
       "COPILOT_TASK_NOT_FOUND",
     );
   }
+  const trackedItem =
+    issue ||
+    Object.freeze({
+      number: directPullRequest.number,
+      title: directPullRequest.title,
+      url: directPullRequest.url,
+      state: directPullRequest.state === "OPEN" ? "OPEN" : "CLOSED",
+      assignees: { nodes: [] },
+    });
   const pullRequests = [
-    ...(issue.closedByPullRequestsReferences?.nodes || []),
-    ...(issue.timelineItems?.nodes || [])
+    ...(directPullRequest ? [directPullRequest] : []),
+    ...(issue?.closedByPullRequestsReferences?.nodes || []),
+    ...(issue?.timelineItems?.nodes || [])
       .map((event) => event?.source)
       .filter(Boolean),
   ].filter(
@@ -484,12 +501,13 @@ export async function getCopilotTaskStatus({
   );
   return Object.freeze({
     repository,
+    resourceType: issue ? "issue" : "pull-request",
     issue: {
-      number: issue.number,
-      title: issue.title,
-      url: issue.url,
-      state: issue.state,
-      copilotAssigned: hasConfirmedCopilotAssignee(issue),
+      number: trackedItem.number,
+      title: trackedItem.title,
+      url: trackedItem.url,
+      state: trackedItem.state,
+      copilotAssigned: hasConfirmedCopilotAssignee(trackedItem),
     },
     pullRequest: pullRequest
       ? {
@@ -507,7 +525,7 @@ export async function getCopilotTaskStatus({
         }
       : null,
     checks,
-    status: classifyCopilotTask(issue, pullRequest),
+    status: classifyCopilotTask(trackedItem, pullRequest),
   });
 }
 
@@ -528,15 +546,18 @@ export function formatCopilotTaskStatus(result) {
   const failedChecks = result.checks.filter((check) =>
     ["ERROR", "FAILURE", "CANCELLED", "TIMED_OUT"].includes(check.state),
   );
+  const isDirectPullRequest = result.resourceType === "pull-request";
   return [
-    `GitHub задача #${result.issue.number}: ${result.issue.title}`,
+    `${isDirectPullRequest ? "GitHub Pull Request" : "GitHub задача"} #${result.issue.number}: ${result.issue.title}`,
     `Състояние: ${labels[result.status] || result.status}.`,
-    `Задача: ${result.issue.url}`,
-    ...(result.pullRequest
+    `${isDirectPullRequest ? "Pull Request" : "Задача"}: ${result.issue.url}`,
+    ...(result.pullRequest && !isDirectPullRequest
       ? [
           `Pull Request: #${result.pullRequest.number} — ${result.pullRequest.url}`,
-          `Клон: ${result.pullRequest.headRef} → ${result.pullRequest.baseRef}`,
         ]
+      : []),
+    ...(result.pullRequest
+      ? [`Клон: ${result.pullRequest.headRef} → ${result.pullRequest.baseRef}`]
       : []),
     ...(failedChecks.length
       ? [

--- a/src/services/mcpReadService.js
+++ b/src/services/mcpReadService.js
@@ -248,13 +248,17 @@ export const MCP_TOOLS = Object.freeze([
   },
   {
     name: "get_github_copilot_task_status",
-    title: "Проследи GitHub Copilot задача",
+    title: "Проследи GitHub Copilot задача или Pull Request",
     description:
-      "Проверява реалното състояние на конкретна GitHub задача, свързания Pull Request, CI проверките и production smoke статуса. Не променя нищо.",
+      "Проверява реалното състояние на конкретна GitHub задача или директен Pull Request, CI проверките и production smoke статуса. Не променя нищо.",
     inputSchema: {
       type: "object",
       properties: {
-        issueNumber: { type: "integer", minimum: 1 },
+        issueNumber: {
+          type: "integer",
+          minimum: 1,
+          description: "Номер на GitHub issue или Pull Request.",
+        },
       },
       required: ["issueNumber"],
       additionalProperties: false,
@@ -547,9 +551,12 @@ export function createMcpRequestHandler({
     } else if (name === "get_github_copilot_task_status") {
       const issueNumber = Number(args?.issueNumber);
       if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
-        throw Object.assign(new Error("Невалиден номер на GitHub задача."), {
-          code: -32602,
-        });
+        throw Object.assign(
+          new Error("Невалиден номер на GitHub задача или Pull Request."),
+          {
+            code: -32602,
+          },
+        );
       }
       const githubSession = await getLatestGitHubSession();
       const status = await getGitHubTaskStatus({

--- a/tests/copilotTaskService.test.js
+++ b/tests/copilotTaskService.test.js
@@ -417,6 +417,72 @@ test("tracks a Copilot issue through a green production status", async () => {
   assert.match(formatCopilotTaskStatus(result), /pull\/146/u);
 });
 
+test("tracks a direct Pull Request number through production status", async () => {
+  const session = await connectedSession();
+  const result = await getCopilotTaskStatus({
+    githubSessionId: session.id,
+    issueNumber: 302,
+    repository: REPOSITORY,
+    fetchImpl: async (_url, options) => {
+      const request = JSON.parse(options.body);
+      assert.match(request.query, /pullRequest\(number: \$issueNumber\)/u);
+      return new Response(
+        JSON.stringify({
+          data: {
+            repository: {
+              issue: null,
+              pullRequest: {
+                number: 302,
+                title: "Подобри GitHub status",
+                url: "https://github.com/example/repo/pull/302",
+                state: "MERGED",
+                isDraft: false,
+                merged: true,
+                mergedAt: "2026-08-09T01:00:00Z",
+                baseRefName: "main",
+                headRefName: "codex/github-status",
+                headRefOid: "head302",
+                statusCheckRollup: {
+                  state: "SUCCESS",
+                  contexts: { nodes: [] },
+                },
+                mergeCommit: {
+                  oid: "merge302",
+                  statusCheckRollup: {
+                    state: "SUCCESS",
+                    contexts: {
+                      nodes: [
+                        {
+                          __typename: "StatusContext",
+                          context: "synchron/production-smoke",
+                          state: "SUCCESS",
+                          targetUrl: "https://github.com/example/run/302",
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+        { status: 200 },
+      );
+    },
+  });
+
+  assert.equal(result.resourceType, "pull-request");
+  assert.equal(result.issue.number, 302);
+  assert.equal(result.pullRequest.number, 302);
+  assert.equal(result.pullRequest.mergeSha, "merge302");
+  assert.equal(result.status, "real-tested");
+  assert.match(formatCopilotTaskStatus(result), /GitHub Pull Request #302/u);
+  assert.doesNotMatch(
+    formatCopilotTaskStatus(result),
+    /Pull Request: #302/u,
+  );
+});
+
 test("requires an exact one-time confirmation before starting Copilot", async () => {
   const session = await connectedSession();
   const prepared = await prepareCopilotTask({


### PR DESCRIPTION
## Промяна
- get_github_copilot_task_status приема issue или директен Pull Request номер
- GraphQL проверява и двата resource типа
- отговорът различава директен PR чрез resourceType
- MCP описанието и грешките са уточнени

## Проверки
- целеви тестове: 29/29
- пълен suite: 651 успешни, 0 провалени, 1 очаквано пропуснат

Не включва merge или deployment.