### PR TITLE
Add Google Cloud deployment foundation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.do
+.env
+.env.*
+node_modules
+runtime-build-info.json
+*.log
+docs
+tests
+deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22-bookworm-slim
+
+ARG APP_COMMIT_SHA=unknown
+
+ENV NODE_ENV=production \
+    PORT=8080 \
+    APP_COMMIT_SHA=${APP_COMMIT_SHA}
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY scripts ./scripts
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY --chown=node:node . .
+
+USER node
+
+EXPOSE 8080
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ npm test
 оценка на външни инструменти са в
 [`docs/PRODUCT_DIRECTION.md`](docs/PRODUCT_DIRECTION.md). Кандидат в този
 документ не означава внедрена или работеща production интеграция.
+
+Планираната Google Cloud foundation е отделна и не променя текущия production
+канал. Каталогът, Cloud Run health contract-ът и migration gates са в
+[`docs/GOOGLE_CLOUD_CONFIGURATION_CATALOG.md`](docs/GOOGLE_CLOUD_CONFIGURATION_CATALOG.md).

--- a/deploy/cloud-run/service.yaml.template
+++ b/deploy/cloud-run/service.yaml.template
@@ -1,0 +1,45 @@
+# Шаблонът е непълен нарочно. Замени всички __PLACEHOLDER__ стойности,
+# прегледай migration gates и не го прилагай без изрично одобрение.
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: "__CLOUD_RUN_SERVICE_NAME__"
+  labels:
+    app.kubernetes.io/name: synchron-backend
+    synchron.foundation/migration-stage: foundation-only
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: synchron-backend
+    spec:
+      serviceAccountName: "__CLOUD_RUN_RUNTIME_SERVICE_ACCOUNT__"
+      containerConcurrency: 20
+      timeoutSeconds: 300
+      containers:
+        - name: web
+          image: "__ARTIFACT_REGISTRY_IMAGE_URI__"
+          ports:
+            - name: http1
+              containerPort: 8080
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: PORT
+              value: "8080"
+            - name: APP_COMMIT_SHA
+              value: "__COMMIT_SHA__"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/docs/CURRENT_PRODUCT_ACCEPTANCE.md
+++ b/docs/CURRENT_PRODUCT_ACCEPTANCE.md
@@ -66,6 +66,9 @@ production проверките винаги се установяват по
 5. Supabase backup и възстановяване. При текущия Free Plan project backup няма;
    dashboard посочва до 7 дни scheduled backups при платен Pro plan, но upgrade
    не е разрешен и не е включван.
+6. Google Cloud migration. Cloud Run template-ът и конфигурационният каталог са
+   planning-only; няма приет GCP deployment, Firestore data plane, Identity
+   Platform user migration или Vertex AI production provider.
 
 ## Следващи стъпки
 
@@ -84,6 +87,13 @@ production проверките винаги се установяват по
    съхранение и restore тест; не е включен. Преди решение се показват актуалната
    цена и пълният план; upgrade или нов secret не се добавят автоматично.
 6. Restore drill само след отделното одобрение по-долу.
+
+Google Cloud migration има отделен ред в
+[`GOOGLE_CLOUD_CONFIGURATION_CATALOG.md`](./GOOGLE_CLOUD_CONFIGURATION_CATALOG.md).
+Той не променя DigitalOcean baseline, OpenSearch memory или Supabase identity.
+Няма приети Cloud Run resources, secrets, DNS промени или прехвърлени лични
+данни, докато exact-SHA runtime, cost/IAM, data/identity, provider и rollback
+gates не бъдат доказани поотделно.
 
 ## Посока след текущото приемане
 

--- a/docs/GOOGLE_CLOUD_CONFIGURATION_CATALOG.md
+++ b/docs/GOOGLE_CLOUD_CONFIGURATION_CATALOG.md
@@ -1,8 +1,8 @@
 # SYNCHRON-X — Google Cloud configuration catalog и migration gates
 
 Този документ е planning-only граница за бъдещ Cloud Run migration. Той не
-доказва създаден Google Cloud ресурс, не добавя secret и не променя текущия
-production deployment.
+доказва създаден Google Cloud ресурс, няма secret стойност и не променя
+текущия production deployment.
 
 ## Текуща authoritative граница
 
@@ -12,7 +12,8 @@ production deployment.
 - Съществуващият `GOOGLE_CLIENT_*` поток е Google OAuth за Drive/Calendar/Gmail,
   а не Identity Platform migration.
 - Firestore, Identity Platform и Vertex AI са planning-only. Няма runtime
-  adapter, data import, user import или provider selection в този слой.
+  adapter, data import, data migration, user import или provider selection в този
+  слой.
 - Cloud Run template-ът е нарочно непълен: има placeholders и няма secret
   references, IAM binding, public invoker или DNS промяна.
 

--- a/docs/GOOGLE_CLOUD_CONFIGURATION_CATALOG.md
+++ b/docs/GOOGLE_CLOUD_CONFIGURATION_CATALOG.md
@@ -1,0 +1,122 @@
+# SYNCHRON-X — Google Cloud configuration catalog и migration gates
+
+Този документ е planning-only граница за бъдещ Cloud Run migration. Той не
+доказва създаден Google Cloud ресурс, не добавя secret и не променя текущия
+production deployment.
+
+## Текуща authoritative граница
+
+- DigitalOcean App Platform остава единственият production deployment канал.
+- OpenSearch остава authoritative за личната и разговорната памет.
+- Supabase остава authoritative за текущите тестови профили и сесии.
+- Съществуващият `GOOGLE_CLIENT_*` поток е Google OAuth за Drive/Calendar/Gmail,
+  а не Identity Platform migration.
+- Firestore, Identity Platform и Vertex AI са planning-only. Няма runtime
+  adapter, data import, user import или provider selection в този слой.
+- Cloud Run template-ът е нарочно непълен: има placeholders и няма secret
+  references, IAM binding, public invoker или DNS промяна.
+
+## Non-secret configuration catalog
+
+Тези полета са deploy-time configuration или документационни имена. Те не
+трябва да се добавят в `.env`, да съдържат token стойности или да се показват
+като runtime readiness без изпълним и приет адаптер.
+
+| Област | Поле | Статус и граница |
+| --- | --- | --- |
+| Google Cloud | `GCP_PROJECT_ID` | Избира се изрично за изолирана среда; не се създава в този PR. |
+| Google Cloud | `GCP_REGION` | Избира се с оглед latency, residency и цена; не се фиксира автоматично. |
+| Artifact Registry | `ARTIFACT_REGISTRY_REPOSITORY` | Само бъдещо име на repository; image се публикува едва след отделно одобрение. |
+| Cloud Run | `CLOUD_RUN_SERVICE_NAME` | Бъдещо име на service; placeholder в template-а. |
+| Cloud Run | `CLOUD_RUN_RUNTIME_SERVICE_ACCOUNT` | Бъдещ runtime identity; IAM role grant не се прави тук. |
+| Cloud Run | `IMAGE_URI` | Трябва да сочи към exact immutable image/commit, не към `latest`. |
+| Runtime | `APP_COMMIT_SHA` | Задължителен exact provenance за `/health`; неизвестен SHA не е acceptance. |
+| Runtime | `NODE_ENV` / `PORT` | `production` и `8080`; вече съществуващият Express contract се запазва. |
+| Cloud Run | `containerConcurrency` / `timeoutSeconds` | Начални консервативни стойности са в template-а; променят се само след load/cost проверка. |
+
+## Secrets и service identity
+
+Cloud Run трябва да използва Application Default Credentials чрез runtime
+service account. Не се добавя `GOOGLE_APPLICATION_CREDENTIALS`, JSON key или
+secret стойност в image, YAML или Git.
+
+Бъдещ Secret Manager mapping може да съдържа само одобрени имена/reference-и,
+например:
+
+- OpenSearch host/port/username/password и memory owner;
+- OpenAI, Gemini и Grok API keys;
+- Supabase session encryption key и tester invite code;
+- GitHub/Google OAuth secrets и session encryption keys;
+- MCP и само разрешените infrastructure diagnostics secrets.
+
+Тези references не се създават, попълват или ротират в този слой. При бъдещ
+staging deploy всеки reference трябва да има owner, IAM scope, rotation plan и
+rollback plan. Липсващ или невалиден reference трябва да остави системата
+not-ready, а не да активира fallback с друг secret.
+
+## Firestore — бъдещ изолиран control plane
+
+| Поле | Предназначение | Приемателна граница |
+| --- | --- | --- |
+| `FIRESTORE_DATABASE_ID` | Бъдещ database идентификатор | Не се provision-ва и не заменя OpenSearch. |
+| `FIRESTORE_LOCATION` | Регион и data residency | Нужни са cost, residency и backup решения преди ресурс. |
+| `FIRESTORE_COLLECTION_PREFIX` | Изолирано име на бъдещи колекции | Няма production collections или import в този PR. |
+| `FIRESTORE_ENABLED` | Бъдещ feature flag | Остава `false`/липсващ до изпълним adapter и тестов sandbox. |
+
+Първият тест трябва да е с изолиран non-production database/namespace, ясна
+schema, backup/restore план и cleanup. Няма четене, запис, restore или изтриване
+на лични данни за целите на migration foundation.
+
+## Identity Platform — бъдещ auth pilot
+
+Бъдещият каталог може да съдържа `IDENTITY_PLATFORM_TENANT_ID`,
+`IDENTITY_PLATFORM_PROJECT_ID`, provider IDs, authorized domains, redirect URI,
+email verification, MFA и session policy. Това са configuration boundaries, не
+готова интеграция.
+
+Приемането започва само с изолиран тестов tenant/account и проверка на
+signup → logout → login, session protection и rollback. Няма миграция на
+Supabase users, sessions или лични профили, няма промяна на текущия Google OAuth
+поток и няма DNS/authorized-domain промяна в този PR.
+
+## Vertex AI — бъдещ provider pilot
+
+Бъдещите non-secret полета са `VERTEX_AI_PROJECT_ID`,
+`VERTEX_AI_LOCATION`, `VERTEX_AI_MODEL`, `VERTEX_AI_TIMEOUT_MS` и
+`VERTEX_AI_ENABLED=false`. Достъпът трябва да е чрез runtime service account и
+одобрена `roles/aiplatform.user` граница; ролята не се предоставя в този слой.
+
+Vertex AI не се добавя директно в AI Core и не става fallback. Реален provider
+трябва първо да има provider adapter, Capability Engine/Tool Registry boundary,
+rate/cost limit, isolated smoke и изрично owner acceptance. До тогава текущият
+OpenAI/Gemini/Grok contract остава непроменен.
+
+## Cloud Run health contract
+
+Cloud Run template-ът е в
+[`deploy/cloud-run/service.yaml.template`](../deploy/cloud-run/service.yaml.template).
+
+- `startupProbe` и `livenessProbe` използват `/health`, който публикува само
+  безопасна версия/commit информация и не зависи от OpenSearch, AI или bridge.
+- `/health/ready` остава по-тежката проверка на AI provider, OpenSearch,
+  memory acceptance и bridge. Cloud Run не го използва като liveness probe.
+- Readiness се приема чрез post-deploy smoke: exact image/commit, `/health`
+  `200`, `/health/ready` `200` и съвпадащи runtime проверки.
+- Няма `readinessProbe`, публичен invoker или ingress policy в този template;
+  тези решения изискват отделен IAM, cost, edge и rollback review.
+
+## Migration gates
+
+| Gate | Нужно доказателство | Стоп условие |
+| --- | --- | --- |
+| 0. Baseline | Чист branch върху одобрения AI CORE commit, `npm test`, production audit и потвърдени текущи DigitalOcean health/smoke checks. | Непознат diff, dirty state или разминаване на SHA. |
+| 1. Artifact | Локален `docker build` с exact commit и `docker run` smoke към `/health`; image-ът не съдържа `.env`/secret values. | `unknown` commit, лош probe, root runtime или липсващ порт 8080. |
+| 2. Изолиран GCP staging | Избран project/region, показана цена, Artifact Registry, runtime service account и Secret Manager references с least privilege. | Нова платена услуга, IAM write или secret без изрично owner одобрение. |
+| 3. Runtime acceptance | Cloud Run revision сочи exact immutable image; `/health`, `/health/ready` и безопасният smoke contract са зелени. | Readiness failure, dependency fallback, неочакван публичен достъп или неясен rollback. |
+| 4. Data/identity pilot | Само sandbox Firestore schema + backup/restore и тестов Identity Platform tenant с signup/logout/login. | Import на production данни, Supabase cutover, изтриване или липсващ cleanup. |
+| 5. Vertex pilot | Изолиран provider smoke, cost/quota ceiling, service-account scope и проверка през одобрен AI Core boundary. | Директен обход на Capability Engine, автоматичен fallback или production secret. |
+| 6. Cutover/rollback | Отделно owner решение, доказан rollback към DigitalOcean и повторен exact-SHA acceptance; DNS се разглежда отделно. | DNS промяна, production migration или deploy без изрично разрешение. |
+
+До преминаване на всички gates този документ описва само готовност за
+планиране. Не представяй template, регистриран service account, започнат
+deployment или наличен backup като production резултат.

--- a/docs/OPERATIONS_RUNBOOK.md
+++ b/docs/OPERATIONS_RUNBOOK.md
@@ -23,6 +23,19 @@ rollback. Историческите audit документи пазят кон�
 Не обявявай deployment за успешен само защото `/health` отговаря. Exact SHA,
 readiness и production smoke трябва да сочат една и съща версия.
 
+## Google Cloud migration boundary
+
+Cloud Run container/template foundation-ът е отделен от текущия DigitalOcean
+production канал. Конфигурационният каталог и migration gates са в
+[`GOOGLE_CLOUD_CONFIGURATION_CATALOG.md`](./GOOGLE_CLOUD_CONFIGURATION_CATALOG.md).
+Докато всички gates не са приети, не създавай GCP resource, secret, IAM binding,
+DNS промяна или data migration.
+
+Cloud Run използва `/health` само за startup/liveness. `/health/ready` остава
+deployment acceptance проверка, защото включва AI, OpenSearch, memory acceptance
+и bridge. Не използвай readiness endpoint като liveness probe и не приемай
+подготвен YAML или image като deployed/accepted.
+
 Флаговете `configured`, `registrationEnabled`, `projectConnection` и
 `sessionProtection` доказват само runtime конфигурация. Те не доказват, че нов
 потребител реално може да се регистрира, да излезе и да влезе отново. Това се

--- a/tests/cloudRunArtifacts.test.js
+++ b/tests/cloudRunArtifacts.test.js
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+
+test("Cloud Run container foundation is production-safe and commit-aware", async () => {
+  const [dockerfile, dockerignore] = await Promise.all([
+    read("../Dockerfile"),
+    read("../.dockerignore"),
+  ]);
+
+  assert.match(dockerfile, /^FROM node:22-bookworm-slim$/mu);
+  assert.match(dockerfile, /ARG APP_COMMIT_SHA=unknown/u);
+  assert.match(dockerfile, /PORT=8080/u);
+  assert.match(dockerfile, /npm ci --omit=dev/u);
+  assert.match(dockerfile, /USER node/u);
+  assert.match(dockerfile, /CMD \["npm", "start"\]/u);
+  assert.match(dockerignore, /^\.env$/mu);
+  assert.match(dockerignore, /^\.env\.\*$/mu);
+  assert.match(dockerignore, /^node_modules$/mu);
+  assert.match(dockerignore, /^runtime-build-info\.json$/mu);
+  assert.match(dockerignore, /^\.git$/mu);
+});
+
+test("Cloud Run template uses liveness without dependency-heavy readiness", async () => {
+  const template = await read("../deploy/cloud-run/service.yaml.template");
+
+  assert.match(template, /__CLOUD_RUN_SERVICE_NAME__/u);
+  assert.match(template, /__ARTIFACT_REGISTRY_IMAGE_URI__/u);
+  assert.match(template, /__COMMIT_SHA__/u);
+  assert.match(template, /containerPort: 8080/u);
+  assert.equal((template.match(/path: \/health/gu) || []).length, 2);
+  assert.match(template, /startupProbe:/u);
+  assert.match(template, /livenessProbe:/u);
+  assert.doesNotMatch(template, /readinessProbe:/u);
+  assert.doesNotMatch(template, /valueFrom:/u);
+  assert.doesNotMatch(template, /secretKeyRef:/u);
+  assert.doesNotMatch(template, /gcloud\s+(run|secrets)/iu);
+});
+
+test("Google Cloud catalog preserves data, secret and deployment boundaries", async () => {
+  const catalog = await read("../docs/GOOGLE_CLOUD_CONFIGURATION_CATALOG.md");
+
+  for (const marker of [
+    "OpenSearch остава authoritative",
+    "Supabase остава authoritative",
+    "Firestore",
+    "Identity Platform",
+    "Vertex AI",
+    "Secret Manager",
+    "DNS",
+    "data migration",
+    "Cloud Run health contract",
+    "Migration gates",
+  ]) {
+    assert.match(catalog, new RegExp(marker, "u"));
+  }
+
+  assert.match(catalog, /Няма runtime\s+adapter/u);
+  assert.match(catalog, /Няма миграция на\s+Supabase users/u);
+  assert.match(catalog, /няма secret\s+стойност/u);
+});

--- a/tests/operationalDocumentation.test.js
+++ b/tests/operationalDocumentation.test.js
@@ -11,6 +11,9 @@ const currentAcceptance = read("../docs/CURRENT_PRODUCT_ACCEPTANCE.md");
 const productDirection = read("../docs/PRODUCT_DIRECTION.md");
 const architecture = read("../docs/SYNCHRON-X-V3-ARCHITECTURE.md");
 const bridgeRunbook = read("../docs/BRIDGE_AND_DIAGNOSTICS.md");
+const googleCloudCatalog = read(
+  "../docs/GOOGLE_CLOUD_CONFIGURATION_CATALOG.md",
+);
 const historicalAudit = read("../docs/archive/TECHNICAL_AUDIT_2026-07.md");
 const historicalShortAudit = read(
   "../docs/archive/TECHNICAL_AUDIT_2026-07-31.md",
@@ -105,6 +108,38 @@ test("current acceptance separates verified state, blockers and explicit approva
   assert.match(currentAcceptance, /Supabase backup.*няма/su);
   assert.match(currentAcceptance, /merge в `main` и production deployment/u);
   assert.match(currentAcceptance, /PRODUCT_DIRECTION\.md/u);
+});
+
+test("Google Cloud foundation stays planning-only and preserves production boundaries", () => {
+  for (const document of [readme, runbook, currentAcceptance]) {
+    assert.match(
+      document,
+      /GOOGLE_CLOUD_CONFIGURATION_CATALOG\.md/u,
+    );
+  }
+
+  for (const marker of [
+    "OpenSearch остава authoritative",
+    "Supabase остава authoritative",
+    "Cloud Run",
+    "Firestore",
+    "Identity Platform",
+    "Vertex AI",
+    "няма secret",
+    "DNS",
+    "data migration",
+  ]) {
+    assert.match(googleCloudCatalog, new RegExp(marker, "u"));
+  }
+
+  assert.match(
+    googleCloudCatalog,
+    /Не се provision-ва и не заменя OpenSearch/u,
+  );
+  assert.match(
+    googleCloudCatalog,
+    /Няма миграция на\s+Supabase users/u,
+  );
 });
 
 test("product direction keeps UX ambition separate from verified tools", () => {


### PR DESCRIPTION
## Обобщение

- Добавя Node.js 22 Cloud Run container foundation с production-only install, `PORT=8080`, non-root runtime и exact commit provenance.
- Добавя непълен Cloud Run service template със `/health` startup/liveness probes; `/health/ready` остава acceptance gate.
- Добавя Google Cloud configuration catalog и migration gates за Cloud Run, Firestore, Identity Platform и Vertex AI.
- Свързва документацията и добавя focused artifact/documentation tests.

## Граници

Този PR не създава Google Cloud ресурси, не добавя или ротират secrets, не променя DNS, IAM, OpenSearch, Supabase или production runtime behavior. Firestore, Identity Platform и Vertex AI остават planning-only.

## Проверки

- `npm test`: 661 passed, 1 skipped.
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities.
- Статичните artifact, probe, boundary и `git diff --check` проверки са успешни.
- Docker smoke не е изпълнен, защото Docker daemon не е наличен в средата.
- Не е извикван `gcloud` и не е създаван външен Google Cloud ресурс.