### PR TITLE
fix: align DigitalOcean provider env checks with AI CORE

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ import {
 import { createRateLimiters } from "./src/middleware/rateLimits.js";
 import { startMemoryStartupVerification } from "./src/services/memoryStartupVerificationService.js";
 import { executeCapability } from "./src/tools/capabilityEngine.js";
+import { getAiProviderStatus } from "./src/services/aiCoreService.js";
 
 import chatRouter from "./src/routes/chat.js";
 import healthRouter from "./src/routes/health.js";
@@ -32,9 +33,10 @@ const { oauthRateLimiter, paidAiRateLimiter, privateApiRateLimiter } =
   createRateLimiters();
 const mcpOAuthRouter = createMcpOAuthRouter({ oauthRateLimiter });
 
-if (!process.env.OPENAI_API_KEY) {
+const aiProviderStatus = getAiProviderStatus(process.env);
+if (!aiProviderStatus.configured) {
   console.warn(
-    "⚠️  OPENAI_API_KEY is not configured. Direct AI conversation is unavailable; independent tools can still run.",
+    `⚠️  AI CORE provider ${aiProviderStatus.selectedProvider ?? "unknown"} is not configured. Direct AI conversation is unavailable; independent tools can still run.`,
   );
 }
 
@@ -252,3 +254,4 @@ function startServer() {
 }
 
 export default app;
+

--- a/server.js
+++ b/server.js
@@ -254,4 +254,10 @@ function startServer() {
 }
 
 export default app;
-
+[31;1mMethodException: [0m
+[31;1m[36;1mLine |[0m
+[31;1m[36;1m[36;1m   2 | [0m … Path 'server.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/server.js
+++ b/server.js
@@ -7,7 +7,6 @@ import {
 import { createRateLimiters } from "./src/middleware/rateLimits.js";
 import { startMemoryStartupVerification } from "./src/services/memoryStartupVerificationService.js";
 import { executeCapability } from "./src/tools/capabilityEngine.js";
-import { getAiProviderStatus } from "./src/services/aiCoreService.js";
 
 import chatRouter from "./src/routes/chat.js";
 import healthRouter from "./src/routes/health.js";
@@ -33,10 +32,9 @@ const { oauthRateLimiter, paidAiRateLimiter, privateApiRateLimiter } =
   createRateLimiters();
 const mcpOAuthRouter = createMcpOAuthRouter({ oauthRateLimiter });
 
-const aiProviderStatus = getAiProviderStatus(process.env);
-if (!aiProviderStatus.configured) {
+if (!process.env.OPENAI_API_KEY) {
   console.warn(
-    `⚠️  AI CORE provider ${aiProviderStatus.selectedProvider ?? "unknown"} is not configured. Direct AI conversation is unavailable; independent tools can still run.`,
+    "⚠️  OPENAI_API_KEY is not configured. Direct AI conversation is unavailable; independent tools can still run.",
   );
 }
 
@@ -254,10 +252,3 @@ function startServer() {
 }
 
 export default app;
-[31;1mMethodException: [0m
-[31;1m[36;1mLine |[0m
-[31;1m[36;1m[36;1m   2 | [0m … Path 'server.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ import {
 import { createRateLimiters } from "./src/middleware/rateLimits.js";
 import { startMemoryStartupVerification } from "./src/services/memoryStartupVerificationService.js";
 import { executeCapability } from "./src/tools/capabilityEngine.js";
+import { getAiProviderStatus } from "./src/services/aiCoreService.js";
 
 import chatRouter from "./src/routes/chat.js";
 import healthRouter from "./src/routes/health.js";
@@ -32,9 +33,10 @@ const { oauthRateLimiter, paidAiRateLimiter, privateApiRateLimiter } =
   createRateLimiters();
 const mcpOAuthRouter = createMcpOAuthRouter({ oauthRateLimiter });
 
-if (!process.env.OPENAI_API_KEY) {
+const aiProviderStatus = getAiProviderStatus(process.env);
+if (!aiProviderStatus.configured) {
   console.warn(
-    "⚠️  OPENAI_API_KEY is not configured. Direct AI conversation is unavailable; independent tools can still run.",
+    `⚠️  AI CORE provider ${aiProviderStatus.selectedProvider ?? "unknown"} is not configured. Direct AI conversation is unavailable; independent tools can still run.`,
   );
 }
 

--- a/src/services/aiCoreService.js
+++ b/src/services/aiCoreService.js
@@ -326,12 +326,6 @@ export function isAiCoreConfigured(env = process.env) {
   return Boolean(provider && isAiProviderConfigured(provider, env));
 }
 
-export function hasConfiguredAiProvider(env = process.env) {
-  return ["openai", "gemini", "grok"].some((provider) =>
-    isAiProviderConfigured(provider, env),
-  );
-}
-
 export function getAiProviderStatus(env = process.env) {
   const selectedProvider = getConfiguredAiProvider(env);
   const providers = ["openai", "gemini", "grok"].map((id) => ({
@@ -402,10 +396,3 @@ export async function requestOpenAIText(options) {
   const response = await requestOpenAIResponse(options);
   return response.text;
 }
-[31;1mMethodException: [0m
-[31;1m[36;1mLine |[0m
-[31;1m[36;1m[36;1m   2 | [0m … iCoreService.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/src/services/aiCoreService.js
+++ b/src/services/aiCoreService.js
@@ -402,4 +402,10 @@ export async function requestOpenAIText(options) {
   const response = await requestOpenAIResponse(options);
   return response.text;
 }
-
+[31;1mMethodException: [0m
+[31;1m[36;1mLine |[0m
+[31;1m[36;1m[36;1m   2 | [0m … iCoreService.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/src/services/aiCoreService.js
+++ b/src/services/aiCoreService.js
@@ -326,6 +326,12 @@ export function isAiCoreConfigured(env = process.env) {
   return Boolean(provider && isAiProviderConfigured(provider, env));
 }
 
+export function hasConfiguredAiProvider(env = process.env) {
+  return ["openai", "gemini", "grok"].some((provider) =>
+    isAiProviderConfigured(provider, env),
+  );
+}
+
 export function getAiProviderStatus(env = process.env) {
   const selectedProvider = getConfiguredAiProvider(env);
   const providers = ["openai", "gemini", "grok"].map((id) => ({

--- a/src/services/aiCoreService.js
+++ b/src/services/aiCoreService.js
@@ -326,6 +326,12 @@ export function isAiCoreConfigured(env = process.env) {
   return Boolean(provider && isAiProviderConfigured(provider, env));
 }
 
+export function hasConfiguredAiProvider(env = process.env) {
+  return ["openai", "gemini", "grok"].some((provider) =>
+    isAiProviderConfigured(provider, env),
+  );
+}
+
 export function getAiProviderStatus(env = process.env) {
   const selectedProvider = getConfiguredAiProvider(env);
   const providers = ["openai", "gemini", "grok"].map((id) => ({
@@ -396,3 +402,4 @@ export async function requestOpenAIText(options) {
   const response = await requestOpenAIResponse(options);
   return response.text;
 }
+

--- a/src/services/workspaceStateService.js
+++ b/src/services/workspaceStateService.js
@@ -398,4 +398,10 @@ export async function saveWorkspaceState(
   }
   return { state, persisted: true, updatedAt };
 }
-
+[31;1mMethodException: [0m
+[31;1m[36;1mLine |[0m
+[31;1m[36;1m[36;1m   2 | [0m … StateService.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/src/services/workspaceStateService.js
+++ b/src/services/workspaceStateService.js
@@ -25,8 +25,6 @@ const VALID_MODELS = new Set([
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
-  "gemini-2.5-flash",
-  "grok-3-mini",
 ]);
 const VALID_PETS = new Set(["robot", "drop", "spark", "owl", "rock", "cat"]);
 const VALID_MEMORY_MODES = new Set(["confirm", "disabled"]);
@@ -398,10 +396,3 @@ export async function saveWorkspaceState(
   }
   return { state, persisted: true, updatedAt };
 }
-[31;1mMethodException: [0m
-[31;1m[36;1mLine |[0m
-[31;1m[36;1m[36;1m   2 | [0m … StateService.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/src/services/workspaceStateService.js
+++ b/src/services/workspaceStateService.js
@@ -25,6 +25,8 @@ const VALID_MODELS = new Set([
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
+  "gemini-2.5-flash",
+  "grok-3-mini",
 ]);
 const VALID_PETS = new Set(["robot", "drop", "spark", "owl", "rock", "cat"]);
 const VALID_MEMORY_MODES = new Set(["confirm", "disabled"]);
@@ -396,3 +398,4 @@ export async function saveWorkspaceState(
   }
   return { state, persisted: true, updatedAt };
 }
+

--- a/src/services/workspaceStateService.js
+++ b/src/services/workspaceStateService.js
@@ -25,6 +25,8 @@ const VALID_MODELS = new Set([
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
+  "gemini-2.5-flash",
+  "grok-3-mini",
 ]);
 const VALID_PETS = new Set(["robot", "drop", "spark", "owl", "rock", "cat"]);
 const VALID_MEMORY_MODES = new Set(["confirm", "disabled"]);

--- a/src/tools/capabilityEngine.js
+++ b/src/tools/capabilityEngine.js
@@ -991,4 +991,10 @@ export function isToolExecutable(toolId, env = process.env) {
   }
   return typeof executors[toolId] === "function";
 }
-
+[31;1mMethodException: [0m
+[31;1m[36;1mLine |[0m
+[31;1m[36;1m[36;1m   2 | [0m … bilityEngine.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/src/tools/capabilityEngine.js
+++ b/src/tools/capabilityEngine.js
@@ -3,7 +3,6 @@ import {
   listAuditEvents,
 } from "../services/permissionService.js";
 import { isCopilotAutomationEnabled } from "../config/featureFlags.js";
-import { hasConfiguredAiProvider, isAiCoreConfigured } from "../services/aiCoreService.js";
 import { answerGitHubReadRequest } from "../services/githubService.js";
 import {
   createGmailDraft,
@@ -125,9 +124,9 @@ export function getToolRuntimeAvailability(
   switch (toolId) {
     case "synchron-agent-chat":
       if (
-        !hasConfiguredAiProvider(env) ||
         !hasEnvironment(
           env,
+          "OPENAI_API_KEY",
           "OPENSEARCH_HOST",
           "OPENSEARCH_PORT",
           "OPENSEARCH_USERNAME",
@@ -336,7 +335,7 @@ export async function buildIntegrationStatusReport(
     ["Supabase Status", supabase],
     ["DigitalOcean Read", digitalOcean],
     ["Cloudflare Read", cloudflare],
-    ["AI CORE разговор", isAiCoreConfigured(env)],
+    ["OpenAI разговор", Boolean(env.OPENAI_API_KEY)],
     ["OpenAI Web Search", Boolean(env.OPENAI_API_KEY)],
     ["Codex", isCodexAgentConfigured(env)],
   ];
@@ -991,10 +990,3 @@ export function isToolExecutable(toolId, env = process.env) {
   }
   return typeof executors[toolId] === "function";
 }
-[31;1mMethodException: [0m
-[31;1m[36;1mLine |[0m
-[31;1m[36;1m[36;1m   2 | [0m … bilityEngine.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/src/tools/capabilityEngine.js
+++ b/src/tools/capabilityEngine.js
@@ -3,6 +3,7 @@ import {
   listAuditEvents,
 } from "../services/permissionService.js";
 import { isCopilotAutomationEnabled } from "../config/featureFlags.js";
+import { hasConfiguredAiProvider, isAiCoreConfigured } from "../services/aiCoreService.js";
 import { answerGitHubReadRequest } from "../services/githubService.js";
 import {
   createGmailDraft,
@@ -124,9 +125,9 @@ export function getToolRuntimeAvailability(
   switch (toolId) {
     case "synchron-agent-chat":
       if (
+        !hasConfiguredAiProvider(env) ||
         !hasEnvironment(
           env,
-          "OPENAI_API_KEY",
           "OPENSEARCH_HOST",
           "OPENSEARCH_PORT",
           "OPENSEARCH_USERNAME",
@@ -335,7 +336,7 @@ export async function buildIntegrationStatusReport(
     ["Supabase Status", supabase],
     ["DigitalOcean Read", digitalOcean],
     ["Cloudflare Read", cloudflare],
-    ["OpenAI разговор", Boolean(env.OPENAI_API_KEY)],
+    ["AI CORE разговор", isAiCoreConfigured(env)],
     ["OpenAI Web Search", Boolean(env.OPENAI_API_KEY)],
     ["Codex", isCodexAgentConfigured(env)],
   ];

--- a/src/tools/capabilityEngine.js
+++ b/src/tools/capabilityEngine.js
@@ -3,6 +3,7 @@ import {
   listAuditEvents,
 } from "../services/permissionService.js";
 import { isCopilotAutomationEnabled } from "../config/featureFlags.js";
+import { hasConfiguredAiProvider, isAiCoreConfigured } from "../services/aiCoreService.js";
 import { answerGitHubReadRequest } from "../services/githubService.js";
 import {
   createGmailDraft,
@@ -124,9 +125,9 @@ export function getToolRuntimeAvailability(
   switch (toolId) {
     case "synchron-agent-chat":
       if (
+        !hasConfiguredAiProvider(env) ||
         !hasEnvironment(
           env,
-          "OPENAI_API_KEY",
           "OPENSEARCH_HOST",
           "OPENSEARCH_PORT",
           "OPENSEARCH_USERNAME",
@@ -335,7 +336,7 @@ export async function buildIntegrationStatusReport(
     ["Supabase Status", supabase],
     ["DigitalOcean Read", digitalOcean],
     ["Cloudflare Read", cloudflare],
-    ["OpenAI разговор", Boolean(env.OPENAI_API_KEY)],
+    ["AI CORE разговор", isAiCoreConfigured(env)],
     ["OpenAI Web Search", Boolean(env.OPENAI_API_KEY)],
     ["Codex", isCodexAgentConfigured(env)],
   ];
@@ -990,3 +991,4 @@ export function isToolExecutable(toolId, env = process.env) {
   }
   return typeof executors[toolId] === "function";
 }
+

--- a/tests/aiCoreService.test.js
+++ b/tests/aiCoreService.test.js
@@ -6,6 +6,7 @@ import {
   extractGeminiOutputText,
   extractGrokOutputText,
   extractOpenAIOutputText,
+  hasConfiguredAiProvider,
   getAiProviderStatus,
   requestAiResponse,
   requestGeminiResponse,
@@ -13,6 +14,12 @@ import {
   requestOpenAIResponse,
   requestOpenAIText,
 } from "../src/services/aiCoreService.js";
+
+test("AI CORE reports any configured chat provider", () => {
+  assert.equal(hasConfiguredAiProvider({ GEMINI_API_KEY: "gemini" }), true);
+  assert.equal(hasConfiguredAiProvider({ GROK_API_KEY: "grok" }), true);
+  assert.equal(hasConfiguredAiProvider({}), false);
+});
 
 test("OpenAI Responses output text is extracted from typed output items", () => {
   assert.equal(

--- a/tests/aiCoreService.test.js
+++ b/tests/aiCoreService.test.js
@@ -6,7 +6,6 @@ import {
   extractGeminiOutputText,
   extractGrokOutputText,
   extractOpenAIOutputText,
-  hasConfiguredAiProvider,
   getAiProviderStatus,
   requestAiResponse,
   requestGeminiResponse,
@@ -14,12 +13,6 @@ import {
   requestOpenAIResponse,
   requestOpenAIText,
 } from "../src/services/aiCoreService.js";
-
-test("AI CORE reports any configured chat provider", () => {
-  assert.equal(hasConfiguredAiProvider({ GEMINI_API_KEY: "gemini" }), true);
-  assert.equal(hasConfiguredAiProvider({ GROK_API_KEY: "grok" }), true);
-  assert.equal(hasConfiguredAiProvider({}), false);
-});
 
 test("OpenAI Responses output text is extracted from typed output items", () => {
   assert.equal(
@@ -283,10 +276,3 @@ test("generic AI dispatch and status are explicit without exposing keys", async 
   assert.equal(result.provider, "grok");
   assert.equal(result.text, "Работи.");
 });
-[31;1mMethodException: [0m
-[31;1m[36;1mLine |[0m
-[31;1m[36;1m[36;1m   2 | [0m … Service.test.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/tests/aiCoreService.test.js
+++ b/tests/aiCoreService.test.js
@@ -6,6 +6,7 @@ import {
   extractGeminiOutputText,
   extractGrokOutputText,
   extractOpenAIOutputText,
+  hasConfiguredAiProvider,
   getAiProviderStatus,
   requestAiResponse,
   requestGeminiResponse,
@@ -13,6 +14,12 @@ import {
   requestOpenAIResponse,
   requestOpenAIText,
 } from "../src/services/aiCoreService.js";
+
+test("AI CORE reports any configured chat provider", () => {
+  assert.equal(hasConfiguredAiProvider({ GEMINI_API_KEY: "gemini" }), true);
+  assert.equal(hasConfiguredAiProvider({ GROK_API_KEY: "grok" }), true);
+  assert.equal(hasConfiguredAiProvider({}), false);
+});
 
 test("OpenAI Responses output text is extracted from typed output items", () => {
   assert.equal(
@@ -276,3 +283,4 @@ test("generic AI dispatch and status are explicit without exposing keys", async 
   assert.equal(result.provider, "grok");
   assert.equal(result.text, "Работи.");
 });
+

--- a/tests/aiCoreService.test.js
+++ b/tests/aiCoreService.test.js
@@ -283,4 +283,10 @@ test("generic AI dispatch and status are explicit without exposing keys", async 
   assert.equal(result.provider, "grok");
   assert.equal(result.text, "Работи.");
 });
-
+[31;1mMethodException: [0m
+[31;1m[36;1mLine |[0m
+[31;1m[36;1m[36;1m   2 | [0m … Service.test.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/tests/capabilityEngine.test.js
+++ b/tests/capabilityEngine.test.js
@@ -477,4 +477,10 @@ test("изпълнява интернет търсене през OpenAI инс�
     else process.env.OPENAI_API_KEY = originalKey;
   }
 });
-
+[31;1mMethodException: [0m
+[31;1m[36;1mLine |[0m
+[31;1m[36;1m[36;1m   2 | [0m … yEngine.test.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/tests/capabilityEngine.test.js
+++ b/tests/capabilityEngine.test.js
@@ -220,21 +220,6 @@ test("runtime availability blocks configured-looking tools without credentials",
   );
 });
 
-test("AI CORE chat availability accepts a configured non-OpenAI provider", () => {
-  const result = getToolRuntimeAvailability(
-    "synchron-agent-chat",
-    { ownerId: "supabase:test" },
-    {
-      GEMINI_API_KEY: "key",
-      OPENSEARCH_HOST: "https://search.example",
-      OPENSEARCH_PORT: "443",
-      OPENSEARCH_USERNAME: "user",
-      OPENSEARCH_PASSWORD: "password",
-    },
-  );
-  assert.equal(result.available, true);
-});
-
 test("code.write спира преди Copilot flow в изключен режим", async () => {
   await assert.rejects(
     () =>
@@ -477,10 +462,3 @@ test("изпълнява интернет търсене през OpenAI инс�
     else process.env.OPENAI_API_KEY = originalKey;
   }
 });
-[31;1mMethodException: [0m
-[31;1m[36;1mLine |[0m
-[31;1m[36;1m[36;1m   2 | [0m … yEngine.test.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/tests/capabilityEngine.test.js
+++ b/tests/capabilityEngine.test.js
@@ -220,6 +220,21 @@ test("runtime availability blocks configured-looking tools without credentials",
   );
 });
 
+test("AI CORE chat availability accepts a configured non-OpenAI provider", () => {
+  const result = getToolRuntimeAvailability(
+    "synchron-agent-chat",
+    { ownerId: "supabase:test" },
+    {
+      GEMINI_API_KEY: "key",
+      OPENSEARCH_HOST: "https://search.example",
+      OPENSEARCH_PORT: "443",
+      OPENSEARCH_USERNAME: "user",
+      OPENSEARCH_PASSWORD: "password",
+    },
+  );
+  assert.equal(result.available, true);
+});
+
 test("code.write спира преди Copilot flow в изключен режим", async () => {
   await assert.rejects(
     () =>
@@ -462,3 +477,4 @@ test("изпълнява интернет търсене през OpenAI инс�
     else process.env.OPENAI_API_KEY = originalKey;
   }
 });
+

--- a/tests/capabilityEngine.test.js
+++ b/tests/capabilityEngine.test.js
@@ -220,6 +220,21 @@ test("runtime availability blocks configured-looking tools without credentials",
   );
 });
 
+test("AI CORE chat availability accepts a configured non-OpenAI provider", () => {
+  const result = getToolRuntimeAvailability(
+    "synchron-agent-chat",
+    { ownerId: "supabase:test" },
+    {
+      GEMINI_API_KEY: "key",
+      OPENSEARCH_HOST: "https://search.example",
+      OPENSEARCH_PORT: "443",
+      OPENSEARCH_USERNAME: "user",
+      OPENSEARCH_PASSWORD: "password",
+    },
+  );
+  assert.equal(result.available, true);
+});
+
 test("code.write спира преди Copilot flow в изключен режим", async () => {
   await assert.rejects(
     () =>

--- a/tests/integrationHealth.test.js
+++ b/tests/integrationHealth.test.js
@@ -174,7 +174,8 @@ test("removed DigitalOcean AI Agent is not required by production configuration"
 
   assert.doesNotMatch(appSpec, /key:\s*AGENT_(?:URL|KEY)/u);
   assert.doesNotMatch(server, /if\s*\(!process\.env\.AGENT_KEY\)/u);
-  assert.match(server, /if\s*\(!process\.env\.OPENAI_API_KEY\)/u);
+  assert.match(server, /getAiProviderStatus\(process\.env\)/u);
+  assert.match(server, /AI CORE provider/u);
   assert.doesNotMatch(identity, /DigitalOcean Agent е резервният AI/u);
   assert.match(identity, /DigitalOcean Agent е премахнат/u);
   assert.doesNotMatch(envExample, /^AGENT_(?:URL|KEY)=/mu);

--- a/tests/workspaceStateService.test.js
+++ b/tests/workspaceStateService.test.js
@@ -107,17 +107,6 @@ test("workspace keeps a supported personal pet", () => {
   assert.equal(state.petId, "drop");
 });
 
-test("workspace preserves supported Gemini and Grok model choices", () => {
-  const state = normalizeWorkspaceState({
-    agents: [
-      { id: "gemini", name: "Gemini", role: "researcher", model: "gemini-2.5-flash" },
-      { id: "grok", name: "Grok", role: "researcher", model: "grok-3-mini" },
-    ],
-  });
-  assert.equal(state.agents[0].model, "gemini-2.5-flash");
-  assert.equal(state.agents[1].model, "grok-3-mini");
-});
-
 test("legacy workspaces receive specialized agents with their own pets", () => {
   const state = normalizeWorkspaceState({
     version: 4,
@@ -231,10 +220,3 @@ test("missing workspace returns a safe starter state", async () => {
     ["Изпълни", "Проучи", "Организирай", "Напиши", "Код"],
   );
 });
-[31;1mMethodException: [0m
-[31;1m[36;1mLine |[0m
-[31;1m[36;1m[36;1m   2 | [0m … Service.test.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
-[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/tests/workspaceStateService.test.js
+++ b/tests/workspaceStateService.test.js
@@ -107,6 +107,17 @@ test("workspace keeps a supported personal pet", () => {
   assert.equal(state.petId, "drop");
 });
 
+test("workspace preserves supported Gemini and Grok model choices", () => {
+  const state = normalizeWorkspaceState({
+    agents: [
+      { id: "gemini", name: "Gemini", role: "researcher", model: "gemini-2.5-flash" },
+      { id: "grok", name: "Grok", role: "researcher", model: "grok-3-mini" },
+    ],
+  });
+  assert.equal(state.agents[0].model, "gemini-2.5-flash");
+  assert.equal(state.agents[1].model, "grok-3-mini");
+});
+
 test("legacy workspaces receive specialized agents with their own pets", () => {
   const state = normalizeWorkspaceState({
     version: 4,
@@ -220,3 +231,4 @@ test("missing workspace returns a safe starter state", async () => {
     ["Изпълни", "Проучи", "Организирай", "Напиши", "Код"],
   );
 });
+

--- a/tests/workspaceStateService.test.js
+++ b/tests/workspaceStateService.test.js
@@ -231,4 +231,10 @@ test("missing workspace returns a safe starter state", async () => {
     ["Изпълни", "Проучи", "Организирай", "Напиши", "Код"],
   );
 });
-
+[31;1mMethodException: [0m
+[31;1m[36;1mLine |[0m
+[31;1m[36;1m[36;1m   2 | [0m … Service.test.js'; [36;1m$c=$c.Replace(([char]13+[char]10),[char]10)[0m; [Conso …[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m     | [31;1m                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m     | [31;1mCannot convert argument "oldChar", with value: "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m", for "Replace" to type "System.Char": "Cannot convert value "[0m
+[31;1m[36;1m[36;1m[0m[36;1m[0m[36;1m[31;1m[31;1m[36;1m[31;1m" to type "System.Char". Error: "String must be exactly one character long.""[0m

--- a/tests/workspaceStateService.test.js
+++ b/tests/workspaceStateService.test.js
@@ -107,6 +107,17 @@ test("workspace keeps a supported personal pet", () => {
   assert.equal(state.petId, "drop");
 });
 
+test("workspace preserves supported Gemini and Grok model choices", () => {
+  const state = normalizeWorkspaceState({
+    agents: [
+      { id: "gemini", name: "Gemini", role: "researcher", model: "gemini-2.5-flash" },
+      { id: "grok", name: "Grok", role: "researcher", model: "grok-3-mini" },
+    ],
+  });
+  assert.equal(state.agents[0].model, "gemini-2.5-flash");
+  assert.equal(state.agents[1].model, "grok-3-mini");
+});
+
 test("legacy workspaces receive specialized agents with their own pets", () => {
   const state = normalizeWorkspaceState({
     version: 4,


### PR DESCRIPTION
Одит на DigitalOcean env имената спрямо актуалния main и минимални кодови поправки:

- chat capability вече приема всеки конфигуриран AI CORE доставчик (OpenAI/Gemini/Grok), като OpenAI Web Search остава OpenAI-only;
- предупреждението при старт е според избрания AI_CORE_PROVIDER, не твърдо според OPENAI_API_KEY;
- workspace persistence вече запазва gemini-2.5-flash и grok-3-mini;
- добавени са regression тестове.

Проверка: 40/40 фокусирани теста зелени, git diff --check чист. Пълният локален suite не завърши в наличния runtime timeout; production health след корекцията на AI_CORE_PROVIDER е 200/ready на b8d4f7d.

Env одитът не променя тайни. Непотребявани/legacy имена в DO са документирани за отделно почистване: AGENT_URL, AGENT_KEY, DATABASE_URL, OPENSEARCH_PROTOCOL, MODEL_ACCESS_KEY, CONTROL_PLANE_API_KEY, Custom_API_Token, XAI_API_KEY и ANTHROPIC_* (Anthropic не е в main). Не са изтрити автоматично.