### PR TITLE
Поправка на timeout при проверка на backup health

### DIFF
--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -29,6 +29,7 @@ import { listTools, registerCoreTools } from "../tools/toolRegistry.js";
 
 const router = express.Router();
 const DEFAULT_READINESS_TIMEOUT_MS = 2_000;
+const DEFAULT_BACKUP_ROUTE_TIMEOUT_MS = 10_000;
 const DEFAULT_OPENSEARCH_BACKUP_MAX_AGE_HOURS = 48;
 const MAX_VERIFIED_BACKUP_CACHE_TTL_MS = 6 * 60 * 60_000;
 const FAILED_BACKUP_CACHE_TTL_MS = 15_000;
@@ -89,10 +90,10 @@ export function resolveStorageBackupCacheTtlMs(
   );
 }
 
-async function withTimeout(promise, timeoutMs) {
+async function withTimeout(promise, timeoutMs, code = "READINESS_TIMEOUT") {
   let timer;
   const timeout = new Promise((_, reject) => {
-    timer = setTimeout(() => reject(new Error("READINESS_TIMEOUT")), timeoutMs);
+    timer = setTimeout(() => reject(new Error(code)), timeoutMs);
   });
 
   try {
@@ -217,10 +218,20 @@ function publicBackupStatus(report) {
 
 export function createStorageBackupsHandler({
   loadStatus = loadStorageBackups,
+  timeoutMs = DEFAULT_BACKUP_ROUTE_TIMEOUT_MS,
 } = {}) {
   return async function storageBackupsHandler(_req, res) {
     setPrivateHealthHeaders(res);
-    const report = await loadStatus();
+    let report;
+    try {
+      report = await withTimeout(
+        loadStatus(),
+        timeoutMs,
+        "BACKUP_HEALTH_TIMEOUT",
+      );
+    } catch {
+      report = unavailableBackupReport();
+    }
     const result = publicBackupStatus(report);
     res.status(result.status === "verified" ? 200 : 503).json(result);
   };

--- a/tests/healthRoutes.test.js
+++ b/tests/healthRoutes.test.js
@@ -215,6 +215,26 @@ test("backup health exposes status without counts, dates or resource ids", async
   );
 });
 
+test("backup health turns a stalled loader into a safe 503 response", async () => {
+  const app = express();
+  app.get(
+    "/health/backups",
+    createStorageBackupsHandler({
+      timeoutMs: 5,
+      loadStatus: () => new Promise(() => {}),
+    }),
+  );
+
+  const response = await request(app).get("/health/backups").expect(503);
+  assert.equal(response.headers["cache-control"], "no-store, max-age=0");
+  assert.equal(response.body.status, "unavailable");
+  assert.equal(
+    response.body.checks.opensearch.errorCode,
+    "STORAGE_BACKUP_REPORT_FAILED",
+  );
+  assert.equal(response.body.checks.opensearch.provesRestore, false);
+});
+
 test("storage report keeps partial evidence readable without changing health semantics", async () => {
   const app = express();
   app.get(


### PR DESCRIPTION
## Промяна

- Ограничавам /health/backups до 10 секунди.
- При timeout или loader failure връщам безопасен 503 JSON вместо gateway timeout.
- Добавям regression test за stalled loader.

## Проверка

- npm test: 652 успешни, 1 пропуснат
- npm audit --omit=dev --audit-level=high: 0 уязвимости