### PR TITLE
Use GitHub issue or pull request union

### DIFF
--- a/src/services/copilotTaskService.js
+++ b/src/services/copilotTaskService.js
@@ -373,31 +373,34 @@ export async function getCopilotTaskStatus({
         $issueNumber: Int!
       ) {
         repository(owner: $owner, name: $name) {
-          issue(number: $issueNumber) {
-            number
-            title
-            url
-            state
-            assignees(first: 10) { nodes { login } }
-            closedByPullRequestsReferences(first: 20) {
-              nodes {
-                ...CopilotPullRequestStatus
+          issueOrPullRequest(number: $issueNumber) {
+            __typename
+            ... on Issue {
+              number
+              title
+              url
+              state
+              assignees(first: 10) { nodes { login } }
+              closedByPullRequestsReferences(first: 20) {
+                nodes {
+                  ...CopilotPullRequestStatus
+                }
               }
-            }
-            timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT]) {
-              nodes {
-                ... on CrossReferencedEvent {
-                  source {
-                    ... on PullRequest {
-                      ...CopilotPullRequestStatus
+              timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT]) {
+                nodes {
+                  ... on CrossReferencedEvent {
+                    source {
+                      ... on PullRequest {
+                        ...CopilotPullRequestStatus
+                      }
                     }
                   }
                 }
               }
             }
-          }
-          pullRequest(number: $issueNumber) {
-            ...CopilotPullRequestStatus
+            ... on PullRequest {
+              ...CopilotPullRequestStatus
+            }
           }
         }
       }
@@ -459,8 +462,10 @@ export async function getCopilotTaskStatus({
     { owner, name, issueNumber: cleanIssueNumber },
     fetchImpl,
   );
-  const issue = data?.repository?.issue || null;
-  const directPullRequest = data?.repository?.pullRequest || null;
+  const trackedResource = data?.repository?.issueOrPullRequest || null;
+  const issue = trackedResource?.__typename === "Issue" ? trackedResource : null;
+  const directPullRequest =
+    trackedResource?.__typename === "PullRequest" ? trackedResource : null;
   if (
     (!issue?.number || !issue?.url) &&
     (!directPullRequest?.number || !directPullRequest?.url)

--- a/tests/copilotTaskService.test.js
+++ b/tests/copilotTaskService.test.js
@@ -354,11 +354,13 @@ test("tracks a Copilot issue through a green production status", async () => {
     fetchImpl: async (_url, options) => {
       const request = JSON.parse(options.body);
       assert.match(request.query, /CopilotTaskStatus/u);
+      assert.match(request.query, /issueOrPullRequest/u);
       return new Response(
         JSON.stringify({
           data: {
             repository: {
-              issue: {
+              issueOrPullRequest: {
+                __typename: "Issue",
                 number: 83,
                 title: "Проследи Copilot",
                 url: "https://github.com/example/repo/issues/83",
@@ -425,13 +427,16 @@ test("tracks a direct Pull Request number through production status", async () =
     repository: REPOSITORY,
     fetchImpl: async (_url, options) => {
       const request = JSON.parse(options.body);
-      assert.match(request.query, /pullRequest\(number: \$issueNumber\)/u);
+      assert.match(
+        request.query,
+        /issueOrPullRequest\(number: \$issueNumber\)/u,
+      );
       return new Response(
         JSON.stringify({
           data: {
             repository: {
-              issue: null,
-              pullRequest: {
+              issueOrPullRequest: {
+                __typename: "PullRequest",
                 number: 302,
                 title: "Подобри GitHub status",
                 url: "https://github.com/example/repo/pull/302",


### PR DESCRIPTION
## Причина
Истинският GitHub GraphQL отговор за директен PR изисква Repository.issueOrPullRequest. Отделното issue(number:) поле може да провали заявката за PR номер.

## Промяна
- използва официалния IssueOrPullRequest union
- различава Issue и PullRequest чрез __typename
- актуализира двата regression теста

## Проверки
- целеви тестове: 29/29
- пълен suite: 651 успешни, 0 провалени, 1 очаквано пропуснат