### PR TITLE
Затегни chat availability gate според избрания provider

### DIFF
--- a/src/tools/capabilityEngine.js
+++ b/src/tools/capabilityEngine.js
@@ -4,9 +4,10 @@ import {
 } from "../services/permissionService.js";
 import { isCopilotAutomationEnabled } from "../config/featureFlags.js";
 import {
-  hasConfiguredAiProvider,
   isAiCoreConfigured,
+  isAiProviderConfigured,
 } from "../services/aiCoreService.js";
+import { resolveWorkAgentProvider } from "../services/workModeService.js";
 import { answerGitHubReadRequest } from "../services/githubService.js";
 import {
   createGmailDraft,
@@ -117,6 +118,15 @@ function hasEnvironment(env, ...names) {
   );
 }
 
+function isChatProviderConfigured(input, env) {
+  const explicitProvider = resolveWorkAgentProvider(
+    input?.workContext?.agent?.model,
+  );
+  return explicitProvider
+    ? isAiProviderConfigured(explicitProvider, env)
+    : isAiCoreConfigured(env);
+}
+
 export function getToolRuntimeAvailability(
   toolId,
   input = {},
@@ -128,7 +138,7 @@ export function getToolRuntimeAvailability(
   switch (toolId) {
     case "synchron-agent-chat":
       if (
-        !hasConfiguredAiProvider(env) ||
+        !isChatProviderConfigured(input, env) ||
         !hasEnvironment(
           env,
           "OPENSEARCH_HOST",

--- a/tests/capabilityEngine.test.js
+++ b/tests/capabilityEngine.test.js
@@ -170,7 +170,7 @@ test("runtime availability blocks configured-looking tools without credentials",
         OPENSEARCH_PASSWORD: "password",
       },
     ).available,
-    true,
+    false,
   );
   assert.equal(
     getToolRuntimeAvailability(
@@ -259,6 +259,28 @@ test("runtime availability blocks configured-looking tools without credentials",
     ).code,
     "CAPABILITY_AUTH_REQUIRED",
   );
+});
+
+test("allows an explicitly configured work-mode chat provider", () => {
+  const runtime = getToolRuntimeAvailability(
+    "synchron-agent-chat",
+    {
+      ownerId: "member-1",
+      workContext: {
+        agent: { model: "claude-sonnet-5" },
+      },
+    },
+    {
+      AI_CORE_PROVIDER: "openai",
+      ANTHROPIC_API_KEY: "key",
+      OPENSEARCH_HOST: "host",
+      OPENSEARCH_PORT: "25060",
+      OPENSEARCH_USERNAME: "user",
+      OPENSEARCH_PASSWORD: "password",
+    },
+  );
+
+  assert.equal(runtime.available, true);
 });
 
 test("code.write спира преди Copilot flow в изключен режим", async () => {

--- a/tests/capabilityEngine.test.js
+++ b/tests/capabilityEngine.test.js
@@ -170,7 +170,7 @@ test("runtime availability blocks configured-looking tools without credentials",
         OPENSEARCH_PASSWORD: "password",
       },
     ).available,
-    false,
+    true,
   );
   assert.equal(
     getToolRuntimeAvailability(
@@ -185,7 +185,7 @@ test("runtime availability blocks configured-looking tools without credentials",
         OPENSEARCH_PASSWORD: "password",
       },
     ).available,
-    true,
+    false,
   );
   assert.equal(
     getToolRuntimeAvailability(


### PR DESCRIPTION
Този stacked fix затяга runtime availability gate-а за synchron-agent-chat: auto/unspecified chat следва избрания AI_CORE_PROVIDER, а explicit work-mode моделът проверява собствения си provider. Добавени са regression проверки за selected openai + само Anthropic key (fail closed) и за explicit Anthropic provider.\n\nПроверки: блокирани локално — node/npm не са инсталирани; node --test tests/capabilityEngine.test.js, npm test и npm audit --omit=dev --audit-level=high не могат да стартират. Diff scan няма secret patterns.\n\nStacked върху codex/add-anthropic-ai-core (PR #311). Без fallback, secret промени, merge или deploy.